### PR TITLE
positional arguments for solutions package commands

### DIFF
--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -12,7 +12,7 @@ import (
 )
 
 var solutionDescribeCmd = &cobra.Command{
-	Use:   "describe --name=<solution>",
+	Use:   "describe (solution | --solution=<solution>)",
 	Short: "",
 	Long:  ``,
 	Run:   solutionDescribe,
@@ -32,7 +32,7 @@ type Solution struct {
 func getSolutionDescribeCmd() *cobra.Command {
 	solutionDescribeCmd.Flags().
 		String("solution", "", "The name of the solution to describe")
-	_ = solutionDescribeCmd.MarkFlagRequired("solution")
+	//_ = solutionDescribeCmd.MarkFlagRequired("solution")
 
 	return solutionDescribeCmd
 }
@@ -40,6 +40,13 @@ func getSolutionDescribeCmd() *cobra.Command {
 func solutionDescribe(cmd *cobra.Command, args []string) {
 	log.Info("Fetching the details of the specified solutions...")
 	solution, _ := cmd.Flags().GetString("solution")
+	if len(args) > 0 {
+		solution = args[0]
+	} else {
+		if len(solution) == 0 {
+			log.Fatal("A non-empty flag \"--solution\" is required.")
+		}
+	}
 
 	cfg := config.GetCurrentContext()
 	layerID := cfg.Tenant

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -12,7 +12,7 @@ import (
 )
 
 var solutionDescribeCmd = &cobra.Command{
-	Use:   "describe (solution | --solution=<solution>)",
+	Use:   "describe <solution-name>",
 	Short: "",
 	Long:  ``,
 	Run:   solutionDescribe,
@@ -32,6 +32,7 @@ type Solution struct {
 func getSolutionDescribeCmd() *cobra.Command {
 	solutionDescribeCmd.Flags().
 		String("solution", "", "The name of the solution to describe")
+	_ = solutionDescribeCmd.Flags().MarkDeprecated("solution", "The --solution flag is deprecated, please use argument instead.")
 	//_ = solutionDescribeCmd.MarkFlagRequired("solution")
 
 	return solutionDescribeCmd
@@ -44,7 +45,7 @@ func solutionDescribe(cmd *cobra.Command, args []string) {
 		solution = args[0]
 	} else {
 		if len(solution) == 0 {
-			log.Fatal("A non-empty flag \"--solution\" is required.")
+			log.Fatal("A non-empty \"solution-name\" argument is required.")
 		}
 	}
 

--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -24,28 +24,31 @@ import (
 )
 
 var solutionDownloadCmd = &cobra.Command{
-	Use:   "download --name=SOLUTION",
+	Use:   "download (name | --name=SOLUTION)",
 	Short: "Download solution",
 	Long: `This command allows the current tenant specified in the profile to download a solution bundle archive into the current directory or the directory specified in command argument.
 
 Example: fsoc solution download --name=spacefleet`,
-	Args:             cobra.ExactArgs(0),
+	Args:             cobra.MaximumNArgs(1),
 	Run:              downloadSolution,
 	TraverseChildren: true,
 }
 
 func getSolutionDownloadCmd() *cobra.Command {
 	solutionDownloadCmd.Flags().String("name", "", "name of the solution to download (required)")
-	_ = solutionDownloadCmd.MarkFlagRequired("name")
+	//_ = solutionDownloadCmd.MarkFlagRequired("name")
 	return solutionDownloadCmd
 }
 
 func downloadSolution(cmd *cobra.Command, args []string) {
 	solutionName, _ := cmd.Flags().GetString("name")
-	if solutionName == "" {
-		log.Fatalf("Solution name cannot be empty, use --name=<solution-name>")
+	if len(args) > 0 {
+		solutionName = args[0]
+	} else {
+		if len(solutionName) == 0 {
+			log.Fatalf("Solution name cannot be empty, use --name=<solution-name>")
+		}
 	}
-
 	var solutionNameWithZipExtension = getSolutionNameWithZip(solutionName)
 
 	headers := map[string]string{

--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -24,7 +24,7 @@ import (
 )
 
 var solutionDownloadCmd = &cobra.Command{
-	Use:   "download (name | --name=SOLUTION)",
+	Use:   "download <name>",
 	Short: "Download solution",
 	Long: `This command allows the current tenant specified in the profile to download a solution bundle archive into the current directory or the directory specified in command argument.
 
@@ -36,6 +36,7 @@ Example: fsoc solution download --name=spacefleet`,
 
 func getSolutionDownloadCmd() *cobra.Command {
 	solutionDownloadCmd.Flags().String("name", "", "name of the solution to download (required)")
+	_ = solutionDownloadCmd.Flags().MarkDeprecated("name", "The --name flag is deprecated, please use argument instead.")
 	//_ = solutionDownloadCmd.MarkFlagRequired("name")
 	return solutionDownloadCmd
 }
@@ -46,7 +47,7 @@ func downloadSolution(cmd *cobra.Command, args []string) {
 		solutionName = args[0]
 	} else {
 		if len(solutionName) == 0 {
-			log.Fatalf("Solution name cannot be empty, use --name=<solution-name>")
+			log.Fatalf("Solution name cannot be empty")
 		}
 	}
 	var solutionNameWithZipExtension = getSolutionNameWithZip(solutionName)

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -32,7 +32,7 @@ import (
 )
 
 var solutionForkCmd = &cobra.Command{
-	Use:   "fork (name source-name | --name=<solutionName> --source-name=<source-solution-name>)",
+	Use:   "fork <name> <source-name>",
 	Short: "Fork a solution in the specified folder",
 	Long:  `This command will download the solution into this folder and change the name of the manifest to the specified name`,
 	Run:   solutionForkCommand,
@@ -40,9 +40,9 @@ var solutionForkCmd = &cobra.Command{
 
 func GetSolutionForkCommand() *cobra.Command {
 	solutionForkCmd.Flags().String("source-name", "", "name of the solution that needs to be downloaded")
-	//_ = solutionForkCmd.MarkFlagRequired("source-name")
+	_ = solutionForkCmd.Flags().MarkDeprecated("source-name", "The --source-name flag is deprecated, please use argument instead.")
 	solutionForkCmd.Flags().String("name", "", "name of the solution to copy it to")
-	//_ = solutionForkCmd.MarkFlagRequired("name")
+	_ = solutionForkCmd.Flags().MarkDeprecated("name", "The --name flag is deprecated, please use argument instead.")
 	return solutionForkCmd
 }
 
@@ -52,8 +52,8 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 	if len(args) == 2 {
 		solutionName, forkName = args[0], args[1]
 	} else {
-		if solutionName == "" {
-			log.Fatalf("name cannot be empty, use --source-name=<source-solution-name> and --name=<solution-name>")
+		if solutionName == "" || forkName == "" {
+			log.Fatalf("name or source-name cannot be empty")
 		}
 	}
 

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -32,7 +32,7 @@ import (
 )
 
 var solutionForkCmd = &cobra.Command{
-	Use:   "fork --name=<solutionName> --source-name=<sourceSolutionName>",
+	Use:   "fork (name source-name | --name=<solutionName> --source-name=<source-solution-name>)",
 	Short: "Fork a solution in the specified folder",
 	Long:  `This command will download the solution into this folder and change the name of the manifest to the specified name`,
 	Run:   solutionForkCommand,
@@ -40,17 +40,21 @@ var solutionForkCmd = &cobra.Command{
 
 func GetSolutionForkCommand() *cobra.Command {
 	solutionForkCmd.Flags().String("source-name", "", "name of the solution that needs to be downloaded")
-	_ = solutionForkCmd.MarkFlagRequired("source-name")
+	//_ = solutionForkCmd.MarkFlagRequired("source-name")
 	solutionForkCmd.Flags().String("name", "", "name of the solution to copy it to")
-	_ = solutionForkCmd.MarkFlagRequired("name")
+	//_ = solutionForkCmd.MarkFlagRequired("name")
 	return solutionForkCmd
 }
 
 func solutionForkCommand(cmd *cobra.Command, args []string) {
 	solutionName, _ := cmd.Flags().GetString("source-name")
 	forkName, _ := cmd.Flags().GetString("name")
-	if solutionName == "" {
-		log.Fatalf("name cannot be empty, use --source-name=<solution-name>")
+	if len(args) == 2 {
+		solutionName, forkName = args[0], args[1]
+	} else {
+		if solutionName == "" {
+			log.Fatalf("name cannot be empty, use --source-name=<source-solution-name> and --name=<solution-name>")
+		}
 	}
 
 	currentDirectory, err := filepath.Abs(".")

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -28,7 +28,7 @@ import (
 )
 
 var solutionInitCmd = &cobra.Command{
-	Use:   "init",
+	Use:   "init (name | --name=testSolution)",
 	Short: "Create a new solution",
 	Long: `This command creates a skeleton of a solution in the current directory.
 
@@ -55,7 +55,7 @@ the "solution extend" command can be used to add more objects.`,
 func getInitSolutionCmd() *cobra.Command {
 	solutionInitCmd.Flags().
 		String("name", "", "The name of the new solution (required)")
-	_ = solutionInitCmd.MarkFlagRequired("name")
+	//_ = solutionInitCmd.MarkFlagRequired("name")
 
 	solutionInitCmd.Flags().
 		Bool("include-service", true, "Add a service component definition to this solution")
@@ -66,12 +66,14 @@ func getInitSolutionCmd() *cobra.Command {
 }
 
 func generateSolutionPackage(cmd *cobra.Command, args []string) {
-
 	solutionName, _ := cmd.Flags().GetString("name")
 	solutionName = strings.ToLower(solutionName)
-
-	if len(solutionName) == 0 {
-		log.Fatal("A non-empty flag \"--name\" is required.")
+	if len(args) > 0 {
+		solutionName = args[0]
+	} else {
+		if len(solutionName) == 0 {
+			log.Fatal("A non-empty flag \"--name\" is required.")
+		}
 	}
 
 	output.PrintCmdStatus(cmd, fmt.Sprintf("Preparing the %s solution package folder structure... \n", solutionName))

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -28,7 +28,7 @@ import (
 )
 
 var solutionInitCmd = &cobra.Command{
-	Use:   "init (name | --name=testSolution)",
+	Use:   "init <name>",
 	Short: "Create a new solution",
 	Long: `This command creates a skeleton of a solution in the current directory.
 
@@ -55,7 +55,7 @@ the "solution extend" command can be used to add more objects.`,
 func getInitSolutionCmd() *cobra.Command {
 	solutionInitCmd.Flags().
 		String("name", "", "The name of the new solution (required)")
-	//_ = solutionInitCmd.MarkFlagRequired("name")
+	_ = solutionInitCmd.Flags().MarkDeprecated("name", "The --name flag is deprecated, please use argument instead.")
 
 	solutionInitCmd.Flags().
 		Bool("include-service", true, "Add a service component definition to this solution")
@@ -72,7 +72,7 @@ func generateSolutionPackage(cmd *cobra.Command, args []string) {
 		solutionName = args[0]
 	} else {
 		if len(solutionName) == 0 {
-			log.Fatal("A non-empty flag \"--name\" is required.")
+			log.Fatal("A non-empty \"name\" argument is required.")
 		}
 	}
 


### PR DESCRIPTION
## Description

solutions commands now take both flag and positional arguments i.e. you can write either of the following

fsoc solution init nameofsolution
--
or
--
fsoc solution init --name=nameofsolution


## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
