### PR TITLE
(WIP) fsoc solution push --subscribe

### DIFF
--- a/cmd/solution/subscribe.go
+++ b/cmd/solution/subscribe.go
@@ -50,8 +50,7 @@ func getSubscribeSolutionCmd() *cobra.Command {
 
 }
 
-func manageSubscription(cmd *cobra.Command, args []string, isSubscribed bool) {
-	solutionName, _ := cmd.Flags().GetString("name")
+func manageSubscription(cmd *cobra.Command, solutionName string, isSubscribed bool) {
 	if solutionName == "" {
 		log.Fatal("Solution name cannot be empty, use --name=<solution>")
 	}
@@ -92,7 +91,8 @@ func manageSubscription(cmd *cobra.Command, args []string, isSubscribed bool) {
 }
 
 func subscribeToSolution(cmd *cobra.Command, args []string) {
-	manageSubscription(cmd, args, true)
+	solutionName, _ := cmd.Flags().GetString("name")
+	manageSubscription(cmd, solutionName, true)
 }
 
 func getSolutionSubscribeUrl() string {

--- a/cmd/solution/unsubscribe.go
+++ b/cmd/solution/unsubscribe.go
@@ -58,7 +58,7 @@ func unsubscribeFromSolution(cmd *cobra.Command, args []string) {
 	if isSystemSolution {
 		log.Fatalf("Cannot unsubscribe tenant from solution %s because it is a system solution\n", solutionName)
 	} else {
-		manageSubscription(cmd, args, false)
+		manageSubscription(cmd, solutionName, false)
 	}
 }
 


### PR DESCRIPTION
## Description

Add a `--subscribe` flag to `fsoc solution push` that subscribes the tenant to the solution after it is pushed, but before it's status is checked.

Note that this will require some changes in the platform to work properly. As is, solution status in not correctly reflects after a subscription, so doing `fsoc solution push --subscribe --wait` will not return success.

## Type of Change

- [x] New Feature


