### PR TITLE
fsoc fork used to assume that the name of the first subfolder was the same as the name of the package, this is not universally true, the code now accounts for this

### DIFF
--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -112,7 +112,7 @@ func extractZip(rootFileSystem afero.Fs, fileSystem afero.Fs, solutionName strin
 	}
 	reader, _ := zip.NewReader(zipFile, fileInfo.Size())
 	zipFileSystem := zipfs.New(reader)
-	dirInfo, err := afero.ReadDir(zipFileSystem, "./")
+	dirInfo, _ := afero.ReadDir(zipFileSystem, "./")
 	err = copyFolderToLocal(zipFileSystem, fileSystem, dirInfo[0].Name())
 	return err
 }

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -101,21 +101,26 @@ func manifestExists(fileSystem afero.Fs, forkName string) bool {
 }
 
 func extractZip(rootFileSystem afero.Fs, fileSystem afero.Fs, solutionName string) error {
+	println("./" + solutionName + ".zip")
 	zipFile, err := rootFileSystem.OpenFile("./"+solutionName+".zip", os.O_RDONLY, os.FileMode(0644))
 	if err != nil {
 		log.Fatalf("Error opening zip file: %v", err)
 	}
-	fileInfo, _ := rootFileSystem.Stat("./" + solutionName + ".zip")
+	fileInfo, err := rootFileSystem.Stat("./" + solutionName + ".zip")
+	if err != nil {
+		log.Errorf("Err reading zip: %v", err)
+	}
 	reader, _ := zip.NewReader(zipFile, fileInfo.Size())
 	zipFileSystem := zipfs.New(reader)
-	err = copyFolderToLocal(zipFileSystem, fileSystem, "./"+solutionName)
+	dirInfo, err := afero.ReadDir(zipFileSystem, "./")
+	err = copyFolderToLocal(zipFileSystem, fileSystem, dirInfo[0].Name())
 	return err
 }
 
 func editManifest(fileSystem afero.Fs, forkName string) {
 	manifestFile, err := afero.ReadFile(fileSystem, "./manifest.json")
 	if err != nil {
-		log.Fatalf("Error opening manifest file")
+		log.Fatalf("Error opening manifest file: %v", err)
 	}
 
 	var manifest Manifest


### PR DESCRIPTION
## Description

Fixed how path to solution bundle is located on `solution fork`

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

