### PR TITLE
fix edge case in uql error display (fsoc-117)

### DIFF
--- a/cmd/uql/uql.go
+++ b/cmd/uql/uql.go
@@ -185,7 +185,9 @@ func printProblemDescription(cmd *cobra.Command, problem uqlProblem, inputQuery 
 		}
 		cmd.Printf("Error in the query:\n%s\n\n", highlightError(query, problem.errorDetails[0]))
 	}
-	printErrorDetail(cmd, problem.errorDetails[0])
+	if problem.errorDetails != nil && len(problem.errorDetails) > 0 {
+		printErrorDetail(cmd, problem.errorDetails[0])
+	}
 }
 
 func printErrorDetail(cmd *cobra.Command, detail errorDetail) {


### PR DESCRIPTION
## Description

Fix an edge case in error display for the UQL command that was causing a crash. (FSOC-117)

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
