### PR TITLE
fix: fsoc-106: additional config bypass needed

### DIFF
--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 )
 
@@ -46,6 +47,7 @@ The directory should either be empty or not exist.`,
 	Args:             cobra.ExactArgs(1),
 	Run:              genDocs,
 	TraverseChildren: true,
+	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
 }
 
 func NewSubCmd() *cobra.Command {

--- a/cmd/version/update.go
+++ b/cmd/version/update.go
@@ -18,8 +18,9 @@ import (
 	//"errors"
 
 	"github.com/apex/log"
-	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/fsoc/cmd/config"
 )
 
 var updateCmd = &cobra.Command{

--- a/cmd/version/update.go
+++ b/cmd/version/update.go
@@ -18,14 +18,16 @@ import (
 	//"errors"
 
 	"github.com/apex/log"
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/spf13/cobra"
 )
 
 var updateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Update fsoc",
-	Long:  `Update fsoc if a new version is available.`,
-	Run:   update,
+	Use:         "update",
+	Short:       "Update fsoc",
+	Long:        `Update fsoc if a new version is available.`,
+	Run:         update,
+	Annotations: map[string]string{config.AnnotationForConfigBypass: ""},
 }
 
 func init() {
@@ -33,7 +35,7 @@ func init() {
 }
 
 func update(cmd *cobra.Command, args []string) {
-	log.Fatalf("Update command is not yet implemented. Please check version manually and download update if available.")
+	log.Fatalf("Update command is not implemented yet. Please check version manually and download an update if available.")
 }
 
 // func update(core *Core, pkg dependency.Installable) {

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 )
 
@@ -29,6 +30,7 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		displayVersion(cmd)
 	},
+	Annotations: map[string]string{config.AnnotationForConfigBypass: ""},
 }
 
 func init() {


### PR DESCRIPTION
## Description

Following FSOC-99 which introduced a uniform enforcement of config profile presence, there are some more commands that should have been excluded from checking (incl. version and help). 

Added config bypass for `version`, `version update`, `help` and all `completion xxx` commands.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)


