### PR TITLE
fix exit code on failed solution validation (fsoc-116)

### DIFF
--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -123,7 +123,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 
 	err = api.HTTPPost(getSolutionValidateUrl(), body.Bytes(), &res, &api.Options{Headers: headers})
 	if err != nil {
-		log.Fatalf("Solution validate command failed: %v", err)
+		log.Fatalf("Solution validate request failed: %v", err)
 	}
 
 	if res.Valid {
@@ -132,6 +132,9 @@ func validateSolution(cmd *cobra.Command, args []string) {
 		message = getSolutionValidationErrorsString(res.Errors.Total, res.Errors)
 	}
 	output.PrintCmdStatus(cmd, message)
+	if !res.Valid {
+		log.Fatalf("%d error(s) found while validating the solution", res.Errors.Total)
+	}
 }
 
 func getSolutionValidationErrorsString(total int, errors Errors) string {


### PR DESCRIPTION
## Description

Fixed exit code for `solution validate` so that non-zero exit code is returned if validation has failed (due to one or more errors reported by the backend)

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
