### PR TITLE
Fixing issue with mock metric generation for melt push

### DIFF
--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/apex/log"
@@ -26,8 +27,8 @@ var meltModelCmd = &cobra.Command{
 	Run:              meltModel,
 }
 
-func getMeltModelCmd() *cobra.Command {
-	return meltModelCmd
+func init() {
+	meltCmd.AddCommand(meltModelCmd)
 }
 
 func meltModel(cmd *cobra.Command, args []string) {
@@ -66,10 +67,22 @@ func GetFmmMetrics(manifest *sol.Manifest) []*sol.FmmMetric {
 			filePath := compDef.ObjectsFile
 			fmmMetrics = append(fmmMetrics, getFmmMetricsFromFile(filePath)...)
 		}
-
-		// if compDef.ObjectsDir != "" {
-
-		// }
+		if compDef.ObjectsDir != "" {
+			filePath := compDef.ObjectsDir
+			err := filepath.Walk(filePath,
+				func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					if strings.Contains(path, ".json") {
+						fmmMetrics = append(fmmMetrics, getFmmMetricsFromFile(path)...)
+					}
+					return nil
+				})
+			if err != nil {
+				log.Fatalf("Error traversing the folder: %v", err)
+			}
+		}
 
 	}
 	return fmmMetrics
@@ -125,6 +138,7 @@ func GetFsocEntities(fmmEntities []*sol.FmmEntity, fsocMetrics []*melt.Metric) [
 			}
 			fsocE.SetAttribute(fmmAttr, "")
 		}
+
 		//adding fsoc metrics to the model
 		for _, fmmEM := range fmmE.MetricTypes {
 			fsocMetricType := fmmEM
@@ -159,10 +173,22 @@ func GetFmmEntities(manifest *sol.Manifest) []*sol.FmmEntity {
 			filePath := compDef.ObjectsFile
 			fmmEntities = append(fmmEntities, getFmmEntitiesFromFile(filePath)...)
 		}
-
-		// if compDef.ObjectsDir != "" {
-
-		// }
+		if compDef.ObjectsDir != "" {
+			filePath := compDef.ObjectsDir
+			err := filepath.Walk(filePath,
+				func(path string, info os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					if strings.Contains(path, ".json") {
+						fmmEntities = append(fmmEntities, getFmmEntitiesFromFile(path)...)
+					}
+					return nil
+				})
+			if err != nil {
+				log.Fatalf("Error traversing the folder: %v", err)
+			}
+		}
 
 	}
 	return fmmEntities

--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -40,13 +40,6 @@ func meltModel(cmd *cobra.Command, args []string) {
 }
 
 func getFsocDataModel(cmd *cobra.Command, manifest *sol.Manifest) *melt.FsocData {
-	// fsocData := &melt.FsocData{
-	// 	Credentials: &api.AgentPrincipalStruct{
-	// 		ClientID: "",
-	// 		Secret:   "",
-	// 	},
-	// }
-
 	fsocData := &melt.FsocData{}
 	fmmEntities := GetFmmEntities(manifest)
 	output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %v entities to the fsoc data model\n", len(fmmEntities)))

--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -57,8 +57,8 @@ func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
 			if len(m.DataPoints) == 0 {
 				for i := 1; i < 6; i++ {
 					st := et.Add(time.Minute * -1)
-					et = st
 					m.AddDataPoint(st.UnixNano(), et.UnixNano(), rand.Float64()*50)
+					et = st
 				}
 			}
 		}

--- a/platform/melt/exporter.go
+++ b/platform/melt/exporter.go
@@ -408,28 +408,46 @@ func (exp *Exporter) exportHTTP(path string, m protoreflect.ProtoMessage) error 
 func toKeyValueList(a map[string]string) []*common.KeyValue {
 	attribs := []*common.KeyValue{}
 
-	atrValue := &common.AnyValue{}
-
 	for k, v := range a {
 		key := k
+		var value *common.KeyValue
+
 		if intValue, err := strconv.Atoi(v); err == nil {
-			atrValue.Value = &common.AnyValue_IntValue{
-				IntValue: int64(intValue),
+			value = &common.KeyValue{
+				Key: key,
+				Value: &common.AnyValue{
+					Value: &common.AnyValue_IntValue{
+						IntValue: int64(intValue),
+					},
+				},
 			}
 		} else if doubleValue, err := strconv.ParseFloat(v, 64); err == nil {
-			atrValue.Value = &common.AnyValue_DoubleValue{
-				DoubleValue: doubleValue,
+			value = &common.KeyValue{
+				Key: key,
+				Value: &common.AnyValue{
+					Value: &common.AnyValue_DoubleValue{
+						DoubleValue: doubleValue,
+					},
+				},
 			}
+
 		} else {
-			atrValue.Value = &common.AnyValue_StringValue{
-				StringValue: v,
+			value = &common.KeyValue{
+				Key: key,
+				Value: &common.AnyValue{
+					Value: &common.AnyValue_StringValue{
+						StringValue: v,
+					},
+				},
 			}
 		}
 
-		attribs = append(attribs, &common.KeyValue{
-			Key:   key,
-			Value: atrValue,
-		})
+		attribs = append(attribs, value)
+
+		// attribs = append(attribs, &common.KeyValue{
+		// 	Key:   key,
+		// 	Value: atrValue,
+		// })
 	}
 	return attribs
 }

--- a/platform/melt/exporter.go
+++ b/platform/melt/exporter.go
@@ -12,6 +12,7 @@ import (
 	logs "go.opentelemetry.io/proto/otlp/logs/v1"
 	metrics "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resource "go.opentelemetry.io/proto/otlp/resource/v1"
+	v1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	spans "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -97,7 +98,7 @@ func (exp *Exporter) buildMetricsPayload(entities []*Entity) *collmetrics.Export
 			Attributes: toKeyValueList(entity.Attributes),
 		}
 
-		exp.addRelationships(entity.Relationships, rm)
+		exp.addRelationshipsToMetrics(entity.Relationships, rm)
 
 		ilm := &metrics.ScopeMetrics{}
 
@@ -121,7 +122,35 @@ func (exp *Exporter) buildMetricsPayload(entities []*Entity) *collmetrics.Export
 	return emsr
 }
 
-func (exp *Exporter) addRelationships(rels []*Relationship, rm *metrics.ResourceMetrics) {
+func (exp *Exporter) addRelationships(rels []*Relationship, r *v1.Resource) {
+	// add relationships
+	if len(rels) > 0 {
+		attrib := &common.KeyValue{
+			Key: keyAppdFMMEntityRelationships,
+		}
+		val := &common.AnyValue_ArrayValue{
+			ArrayValue: &common.ArrayValue{
+				Values: []*common.AnyValue{},
+			},
+		}
+		for _, r := range rels {
+			kvlv := &common.AnyValue{
+				Value: &common.AnyValue_KvlistValue{
+					KvlistValue: &common.KeyValueList{
+						Values: toKeyValueList(r.Attributes),
+					},
+				},
+			}
+			val.ArrayValue.Values = append(val.ArrayValue.Values, kvlv)
+		}
+		attrib.Value = &common.AnyValue{
+			Value: val,
+		}
+		r.Attributes = append(r.Attributes, attrib)
+	}
+}
+
+func (exp *Exporter) addRelationshipsToMetrics(rels []*Relationship, rm *metrics.ResourceMetrics) {
 	// add relationships
 	if len(rels) > 0 {
 		attrib := &common.KeyValue{
@@ -162,6 +191,8 @@ func (exp *Exporter) buildLogsPayload(entities []*Entity) *colllogs.ExportLogsSe
 		rl.Resource = &resource.Resource{
 			Attributes: toKeyValueList(e.Attributes),
 		}
+
+		exp.addRelationships(e.Relationships, rl.Resource)
 
 		ill := &logs.ScopeLogs{}
 

--- a/platform/melt/exporter_test.go
+++ b/platform/melt/exporter_test.go
@@ -174,7 +174,7 @@ func newTestEntity() *Entity {
 	e := NewEntity("geometry:shape")
 	e.SetAttribute("geometry.shape.type", "square")
 	e.SetAttribute("geometry.shape.name", "My Square")
-	e.SetAttribute("geometry.square.side", "10")
+	e.SetAttribute("geometry.square.side", " 10")
 	return e
 }
 


### PR DESCRIPTION
## Description

melt push mock generation was not creating proper start and end times for metric datapoints causing the platform to drop metrics due to invalid injestGranularities.


## Type of Change

- [X] Bug Fix
