### PR TITLE
FSOC-36 Replace server with url in config file 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ export CGO_ENABLED ?= 0
 CURRENT_PATH := $(PATH)
 TEST_REPORTS_DIR = ./build/reports
 
-export PATH := bin:${PATH}
-export GOBIN = $(SCRIPT_DIR)/bin
-export PATH = $(GOBIN):$(CURRENT_PATH)
+GOBIN = $(SCRIPT_DIR)/bin
+PATH  := $(GOBIN):bin:$(PATH)
+SHELL := env PATH=$(PATH) /bin/bash
 
 GORELEASER ?= $(GOBIN)/goreleaser
 GOLINT ?= $(GOBIN)/golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ TEST_REPORTS_DIR = ./build/reports
 
 GOBIN = $(SCRIPT_DIR)/bin
 PATH  := $(GOBIN):bin:$(PATH)
-SHELL := env PATH=$(PATH) /bin/bash
+SHELL := env PATH=$(PATH) GOBIN=$(GOBIN) /bin/bash
 
 GORELEASER ?= $(GOBIN)/goreleaser
 GOLINT ?= $(GOBIN)/golangci-lint

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -20,6 +20,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -92,6 +93,22 @@ func getConfig() configFileContents {
 	if err != nil {
 		log.Fatalf("unable to read config, %v", err)
 	}
+	needReWrite := false
+	newContexts := make([]Context, len(c.Contexts))
+	for i, context := range c.Contexts {
+		if context.Server != "" {
+			context.URL = fmt.Sprintf("https://%s", context.Server)
+			log.Warnf("The server config is deprecated. Replacing 'server: %s' for context '%s' with 'url: %s' now...", context.Server, context.Name, context.URL)
+			context.Server = ""
+			needReWrite = true
+		}
+		newContexts[i] = context
+	}
+	if needReWrite {
+		updateConfigFile(map[string]interface{}{
+			"contexts": newContexts,
+		})
+	}
 	return c
 }
 
@@ -120,7 +137,7 @@ func updateConfigFile(keyValues map[string]interface{}) {
 	viper.SetConfigType("yaml")
 	if viper.ConfigFileUsed() == "" {
 		home, _ := os.UserHomeDir()
-		configFileLocation := strings.Replace(defaultConfigFile, "~", home, 1)
+		configFileLocation := strings.Replace(DefaultConfigFile, "~", home, 1)
 		viper.SetConfigFile(configFileLocation)
 	}
 	viper.SetConfigPermissions(0600) // o=rw

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -108,6 +108,7 @@ func getConfig() configFileContents {
 		updateConfigFile(map[string]interface{}{
 			"contexts": newContexts,
 		})
+		c.Contexts = newContexts
 	}
 	return c
 }

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -87,12 +87,7 @@ func GetCurrentContext() *Context {
 	return nil
 }
 
-func getConfig() configFileContents {
-	var c configFileContents
-	err := viper.Unmarshal(&c)
-	if err != nil {
-		log.Fatalf("unable to read config, %v", err)
-	}
+func replaceServerWithURLInConfig(c *configFileContents) {
 	needReWrite := false
 	newContexts := make([]Context, len(c.Contexts))
 	for i, context := range c.Contexts {
@@ -110,6 +105,15 @@ func getConfig() configFileContents {
 		})
 		c.Contexts = newContexts
 	}
+}
+
+func getConfig() configFileContents {
+	var c configFileContents
+	err := viper.Unmarshal(&c)
+	if err != nil {
+		log.Fatalf("unable to read config, %v", err)
+	}
+	replaceServerWithURLInConfig(&c)
 	return c
 }
 

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateConfigWhenGetConfig(t *testing.T) {

--- a/cmd/config/config_test.go
+++ b/cmd/config/config_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+func TestUpdateConfigWhenGetConfig(t *testing.T) {
+	viper.SetConfigFile(".tmp-config")
+	viper.SetConfigType("yaml")
+	fileName := viper.ConfigFileUsed()
+	fo, err := os.Create(fileName)
+	assert.Nil(t, err, "Failed to create temp config file")
+	oldConfigs := `
+contexts:
+    - name: default
+      auth_method: none
+      server: mytenant.saas.observer.com
+current_context: default
+`
+	_, err = fo.Write([]byte(oldConfigs))
+	fo.Close()
+	assert.Nil(t, err, "Failed to write temp config file")
+	defer os.Remove(fileName)
+	err = viper.ReadInConfig()
+	assert.Nil(t, err, "Failed to read config file")
+
+	config := getConfig()
+	assert.Equal(t, "", config.Contexts[0].Server)
+	assert.Equal(t, "https://mytenant.saas.observer.com", config.Contexts[0].URL)
+
+	err = viper.ReadInConfig()
+	assert.Nil(t, err, "Failed to read config file after update")
+	newContexts := viper.Get("contexts").([]Context)
+	assert.Equal(t, 1, len(newContexts))
+	assert.Equal(t, "", newContexts[0].Server)
+	assert.Equal(t, "https://mytenant.saas.observer.com", newContexts[0].URL)
+}

--- a/cmd/config/get.go
+++ b/cmd/config/get.go
@@ -75,7 +75,7 @@ func configGetContext(cmd *cobra.Command, args []string) error {
 		}
 	}
 	appendIfPresent("Auth Method", ctx.AuthMethod)
-	appendIfPresent("Server", ctx.Server)
+	appendIfPresent("URL", ctx.URL)
 	appendIfPresent("Tenant", ctx.Tenant)
 	appendIfPresent("User ID", ctx.User)
 	appendIfPresent("Token", ctx.Token)

--- a/cmd/config/list.go
+++ b/cmd/config/list.go
@@ -35,7 +35,7 @@ func newCmdConfigList() *cobra.Command {
 }
 
 var headers = []string{
-	"Use", "Name", "Auth Method", "Server", "User",
+	"Use", "Name", "Auth Method", "URL", "User",
 }
 
 func configListContexts(cmd *cobra.Command, args []string) error {
@@ -61,7 +61,7 @@ func configListContexts(cmd *cobra.Command, args []string) error {
 		// if credentials == "" && c.CsvFile != "" {
 		// 	credentials = c.CsvFile
 		// }
-		contexts = append(contexts, []string{current, c.Name, c.AuthMethod, c.Server, c.User})
+		contexts = append(contexts, []string{current, c.Name, c.AuthMethod, c.URL, c.User})
 	}
 
 	output.PrintCmdOutputCustom(cmd, cfg, &output.Table{

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -17,6 +17,7 @@ package config
 import (
 	"bufio"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,13 +50,33 @@ func newCmdConfigSet() *cobra.Command {
 		Annotations: map[string]string{AnnotationForConfigBypass: ""},
 		Run:         configSetContext,
 	}
-
+	cmd.Flags().String("server", "", "[Deprecated, use 'url' instead] Set server URL in context.")
 	cmd.Flags().String("url", "", "Set server URL in context")
 	cmd.Flags().String("tenant", "", "Set tenant ID in context")
 	cmd.Flags().String("token", "", "Set token value in context (use --token=- to get from stdin)")
 	cmd.Flags().String("secret-file", "", "Set credentials file to use for service principal login (.json or .csv)")
 	cmd.Flags().String("auth", "", fmt.Sprintf(`Select authentication method, one of {"%v"}`, strings.Join(GetAuthMethodsStringList(), `", "`)))
 	return cmd
+}
+
+func validateUrl(providedUrl string) (string, error) {
+	parsedUrl, err := url.ParseRequestURI(providedUrl)
+	if err != nil {
+		parsedUrl, err = url.ParseRequestURI(fmt.Sprintf("https://%s", providedUrl))
+	}
+	if err != nil {
+		return "", fmt.Errorf("the provided url is not valid: %s", err)
+	}
+	if parsedUrl.Host == "" {
+		return "", fmt.Errorf("no host is provided in the url: %s", providedUrl)
+	}
+	if parsedUrl.Scheme != "https" && parsedUrl.Scheme != "http" {
+		return "", fmt.Errorf("invalid schema is provided: %s", parsedUrl.Scheme)
+	}
+	if parsedUrl.String() != providedUrl {
+		log.Warnf("The provided url (%s) is cleaned and stored as %s.", providedUrl, parsedUrl.String())
+	}
+	return parsedUrl.String(), nil
 }
 
 func configSetContext(cmd *cobra.Command, args []string) {
@@ -108,8 +129,18 @@ func configSetContext(cmd *cobra.Command, args []string) {
 	}
 
 	// update only the fields for which flags were specified explicitly
+	if flags.Changed("server") {
+		providedServer, _ := flags.GetString("server")
+		ctxPtr.URL = fmt.Sprintf("https://%s", providedServer)
+		log.Warnf("The --server option is now deprecated. Please use --url instead future. We will set the 'url: %s' for you now", ctxPtr.URL)
+	}
 	if flags.Changed("url") {
-		ctxPtr.URL, _ = flags.GetString("url")
+		providedUrl, _ := flags.GetString("url")
+		cleanedUrl, err := validateUrl(providedUrl)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		ctxPtr.URL = cleanedUrl
 	}
 	if flags.Changed("tenant") {
 		ctxPtr.Tenant, _ = flags.GetString("tenant")

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -50,7 +50,7 @@ func newCmdConfigSet() *cobra.Command {
 		Run:         configSetContext,
 	}
 
-	cmd.Flags().String("server", "", "Set server URL in context")
+	cmd.Flags().String("url", "", "Set server URL in context")
 	cmd.Flags().String("tenant", "", "Set tenant ID in context")
 	cmd.Flags().String("token", "", "Set token value in context (use --token=- to get from stdin)")
 	cmd.Flags().String("secret-file", "", "Set credentials file to use for service principal login (.json or .csv)")
@@ -108,8 +108,8 @@ func configSetContext(cmd *cobra.Command, args []string) {
 	}
 
 	// update only the fields for which flags were specified explicitly
-	if flags.Changed("server") {
-		ctxPtr.Server, _ = flags.GetString("server")
+	if flags.Changed("url") {
+		ctxPtr.URL, _ = flags.GetString("url")
 	}
 	if flags.Changed("tenant") {
 		ctxPtr.Tenant, _ = flags.GetString("tenant")

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestValidateUrlWithInvalidURL(t *testing.T) {
+	url, err := validateUrl("/web")
+	assert.Equal(t, "", url)
+	assert.NotNil(t, err)
+	assert.Regexp(t, "no host is provided in the url.*", err)
+
+	url, err = validateUrl("h://web")
+	assert.Equal(t, "", url)
+	assert.NotNil(t, err)
+	assert.Regexp(t, "invalid schema.*", err)
+}
+
+func TestValidateUrlWithDataNeedClean(t *testing.T) {
+	url, err := validateUrl("mytenant.saas.observe.com")
+	assert.Nil(t, err)
+	assert.Equal(t, url, "https://mytenant.saas.observe.com")
+
+	url, err = validateUrl("mytenant.saas.observe.com/index/a?b=1")
+	assert.Nil(t, err)
+	assert.Equal(t, url, "https://mytenant.saas.observe.com/index/a?b=1")
+}
+
+func TestValidateUrlWithValidData(t *testing.T) {
+	url, err := validateUrl("http://mytenant.saas.observe.com")
+	assert.Nil(t, err)
+	assert.Equal(t, url, "http://mytenant.saas.observe.com")
+}

--- a/cmd/config/set_test.go
+++ b/cmd/config/set_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValidateUrlWithInvalidURL(t *testing.T) {

--- a/cmd/config/types.go
+++ b/cmd/config/types.go
@@ -44,7 +44,7 @@ type Context struct {
 	Name       string `json:"name" yaml:"name"`
 	AuthMethod string `json:"auth_method,omitempty" yaml:"auth_method,omitempty" mapstructure:"auth_method"`
 	// Server: Deprecated
-	//Server       string `json:"server,omitempty" yaml:"server,omitempty"`
+	Server       string `json:"server,omitempty" yaml:"server,omitempty"`
 	URL          string `json:"url,omitempty" yaml:"url,omitempty"`
 	Tenant       string `json:"tenant,omitempty" yaml:"tenant,omitempty"`
 	User         string `json:"user,omitempty" yaml:"user,omitempty"`

--- a/cmd/config/types.go
+++ b/cmd/config/types.go
@@ -15,7 +15,7 @@
 package config
 
 const (
-	defaultConfigFile = "~/.fsoc"
+	DefaultConfigFile = "~/.fsoc"
 	defaultContext    = "default"
 )
 
@@ -41,9 +41,11 @@ const (
 // field contains the name of the context (which is unique within the config file);
 // the remaining fields define the access profile.
 type Context struct {
-	Name         string `json:"name" yaml:"name"`
-	AuthMethod   string `json:"auth_method,omitempty" yaml:"auth_method,omitempty" mapstructure:"auth_method"`
-	Server       string `json:"server,omitempty" yaml:"server,omitempty"`
+	Name       string `json:"name" yaml:"name"`
+	AuthMethod string `json:"auth_method,omitempty" yaml:"auth_method,omitempty" mapstructure:"auth_method"`
+	// Server: Deprecated
+	//Server       string `json:"server,omitempty" yaml:"server,omitempty"`
+	URL          string `json:"url,omitempty" yaml:"url,omitempty"`
 	Tenant       string `json:"tenant,omitempty" yaml:"tenant,omitempty"`
 	User         string `json:"user,omitempty" yaml:"user,omitempty"`
 	Token        string `json:"token,omitempty" yaml:"token,omitempty"` // access token

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,7 +71,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.fsoc.yaml)")
+	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("config file (default is %s)", config.DefaultConfigFile))
 	rootCmd.PersistentFlags().StringVar(&cfgProfile, "profile", "", "access profile (default is current or \"default\")")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "auto", "output format (auto, table, detail, json, yaml)")
 	rootCmd.PersistentFlags().String("fields", "", "perform specified fields transform/extract JQ expression")

--- a/cmd/solution/author.go
+++ b/cmd/solution/author.go
@@ -112,10 +112,9 @@ func authorRun(cmd *cobra.Command, cfg *config.Context, dir string, local bool) 
 		}
 	} else {
 		// point to authoring tool in tenant's UI
-		browserUrl = &url.URL{
-			Scheme: "https",
-			Host:   cfg.Server,
-			Path:   authoringToolPath,
+		browserUrl, err = url.Parse(cfg.URL)
+		if err != nil {
+			log.Fatalf("Failed to parse the url provided in context. URL: %s, err: %s", cfg.URL, err)
 		}
 	}
 	queryParams := url.Values{

--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -47,6 +47,9 @@ func getSolutionList(cmd *cobra.Command, args []string) {
 	headers := map[string]string{
 		"layer-type": "TENANT",
 		"layer-id":   layerID,
+		"appd-pty":   "U0VSVklDRQ==",
+		"appd-pid":   "VVNFUg==",
+		"appd-tid":   "NGIwMjU5OGQtNzM4NC00NTgwLTk5YzctYjM3YjBkMmQ2YTFl",
 	}
 
 	// get data and display

--- a/platform/api/call.go
+++ b/platform/api/call.go
@@ -133,7 +133,7 @@ func jsonRequest(method string, path string, body any, out any, options *Options
 	if cfg == nil {
 		return errors.New("Missing context; use 'fsoc config set' to configure your context")
 	}
-	log.WithFields(log.Fields{"context": cfg.Name, "server": cfg.Server, "tenant": cfg.Tenant}).Info("Using context")
+	log.WithFields(log.Fields{"context": cfg.Name, "URL": cfg.URL, "tenant": cfg.Tenant}).Info("Using context")
 
 	// force login if no token
 	if cfg.Token == "" {
@@ -252,11 +252,11 @@ func prepareJSONRequest(cfg *config.Context, client *http.Client, method string,
 	}
 
 	// create a HTTP request
-	url := &url.URL{
-		Scheme: "https",
-		Host:   cfg.Server,
-		Path:   path,
+	url, err := url.Parse(cfg.URL)
+	if err != nil {
+		log.Fatalf("Failed to parse the url provided in context. URL: %s, err: %s", cfg.URL, err)
 	}
+	url.Path = path
 
 	// checking if there is a query in the path
 	iQuery := strings.Index(path, "?")
@@ -311,7 +311,7 @@ func httpRequest(method string, path string, body []byte, out any, options *Opti
 	if cfg == nil {
 		return errors.New("Missing context; use 'fsoc config set' to configure your context")
 	}
-	log.WithFields(log.Fields{"context": cfg.Name, "server": cfg.Server, "tenant": cfg.Tenant}).Info("Using context")
+	log.WithFields(log.Fields{"context": cfg.Name, "URL": cfg.URL, "tenant": cfg.Tenant}).Info("Using context")
 
 	// force login if no token
 	if cfg.Token == "" {
@@ -431,11 +431,12 @@ func prepareHTTPRequest(cfg *config.Context, client *http.Client, method string,
 	// }
 
 	// create a HTTP request
-	url := &url.URL{
-		Scheme: "https",
-		Host:   cfg.Server,
-		Path:   path,
+
+	url, err := url.Parse(cfg.URL)
+	if err != nil {
+		log.Fatalf("Failed to parse the url provided in context. URL: %s, err: %s", cfg.URL, err)
 	}
+	url.Path = path
 
 	// checking if there is a query in the path
 	iQuery := strings.Index(path, "?")

--- a/platform/api/call_test.go
+++ b/platform/api/call_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"github.com/cisco-open/fsoc/cmd/config"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestPrepareHTTPRequest(t *testing.T) {
+	client := &http.Client{}
+	cfg := &config.Context{
+		URL: "http://localhost:8080",
+	}
+	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost:8080/test/path/1", req.URL.String())
+}
+
+func TestPrepareJSONRequest(t *testing.T) {
+	client := &http.Client{}
+	cfg := &config.Context{
+		URL: "http://localhost:8080",
+	}
+	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil)
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost:8080/test/path/1", req.URL.String())
+}

--- a/platform/api/call_test.go
+++ b/platform/api/call_test.go
@@ -1,10 +1,12 @@
 package api
 
 import (
-	"github.com/cisco-open/fsoc/cmd/config"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cisco-open/fsoc/cmd/config"
 )
 
 func TestPrepareHTTPRequest(t *testing.T) {

--- a/platform/api/oauth.go
+++ b/platform/api/oauth.go
@@ -86,7 +86,7 @@ func oauthLogin(ctx *config.Context) error {
 	if ctx.Tenant == "" {
 		tenantId, err := resolveTenant(ctx)
 		if err != nil {
-			return fmt.Errorf("Could not resolve tenant ID for %q: %v", ctx.Server, err.Error())
+			return fmt.Errorf("Could not resolve tenant ID for %q: %v", ctx.URL, err.Error())
 		}
 		ctx.Tenant = tenantId
 		log.Infof("Successfully resolved tenant ID to %v", ctx.Tenant)
@@ -354,7 +354,7 @@ func oauthUriWithSuffix(ctx *config.Context, suffix string) string {
 	// 	panic(fmt.Sprintf("unexpected failure constructing oauth2 endpoint URI: %v; terminating (likely a bug)", err))
 	// }
 	// return uri
-	return strings.Join([]string{"https://" + ctx.Server, "auth", ctx.Tenant, oauth2ClientId, suffix}, "/")
+	return strings.Join([]string{ctx.URL, "auth", ctx.Tenant, oauth2ClientId, suffix}, "/")
 }
 
 func startCallbackServer() (*http.Server, chan authCodes, error) {

--- a/platform/api/tenant.go
+++ b/platform/api/tenant.go
@@ -107,9 +107,10 @@ func computeResolverEndpoint(ctx *config.Context) (string, error) {
 	// In case of production tenants, we need to manually insert "saas" into the url being calculated
 	// in order to determine the lookup url correctly
 	elements[1] = "saas"
+	originalHost := uri.Host
 	uri.Host = strings.Join(elements, ".")
 	//TODO: enable for Go 1.19
 	// uri = uri.JoinPath("tenants", "lookup", ctx.Server)
-	uri.Path += "/tenants/lookup/" + uri.Host // use this until Go 1.19 is supported in building
+	uri.Path += "/tenants/lookup/" + originalHost // use this until Go 1.19 is supported in building
 	return uri.String(), nil
 }

--- a/platform/api/tenant.go
+++ b/platform/api/tenant.go
@@ -38,7 +38,7 @@ func resolveTenant(ctx *config.Context) (string, error) {
 		return "", err
 	}
 
-	log.Infof("Looking up tenant ID for %v", ctx.Server)
+	log.Infof("Looking up tenant ID for %v", ctx.URL)
 
 	// create a GET HTTP request
 	client := &http.Client{}
@@ -93,14 +93,14 @@ func resolveTenant(ctx *config.Context) (string, error) {
 // computeResolverEndpoint figures out the URL for the tenant resolver API,
 // given a tenant vanity URL
 func computeResolverEndpoint(ctx *config.Context) (string, error) {
-	uri, err := url.Parse("https://" + ctx.Server)
+	uri, err := url.Parse(ctx.URL)
 	if err != nil {
 		return "", err
 	}
 
 	elements := strings.Split(uri.Host, ".") // last element may have ":<port>"
 	if len(elements) != 4 {
-		return "", fmt.Errorf("Cannot determine tenant resolver URI for %q, please specify --tenant on `fsoc config set`", ctx.Server)
+		return "", fmt.Errorf("Cannot determine tenant resolver URI for %q, please specify --tenant on `fsoc config set`", ctx.URL)
 	}
 
 	elements[0] = RESOLVER_HOST
@@ -110,6 +110,6 @@ func computeResolverEndpoint(ctx *config.Context) (string, error) {
 	uri.Host = strings.Join(elements, ".")
 	//TODO: enable for Go 1.19
 	// uri = uri.JoinPath("tenants", "lookup", ctx.Server)
-	uri.Path += "/tenants/lookup/" + ctx.Server // use this until Go 1.19 is supported in building
+	uri.Path += "/tenants/lookup/" + uri.Host // use this until Go 1.19 is supported in building
 	return uri.String(), nil
 }

--- a/platform/api/tenant_test.go
+++ b/platform/api/tenant_test.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/cisco-open/fsoc/cmd/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestComputeResolverEndpointForLocalSetup(t *testing.T) {
+	cfg := &config.Context{
+		URL:    "http://localhost:8080",
+		Tenant: "123-123",
+	}
+	endpoint, err := computeResolverEndpoint(cfg)
+	assert.NotNil(t, err)
+	assert.Equal(t, "", endpoint)
+}
+
+func TestComputeResolverEndpointForProduction(t *testing.T) {
+	cfg := &config.Context{
+		URL:    "https://MYTENANT.saas.appd-test.com",
+		Tenant: "123-123",
+	}
+	endpoint, err := computeResolverEndpoint(cfg)
+	assert.Nil(t, err)
+	assert.Equal(t, "https://observe-tenant-lookup-api.saas.appd-test.com/tenants/lookup/MYTENANT.saas.appd-test.com", endpoint)
+}

--- a/platform/api/tenant_test.go
+++ b/platform/api/tenant_test.go
@@ -1,9 +1,11 @@
 package api
 
 import (
-	"github.com/cisco-open/fsoc/cmd/config"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cisco-open/fsoc/cmd/config"
 )
 
 func TestComputeResolverEndpointForLocalSetup(t *testing.T) {


### PR DESCRIPTION
Replace the `server` config with `url` to better support local development. 
Also fixed one minor error in the help message - default config file is `~/.fsoc` instead of `~/.fsoc.yaml`