### PR TITLE
preemptive support for solution tag header requirement

### DIFF
--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -50,6 +50,7 @@ func downloadSolution(cmd *cobra.Command, args []string) {
 
 	headers := map[string]string{
 		"stage":            "STABLE",
+		"tag":              "stable",
 		"solutionFileName": solutionNameWithZipExtension,
 	}
 	httpOptions := api.Options{Headers: headers}

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -163,6 +163,7 @@ func downloadSolutionZip(cmd *cobra.Command, solutionName string, forkName strin
 
 	headers := map[string]string{
 		"stage":            "STABLE",
+		"tag":              "stable",
 		"solutionFileName": solutionNameWithZipExtension,
 	}
 	httpOptions := api.Options{Headers: headers}

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -123,6 +123,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 
 	headers := map[string]string{
 		"stage":        "STABLE",
+		"tag":          "stable",
 		"operation":    "UPLOAD",
 		"Content-Type": writer.FormDataContentType(),
 	}

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -115,6 +115,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 
 	headers := map[string]string{
 		"stage":        "STABLE",
+		"tag":          "stable",
 		"operation":    "VALIDATE",
 		"Content-Type": writer.FormDataContentType(),
 	}


### PR DESCRIPTION
## Description

Provide the new `tag` header that the `solution` API is about to start requiring on `push`. For now, provide this header on all commands that deal with a remote name: `push`, `download`, `fork`, `validate`. This set may be revised in the future.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
