### PR TITLE
Fix package

### DIFF
--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -128,7 +128,7 @@ func addFileToZip(zipWriter *zip.Writer, fileName string, info os.FileInfo) {
 	defer newFile.Close()
 
 	if info.IsDir() {
-		fileName = fileName + "/"
+		fileName = fileName + string(os.PathSeparator)
 	}
 
 	archWriter, err := zipWriter.Create(fileName)


### PR DESCRIPTION
## Description

Found an issue where packaging would create zip files with path separators on Windows OS that aren't accepted by the validation step in Orion.

## Type of Change

- [X ] Bug Fix