### PR TITLE
Meltgen

### DIFF
--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/apex/log"
@@ -26,8 +27,8 @@ var meltModelCmd = &cobra.Command{
 	Run:              meltModel,
 }
 
-func getMeltModelCmd() *cobra.Command {
-	return meltModelCmd
+func init() {
+	meltCmd.AddCommand(meltModelCmd)
 }
 
 func meltModel(cmd *cobra.Command, args []string) {
@@ -66,10 +67,22 @@ func GetFmmMetrics(manifest *sol.Manifest) []*sol.FmmMetric {
 			filePath := compDef.ObjectsFile
 			fmmMetrics = append(fmmMetrics, getFmmMetricsFromFile(filePath)...)
 		}
-
-		// if compDef.ObjectsDir != "" {
-
-		// }
+		if compDef.ObjectsDir != "" {
+			filePath := compDef.ObjectsDir
+			err := filepath.Walk(filePath,
+				func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					if strings.Contains(path, ".json") {
+						fmmMetrics = append(fmmMetrics, getFmmMetricsFromFile(path)...)
+					}
+					return nil
+				})
+			if err != nil {
+				log.Fatalf("Error traversing the folder: %v", err)
+			}
+		}
 
 	}
 	return fmmMetrics
@@ -125,6 +138,7 @@ func GetFsocEntities(fmmEntities []*sol.FmmEntity, fsocMetrics []*melt.Metric) [
 			}
 			fsocE.SetAttribute(fmmAttr, "")
 		}
+
 		//adding fsoc metrics to the model
 		for _, fmmEM := range fmmE.MetricTypes {
 			fsocMetricType := fmmEM
@@ -159,10 +173,22 @@ func GetFmmEntities(manifest *sol.Manifest) []*sol.FmmEntity {
 			filePath := compDef.ObjectsFile
 			fmmEntities = append(fmmEntities, getFmmEntitiesFromFile(filePath)...)
 		}
-
-		// if compDef.ObjectsDir != "" {
-
-		// }
+		if compDef.ObjectsDir != "" {
+			filePath := compDef.ObjectsDir
+			err := filepath.Walk(filePath,
+				func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					if strings.Contains(path, ".json") {
+						fmmEntities = append(fmmEntities, getFmmEntitiesFromFile(path)...)
+					}
+					return nil
+				})
+			if err != nil {
+				log.Fatalf("Error traversing the folder: %v", err)
+			}
+		}
 
 	}
 	return fmmEntities

--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -40,13 +40,6 @@ func meltModel(cmd *cobra.Command, args []string) {
 }
 
 func getFsocDataModel(cmd *cobra.Command, manifest *sol.Manifest) *melt.FsocData {
-	// fsocData := &melt.FsocData{
-	// 	Credentials: &api.AgentPrincipalStruct{
-	// 		ClientID: "",
-	// 		Secret:   "",
-	// 	},
-	// }
-
 	fsocData := &melt.FsocData{}
 	fmmEntities := GetFmmEntities(manifest)
 	output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %v entities to the fsoc data model\n", len(fmmEntities)))

--- a/platform/melt/exporter.go
+++ b/platform/melt/exporter.go
@@ -12,6 +12,7 @@ import (
 	logs "go.opentelemetry.io/proto/otlp/logs/v1"
 	metrics "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resource "go.opentelemetry.io/proto/otlp/resource/v1"
+	v1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	spans "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -97,7 +98,7 @@ func (exp *Exporter) buildMetricsPayload(entities []*Entity) *collmetrics.Export
 			Attributes: toKeyValueList(entity.Attributes),
 		}
 
-		exp.addRelationships(entity.Relationships, rm)
+		exp.addRelationshipsToMetrics(entity.Relationships, rm)
 
 		ilm := &metrics.ScopeMetrics{}
 
@@ -121,7 +122,35 @@ func (exp *Exporter) buildMetricsPayload(entities []*Entity) *collmetrics.Export
 	return emsr
 }
 
-func (exp *Exporter) addRelationships(rels []*Relationship, rm *metrics.ResourceMetrics) {
+func (exp *Exporter) addRelationships(rels []*Relationship, r *v1.Resource) {
+	// add relationships
+	if len(rels) > 0 {
+		attrib := &common.KeyValue{
+			Key: keyAppdFMMEntityRelationships,
+		}
+		val := &common.AnyValue_ArrayValue{
+			ArrayValue: &common.ArrayValue{
+				Values: []*common.AnyValue{},
+			},
+		}
+		for _, r := range rels {
+			kvlv := &common.AnyValue{
+				Value: &common.AnyValue_KvlistValue{
+					KvlistValue: &common.KeyValueList{
+						Values: toKeyValueList(r.Attributes),
+					},
+				},
+			}
+			val.ArrayValue.Values = append(val.ArrayValue.Values, kvlv)
+		}
+		attrib.Value = &common.AnyValue{
+			Value: val,
+		}
+		r.Attributes = append(r.Attributes, attrib)
+	}
+}
+
+func (exp *Exporter) addRelationshipsToMetrics(rels []*Relationship, rm *metrics.ResourceMetrics) {
 	// add relationships
 	if len(rels) > 0 {
 		attrib := &common.KeyValue{
@@ -162,6 +191,8 @@ func (exp *Exporter) buildLogsPayload(entities []*Entity) *colllogs.ExportLogsSe
 		rl.Resource = &resource.Resource{
 			Attributes: toKeyValueList(e.Attributes),
 		}
+
+		exp.addRelationships(e.Relationships, rl.Resource)
 
 		ill := &logs.ScopeLogs{}
 


### PR DESCRIPTION
## Description
fsoc melt model now supports components defined using objectDir
refactored addRelationship in melt library to be more generic and support any MELT signal by taking v1.Resource as the input
renamed the old addRelationship to addRelationshipToMetrics so we can review new implementation and decide what to do.

## Type of Change

- [ X] New Feature
- [ X] Refactor

