### PR TITLE
Add isactive filter to workload filter when querying by name

### DIFF
--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -83,7 +83,7 @@ func workloadReport(cmd *cobra.Command, args []string) error {
 func getWorkloadId(workloadName string) (*string, error) {
 
 	// UQL query to retrieve ID via workload.name attribute
-	queryStr := fmt.Sprintf("SINCE -7d FETCH id FROM entities(k8s:workload)[attributes(k8s.workload.name) = '%s']", workloadName)
+	queryStr := fmt.Sprintf("SINCE -7d FETCH id FROM entities(k8s:workload)[isActive = true][attributes(k8s.workload.name) = '%s']", workloadName)
 
 	response, err := uql.ExecuteQuery(&uql.Query{Str: queryStr}, uql.ApiVersion1)
 	if err != nil {


### PR DESCRIPTION
## Description

When searching workload by name, filter with isActive to reduce likelihood of fetching previous deployments

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
