### PR TITLE
fsoc melt using melt library

### DIFF
--- a/cmd/melt.go
+++ b/cmd/melt.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "github.com/cisco-open/fsoc/cmd/melt"
+
+func init() {
+	registerSubsystem(melt.NewSubCmd())
+}

--- a/cmd/melt/melt.go
+++ b/cmd/melt/melt.go
@@ -1,0 +1,35 @@
+// Copyright 2022 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package melt
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// meltCmd represents the login command
+var meltCmd = &cobra.Command{
+	Use:              "melt",
+	Short:            "Generates fsoc telemetry data models and sends OTLP payloads to the FSO ingestion services",
+	Long:             "This command generate fsoc telemetry data models and sends the data to the FSO Platform Ingestion services. \nIt helps developers to generate mock telemetry data to test their solution's domain models.",
+	TraverseChildren: true,
+}
+
+func NewSubCmd() *cobra.Command {
+
+	// meltCmd.AddCommand(getMeltGenCmd())
+	meltCmd.AddCommand(getMeltPushCmd())
+	meltCmd.AddCommand(getMeltModelCmd())
+	return meltCmd
+}

--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -120,6 +120,9 @@ func GetFsocEntities(fmmEntities []*sol.FmmEntity, fsocMetrics []*melt.Metric) [
 		fsocE := melt.NewEntity(fsocEType)
 		fmmAttrs := maps.Keys(fmmE.AttributeDefinitions.Attributes)
 		for _, fmmAttr := range fmmAttrs {
+			if !strings.Contains(fmmAttr, fmmE.Namespace.Name) {
+				fmmAttr = fmt.Sprintf("%s.%s.%s", fmmE.Namespace.Name, fmmE.Name, fmmAttr)
+			}
 			fsocE.SetAttribute(fmmAttr, "")
 		}
 		//adding fsoc metrics to the model

--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -1,0 +1,224 @@
+package melt
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v2"
+
+	sol "github.com/cisco-open/fsoc/cmd/solution"
+	"github.com/cisco-open/fsoc/output"
+	"github.com/cisco-open/fsoc/platform/melt"
+)
+
+// meltCmd represents the login command
+var meltModelCmd = &cobra.Command{
+	Use:              "model",
+	Short:            "Generates a fsoc telemetry data model .yaml file based on your solution domain model",
+	Long:             `This command converts your fmm domain models as a fsoc telemetry data model .yaml file so you can generate mock telemetry data for your solutioin.`,
+	TraverseChildren: true,
+	Run:              meltModel,
+}
+
+func getMeltModelCmd() *cobra.Command {
+	return meltModelCmd
+}
+
+func meltModel(cmd *cobra.Command, args []string) {
+	manifest := sol.GetManifest()
+	fileName := fmt.Sprintf("%s-%s-melt.yaml", manifest.Name, manifest.SolutionVersion)
+	fsocData := getFsocDataModel(cmd, manifest)
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Generating %s\n", fileName))
+	writeDataFile(fsocData, fileName)
+}
+
+func getFsocDataModel(cmd *cobra.Command, manifest *sol.Manifest) *melt.FsocData {
+	// fsocData := &melt.FsocData{
+	// 	Credentials: &api.AgentPrincipalStruct{
+	// 		ClientID: "",
+	// 		Secret:   "",
+	// 	},
+	// }
+
+	fsocData := &melt.FsocData{}
+	fmmEntities := GetFmmEntities(manifest)
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %v entities to the fsoc data model\n", len(fmmEntities)))
+	fmmMetrics := GetFmmMetrics(manifest)
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %v metrics to the fsoc data model\n", len(fmmMetrics)))
+	fsocMetrics := GetFsocMetrics(fmmMetrics)
+	fsocEntities := GetFsocEntities(fmmEntities, fsocMetrics)
+	fsocData.Melt = fsocEntities
+
+	return fsocData
+}
+
+func GetFmmMetrics(manifest *sol.Manifest) []*sol.FmmMetric {
+	fmmMetrics := make([]*sol.FmmMetric, 0)
+	entityComponentDefs := GetComponentDefs("fmm:metric", manifest)
+	for _, compDef := range entityComponentDefs {
+		if compDef.ObjectsFile != "" {
+			filePath := compDef.ObjectsFile
+			fmmMetrics = append(fmmMetrics, getFmmMetricsFromFile(filePath)...)
+		}
+
+		// if compDef.ObjectsDir != "" {
+
+		// }
+
+	}
+	return fmmMetrics
+}
+
+func getFmmMetricsFromFile(filePath string) []*sol.FmmMetric {
+	fmmMetrics := make([]*sol.FmmMetric, 0)
+	metricDefFile := openFile(filePath)
+	defer metricDefFile.Close()
+	metricDefBytes, _ := io.ReadAll(metricDefFile)
+	metricDefContent := string(metricDefBytes)
+
+	if strings.Index(metricDefContent, "[") == 0 {
+		metricsArray := make([]*sol.FmmMetric, 0)
+		err := json.Unmarshal(metricDefBytes, &metricsArray)
+		if err != nil {
+			log.Fatalf("Can't parse an array of metric definition objects from the %q file:\n %v", filePath, err)
+		}
+		fmmMetrics = append(fmmMetrics, metricsArray...)
+	} else {
+		var metric *sol.FmmMetric
+		err := json.Unmarshal(metricDefBytes, &metric)
+		if err != nil {
+			log.Fatalf("Can't parse a metric definition objects from the %q file:\n %v ", filePath, err)
+		}
+		fmmMetrics = append(fmmMetrics, metric)
+	}
+	return fmmMetrics
+}
+
+func GetFsocMetrics(fmmMetrics []*sol.FmmMetric) []*melt.Metric {
+	fsocMetrics := make([]*melt.Metric, 0)
+
+	for _, fmmMt := range fmmMetrics {
+		fsocMType := fmt.Sprintf("%s:%s", fmmMt.Namespace.Name, fmmMt.Name)
+		fsocMt := melt.NewMetric(fsocMType, fmmMt.Unit, string(fmmMt.ContentType), string(fmmMt.Type))
+		fsocMetrics = append(fsocMetrics, fsocMt)
+	}
+
+	return fsocMetrics
+}
+
+func GetFsocEntities(fmmEntities []*sol.FmmEntity, fsocMetrics []*melt.Metric) []*melt.Entity {
+	fsocEntities := make([]*melt.Entity, 0)
+
+	for _, fmmE := range fmmEntities {
+		fsocEType := fmt.Sprintf("%s:%s", fmmE.Namespace.Name, fmmE.Name)
+		fsocE := melt.NewEntity(fsocEType)
+		fmmAttrs := maps.Keys(fmmE.AttributeDefinitions.Attributes)
+		for _, fmmAttr := range fmmAttrs {
+			fsocE.SetAttribute(fmmAttr, "")
+		}
+		//adding fsoc metrics to the model
+		for _, fmmEM := range fmmE.MetricTypes {
+			fsocMetricType := fmmEM
+			for _, fsocMt := range fsocMetrics {
+				if fsocMt.TypeName == fsocMetricType {
+					fsocE.AddMetric(fsocMt)
+				}
+			}
+
+		}
+
+		// add logs tp the entity
+		for i := 0; i < 2; i++ {
+			fsocL := melt.NewLog()
+			fsocL.SetAttribute("level", "info")
+			fsocL.Severity = "INFO"
+			fsocL.Body = fmt.Sprintf("hello world-%d for an entity of type %s", i, fsocE.TypeName)
+			fsocE.AddLog(fsocL)
+		}
+
+		fsocEntities = append(fsocEntities, fsocE)
+	}
+
+	return fsocEntities
+}
+
+func GetFmmEntities(manifest *sol.Manifest) []*sol.FmmEntity {
+	fmmEntities := make([]*sol.FmmEntity, 0)
+	entityComponentDefs := GetComponentDefs("fmm:entity", manifest)
+	for _, compDef := range entityComponentDefs {
+		if compDef.ObjectsFile != "" {
+			filePath := compDef.ObjectsFile
+			fmmEntities = append(fmmEntities, getFmmEntitiesFromFile(filePath)...)
+		}
+
+		// if compDef.ObjectsDir != "" {
+
+		// }
+
+	}
+	return fmmEntities
+}
+
+func getFmmEntitiesFromFile(filePath string) []*sol.FmmEntity {
+	fmmEntities := make([]*sol.FmmEntity, 0)
+	entityDefFile := openFile(filePath)
+	defer entityDefFile.Close()
+	entityDefBytes, _ := io.ReadAll(entityDefFile)
+	entityDefContent := string(entityDefBytes)
+
+	if strings.Index(entityDefContent, "[") == 0 {
+		entitiesArray := make([]*sol.FmmEntity, 0)
+		err := json.Unmarshal(entityDefBytes, &entitiesArray)
+		if err != nil {
+			log.Fatalf("Can't parse an array of entity definition objects from the %q file:\n %v", filePath, err)
+		}
+		fmmEntities = append(fmmEntities, entitiesArray...)
+	} else {
+		var entity *sol.FmmEntity
+		err := json.Unmarshal(entityDefBytes, &entity)
+		if err != nil {
+			log.Fatalf("Can't parse an entity definition objects from the %q file:\n %v", filePath, err)
+		}
+		fmmEntities = append(fmmEntities, entity)
+	}
+	return fmmEntities
+}
+
+func GetComponentDefs(typeName string, manifest *sol.Manifest) []sol.ComponentDef {
+
+	componentDefs := make([]sol.ComponentDef, 0)
+
+	for _, compDef := range manifest.Objects {
+		if compDef.Type == typeName {
+			componentDefs = append(componentDefs, compDef)
+		}
+	}
+	return componentDefs
+}
+
+func openFile(filePath string) *os.File {
+	svcFile, err := os.Open(filePath)
+	if err != nil {
+		log.Fatalf("Can't open the file named %q: %v", filePath, err)
+	}
+	return svcFile
+}
+
+func writeDataFile(fsoData *melt.FsocData, fileName string) {
+	fsoDataYamlFile, err := os.Create(fileName)
+	if err != nil {
+		log.Fatalf("Failed to create FsoData yaml file %q: %v", fileName, err)
+	}
+	defer fsoDataYamlFile.Close()
+
+	svcJson, _ := yaml.Marshal(fsoData)
+
+	_, _ = fsoDataYamlFile.WriteString(string(svcJson))
+	fsoDataYamlFile.Close()
+}

--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -2,7 +2,9 @@ package melt
 
 import (
 	"io"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
@@ -33,92 +35,49 @@ func getMeltPushCmd() *cobra.Command {
 
 func meltSend(cmd *cobra.Command, args []string) {
 	if len(args) < 1 {
-		log.Error("Missing the fsoc telemetry data model .yaml file name")
+		log.Error("Missing the fsoc telemetry data model .yaml file name!s")
+		return
+	}
+	if !cmd.Flags().Changed("profile") {
+		log.Error("The required --profile <agent-principal-profile> flag is missing!")
 		return
 	}
 	dataFileName := args[0]
 	sendDataFromFile(cmd, dataFileName)
 }
 
-// func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
-// 	fsoData, err := loadDataFile(dataFileName)
-// 	if err != nil {
-// 		log.Fatalf("Can't open the file named %q: %v", dataFileName, err)
-// 	}
-// 	cfg := config.GetCurrentContext()
-// 	authObj, err := api.AgentPrincipalLogin(cfg, fsoData.Credentials)
-// 	if err != nil {
-// 		log.Fatalf("Couldn't authenticate using agent principal credentials: %v", err)
-// 	}
-
-// 	// authObj := &api.TokenStruct{
-// 	// 	AccessToken: "thisIsTheToken",
-// 	// }
-// 	exportMeltStraight(cmd, authObj, fsoData)
-// }
-
 func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
 	fsoData, err := loadDataFile(dataFileName)
 	if err != nil {
 		log.Fatalf("Can't open the file named %q: %v", dataFileName, err)
 	}
+
+	for _, entity := range fsoData.Melt {
+		entity.SetAttribute("telemetry.sdk.name", "fsoc-melt")
+		for _, m := range entity.Metrics {
+			et := time.Now()
+			if len(m.DataPoints) == 0 {
+				for i := 1; i < 6; i++ {
+					st := et.Add(time.Minute * -1)
+					et = st
+					m.AddDataPoint(st.UnixNano(), et.UnixNano(), rand.Float64()*50)
+				}
+			}
+		}
+		for _, l := range entity.Logs {
+			if l.Timestamp == 0 {
+				l.Timestamp = time.Now().UnixNano()
+			}
+		}
+	}
+
 	exportMeltStraight(cmd, fsoData)
 }
-
-// func exportMeltStraight(cmd *cobra.Command, authObj *api.TokenStruct, fsoData *melt.FsocData) {
-
-// 	token := authObj.AccessToken
-// 	endPoint := "/data/v1"
-
-// 	output.PrintCmdStatus(cmd, "Generating new MELT telemetry... \n")
-// 	exportMelt(cmd, endPoint, token, *fsoData)
-// }
 
 func exportMeltStraight(cmd *cobra.Command, fsoData *melt.FsocData) {
 	output.PrintCmdStatus(cmd, "Generating new MELT telemetry... \n")
 	exportMelt(cmd, *fsoData)
 }
-
-// func exportMeltTicker(cmd *cobra.Command, fsoData *melt.FsoData) {
-// 	interval, _ := time.ParseDuration("1m")
-// 	ticker := time.NewTicker(interval)
-
-// 	for _ = range ticker.C {
-
-// 		authObj, err := login.Login(fsoData.Credentials)
-// 		if err != nil {
-// 			log.Fatalf("Failed to authenticate %v", err.Error())
-// 			return
-// 		}
-
-// 		token := authObj.AccessToken
-// 		urlStruct, err := url.Parse(fsoData.Credentials.TokenURL)
-// 		server := urlStruct.Host
-
-// 		endPoint := "https://" + server + "/data/v1"
-
-// 		output.PrintCmdStatus("Generating and pushing OTLP MELT Telemetry data to the FSO Platform...")
-// 		exportMelt(cmd, endPoint, token, *fsoData)
-// 	}
-// }
-
-// func exportMelt(cmd *cobra.Command, endPoint, token string, fsoData melt.FsocData) {
-// 	// invoke the exporter
-// 	exp := &melt.Exporter{}
-
-// 	output.PrintCmdStatus(cmd, "\nExporting metrics... \n")
-// 	err := exp.ExportMetrics(fsoData.Melt)
-// 	if err != nil {
-// 		log.Fatalf("Error exporting metrics: %s", err)
-// 	}
-
-// 	output.PrintCmdStatus(cmd, "\nExporting logs... \n")
-// 	err = exp.ExportLogs(fsoData.Melt)
-// 	if err != nil {
-// 		log.Fatalf("Error exporting logs: %s", err)
-// 	}
-
-// }
 
 func exportMelt(cmd *cobra.Command, fsoData melt.FsocData) {
 	// invoke the exporter
@@ -157,31 +116,3 @@ func loadDataFile(fileName string) (*melt.FsocData, error) {
 
 	return fsoData, nil
 }
-
-// func exportEvents(ctx context.Context, endPoint, token string) error {
-// 	el := []*melt.Entity{}
-
-// 	// create an entity
-// 	e1 := melt.NewEntity("geometry:square")
-// 	e1.SetAttribute("geometry.shape.name", "Square 100")
-// 	e1.SetAttribute("geometry.shape.type", "square")
-// 	e1.SetAttribute("geometry.square.side", "10")
-// 	e1.SetAttribute("telemetry.sdk.name", "appd-datagen")
-
-// 	// add events to the entity
-// 	for i := 1; i < 5; i++ {
-// 		l := melt.NewEvent("geometry:operation")
-// 		l.SetAttribute("type", "draw")
-// 		l.Timestamp = time.Now().UnixNano()
-// 		e1.AddLog(l)
-// 	}
-// 	el = append(el, e1)
-
-// 	// invoke the exporter
-// 	exp := &exporter.Exporter{}
-// 	expReq := melt.ExportRequest{
-// 		EndPoint:    endPoint,
-// 		Credentials: melt.Credentials{Token: token},
-// 	}
-// 	return exp.ExportLogs(ctx, expReq, el)
-// }

--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -1,0 +1,187 @@
+package melt
+
+import (
+	"io"
+	"os"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/cisco-open/fsoc/output"
+	"github.com/cisco-open/fsoc/platform/melt"
+)
+
+// meltCmd represents the login command
+var meltSendCmd = &cobra.Command{
+	Use:   "push",
+	Short: "Generates OTLP telemetry based on fsoc telemetry data model .yaml",
+	Long: `This command generates OTLP payload based on a fsoc telemetry data models and sends the data to the FSO Platform Ingestion services.
+	
+	To properly use the command you will need to create a fsoc profile using an agent principal yaml:
+	fsoc config set --profile <agent-principal-profile> --auth agent-principal --secret-file <agent-principal.yaml>
+	
+	Then you will use the agent principal profile as part of the command:
+	fsoc melt push <fsocdatamodel>.yaml --profile <agent-principal-profile> `,
+	TraverseChildren: true,
+	Run:              meltSend,
+}
+
+func getMeltPushCmd() *cobra.Command {
+	return meltSendCmd
+}
+
+func meltSend(cmd *cobra.Command, args []string) {
+	if len(args) < 1 {
+		log.Error("Missing the fsoc telemetry data model .yaml file name")
+		return
+	}
+	dataFileName := args[0]
+	sendDataFromFile(cmd, dataFileName)
+}
+
+// func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
+// 	fsoData, err := loadDataFile(dataFileName)
+// 	if err != nil {
+// 		log.Fatalf("Can't open the file named %q: %v", dataFileName, err)
+// 	}
+// 	cfg := config.GetCurrentContext()
+// 	authObj, err := api.AgentPrincipalLogin(cfg, fsoData.Credentials)
+// 	if err != nil {
+// 		log.Fatalf("Couldn't authenticate using agent principal credentials: %v", err)
+// 	}
+
+// 	// authObj := &api.TokenStruct{
+// 	// 	AccessToken: "thisIsTheToken",
+// 	// }
+// 	exportMeltStraight(cmd, authObj, fsoData)
+// }
+
+func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
+	fsoData, err := loadDataFile(dataFileName)
+	if err != nil {
+		log.Fatalf("Can't open the file named %q: %v", dataFileName, err)
+	}
+	exportMeltStraight(cmd, fsoData)
+}
+
+// func exportMeltStraight(cmd *cobra.Command, authObj *api.TokenStruct, fsoData *melt.FsocData) {
+
+// 	token := authObj.AccessToken
+// 	endPoint := "/data/v1"
+
+// 	output.PrintCmdStatus(cmd, "Generating new MELT telemetry... \n")
+// 	exportMelt(cmd, endPoint, token, *fsoData)
+// }
+
+func exportMeltStraight(cmd *cobra.Command, fsoData *melt.FsocData) {
+	output.PrintCmdStatus(cmd, "Generating new MELT telemetry... \n")
+	exportMelt(cmd, *fsoData)
+}
+
+// func exportMeltTicker(cmd *cobra.Command, fsoData *melt.FsoData) {
+// 	interval, _ := time.ParseDuration("1m")
+// 	ticker := time.NewTicker(interval)
+
+// 	for _ = range ticker.C {
+
+// 		authObj, err := login.Login(fsoData.Credentials)
+// 		if err != nil {
+// 			log.Fatalf("Failed to authenticate %v", err.Error())
+// 			return
+// 		}
+
+// 		token := authObj.AccessToken
+// 		urlStruct, err := url.Parse(fsoData.Credentials.TokenURL)
+// 		server := urlStruct.Host
+
+// 		endPoint := "https://" + server + "/data/v1"
+
+// 		output.PrintCmdStatus("Generating and pushing OTLP MELT Telemetry data to the FSO Platform...")
+// 		exportMelt(cmd, endPoint, token, *fsoData)
+// 	}
+// }
+
+// func exportMelt(cmd *cobra.Command, endPoint, token string, fsoData melt.FsocData) {
+// 	// invoke the exporter
+// 	exp := &melt.Exporter{}
+
+// 	output.PrintCmdStatus(cmd, "\nExporting metrics... \n")
+// 	err := exp.ExportMetrics(fsoData.Melt)
+// 	if err != nil {
+// 		log.Fatalf("Error exporting metrics: %s", err)
+// 	}
+
+// 	output.PrintCmdStatus(cmd, "\nExporting logs... \n")
+// 	err = exp.ExportLogs(fsoData.Melt)
+// 	if err != nil {
+// 		log.Fatalf("Error exporting logs: %s", err)
+// 	}
+
+// }
+
+func exportMelt(cmd *cobra.Command, fsoData melt.FsocData) {
+	// invoke the exporter
+	exp := &melt.Exporter{}
+
+	output.PrintCmdStatus(cmd, "\nExporting metrics... \n")
+	err := exp.ExportMetrics(fsoData.Melt)
+	if err != nil {
+		log.Fatalf("Error exporting metrics: %s", err)
+	}
+
+	output.PrintCmdStatus(cmd, "\nExporting logs... \n")
+	err = exp.ExportLogs(fsoData.Melt)
+	if err != nil {
+		log.Fatalf("Error exporting logs: %s", err)
+	}
+
+}
+
+func loadDataFile(fileName string) (*melt.FsocData, error) {
+	var fsoData *melt.FsocData
+
+	dataFile, err := os.Open(fileName)
+	if err != nil {
+		log.Fatalf("Can't open the file named %q: %v", fileName, err)
+	}
+
+	defer dataFile.Close()
+
+	dataBytes, _ := io.ReadAll(dataFile)
+
+	err = yaml.Unmarshal(dataBytes, &fsoData)
+	if err != nil {
+		log.Fatalf("Failed to parse fsoc telemetry model file: %v", err)
+	}
+
+	return fsoData, nil
+}
+
+// func exportEvents(ctx context.Context, endPoint, token string) error {
+// 	el := []*melt.Entity{}
+
+// 	// create an entity
+// 	e1 := melt.NewEntity("geometry:square")
+// 	e1.SetAttribute("geometry.shape.name", "Square 100")
+// 	e1.SetAttribute("geometry.shape.type", "square")
+// 	e1.SetAttribute("geometry.square.side", "10")
+// 	e1.SetAttribute("telemetry.sdk.name", "appd-datagen")
+
+// 	// add events to the entity
+// 	for i := 1; i < 5; i++ {
+// 		l := melt.NewEvent("geometry:operation")
+// 		l.SetAttribute("type", "draw")
+// 		l.Timestamp = time.Now().UnixNano()
+// 		e1.AddLog(l)
+// 	}
+// 	el = append(el, e1)
+
+// 	// invoke the exporter
+// 	exp := &exporter.Exporter{}
+// 	expReq := melt.ExportRequest{
+// 		EndPoint:    endPoint,
+// 		Credentials: melt.Credentials{Token: token},
+// 	}
+// 	return exp.ExportLogs(ctx, expReq, el)
+// }

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -565,3 +565,20 @@ func getStringfiedArray(array []string) string {
 	prettyArrayString := strings.Replace(strings.Join(tokenized, ", "), "\"", "'", -1)
 	return prettyArrayString
 }
+
+func GetManifest() *Manifest {
+	manifestFile := openFile("manifest.json")
+	defer manifestFile.Close()
+
+	manifestBytes, err := io.ReadAll(manifestFile)
+	if err != nil {
+		log.Fatalf("Failed to read solution manifest: %v", err)
+	}
+
+	var manifest *Manifest
+	err = json.Unmarshal(manifestBytes, &manifest)
+	if err != nil {
+		log.Fatalf("Failed to parse solution manifest: %v", err)
+	}
+	return manifest
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.pinniped.dev v0.22.0
 	golang.org/x/exp v0.0.0-20230306221820-f0f767cdffd6
 	golang.org/x/oauth2 v0.6.0
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -636,6 +636,8 @@ gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWD
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/platform/api/call.go
+++ b/platform/api/call.go
@@ -246,7 +246,11 @@ func httpRequest(method string, path string, body any, out any, options *Options
 			if err != nil {
 				return fmt.Errorf("Failed to save the solution archive file as %q: %w", solutionFileName, err)
 			}
+		} else if contentType == "application/x-protobuf" {
+			// unmarshal response from protobuff
+			log.Infof("Protobuf received:(%q)", respBytes)
 		} else {
+
 			// unmarshal response from JSON (assuming JSON data, even if the content-type is not set)
 			if err := json.Unmarshal(respBytes, out); err != nil {
 				return fmt.Errorf("Failed to JSON-parse the response: %w (%q)", err, respBytes)

--- a/platform/melt/exporter.go
+++ b/platform/melt/exporter.go
@@ -35,7 +35,7 @@ const (
 type Exporter struct{}
 
 // ExportMetrics - export metrics
-func (exp *Exporter) ExportMetrics(ctx context.Context, entities []*Entity) error {
+func (exp *Exporter) ExportMetrics(entities []*Entity) error {
 	emsr := exp.buildMetricsPayload(entities)
 
 	if emsr.ResourceMetrics == nil {
@@ -46,11 +46,11 @@ func (exp *Exporter) ExportMetrics(ctx context.Context, entities []*Entity) erro
 	b, _ := json.Marshal(emsr)
 	log.Debugf("METRICS: %s", string(b))
 
-	return exp.exportHTTP(ctx, pathMetrics, emsr)
+	return exp.exportHTTP(pathMetrics, emsr)
 }
 
 // ExportLogs - export resource logs
-func (exp *Exporter) ExportLogs(ctx context.Context, entities []*Entity) error {
+func (exp *Exporter) ExportLogs(entities []*Entity) error {
 	elsr := exp.buildLogsPayload(entities)
 
 	if elsr.ResourceLogs == nil {
@@ -61,13 +61,13 @@ func (exp *Exporter) ExportLogs(ctx context.Context, entities []*Entity) error {
 	b, _ := json.Marshal(elsr)
 	log.Debugf("LOGS: %s", string(b))
 
-	return exp.exportHTTP(ctx, pathLogs, elsr)
+	return exp.exportHTTP(pathLogs, elsr)
 }
 
 // ExportEvents - export events as resource logs
 // OTEL does not distibguish between events and logs
-func (exp *Exporter) ExportEvents(ctx context.Context, entities []*Entity) error {
-	return exp.ExportLogs(ctx, entities)
+func (exp *Exporter) ExportEvents(entities []*Entity) error {
+	return exp.ExportLogs(entities)
 }
 
 // ExportSpans - export resource spans
@@ -82,13 +82,16 @@ func (exp *Exporter) ExportSpans(ctx context.Context, entities []*Entity) error 
 	b, _ := json.Marshal(essr)
 	log.Debugf("SPANS: %s", string(b))
 
-	return exp.exportHTTP(ctx, pathSpans, essr)
+	return exp.exportHTTP(pathSpans, essr)
 }
 
 func (exp *Exporter) buildMetricsPayload(entities []*Entity) *collmetrics.ExportMetricsServiceRequest {
 	emsr := &collmetrics.ExportMetricsServiceRequest{}
 
 	for _, entity := range entities {
+		if len(entity.Metrics) == 0 {
+			continue
+		}
 
 		rm := &metrics.ResourceMetrics{}
 		rm.Resource = &resource.Resource{
@@ -350,7 +353,7 @@ func (exp *Exporter) createOtelSpan(t *Span) *spans.Span {
 	return ots
 }
 
-func (exp *Exporter) exportHTTP(ctx context.Context, path string, m protoreflect.ProtoMessage) error {
+func (exp *Exporter) exportHTTP(path string, m protoreflect.ProtoMessage) error {
 	options := api.Options{
 		Headers: map[string]string{
 			"Content-Type": "application/x-protobuf",

--- a/platform/melt/types.go
+++ b/platform/melt/types.go
@@ -47,7 +47,7 @@ type FsocData struct {
 // Entity - type for holding entity inforrmation
 type Entity struct {
 	TypeName      string
-	ID            string
+	ID            string `yaml:"id,omitempty"`
 	Attributes    map[string]string
 	Metrics       []*Metric
 	Logs          []*Log
@@ -57,29 +57,28 @@ type Entity struct {
 
 // Metric - structs for metrics
 type Metric struct {
-	// Kind     string
 	TypeName               string
 	ContentType            string
 	Unit                   string
 	Type                   string
-	Resource               Resource
+	Resource               Resource `yaml:"resource,omitempty"`
 	Attributes             map[string]string
-	DataPoints             []*DataPoint
-	Min                    string
-	Max                    string
-	IsMonotonic            bool
-	AggregationTemporality AggregationTemporality
+	DataPoints             []*DataPoint           `yaml:"datapoints,omitempty"`
+	Min                    string                 `yaml:"min,omitempty"`
+	Max                    string                 `yaml:"max,omitempty"`
+	IsMonotonic            bool                   `yaml:"ismonotonic,omitempty"`
+	AggregationTemporality AggregationTemporality `yaml:"aggregationtemporality,omitempty"`
 }
 
 // Log - structs for logs“
 type Log struct {
-	Resource   Resource
+	Resource   Resource `yaml:"resource,omitempty"`
 	Body       string
 	Severity   string // use for log
-	Timestamp  int64
+	Timestamp  int64  `yaml:"timestamp,omitempty"`
 	Attributes map[string]string
-	IsEvent    bool
-	TypeName   string
+	IsEvent    bool   `yaml:"isevent,omitempty"`
+	TypeName   string `yaml:"typename,omitempty"`
 }
 
 // Resource - structs for data point

--- a/platform/melt/types.go
+++ b/platform/melt/types.go
@@ -40,6 +40,10 @@ const (
 	SpanStatusCodeError SpanStatusCode = 2
 )
 
+type FsocData struct {
+	Melt []*Entity
+}
+
 // Entity - type for holding entity inforrmation
 type Entity struct {
 	TypeName      string


### PR DESCRIPTION
## Description

fsoc melt commands to help developers unit test their solution domain models and melt processing rules.

fsoc melt model: executed from within a solution package folder, generate the fsoc melt telemetry data model .yaml file which developers can provide mock data to generate otlp telemetry

fsoc melt push: executed from anywhere, take the datamodel.yaml file, and pushed the telemetry it represents as otlp into the platform

## Type of Change

- [ X] New Feature

