### PR TITLE
Only set telemetry.sdk.name if not provided manually

### DIFF
--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -51,7 +51,11 @@ func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
 	}
 
 	for _, entity := range fsoData.Melt {
-		entity.SetAttribute("telemetry.sdk.name", "fsoc-melt")
+		if _, ok := entity.Attributes["telemetry.sdk.name"]; ok {
+			log.Info("telemetry.sdk.name already set, skipping...")
+		} else {
+			entity.SetAttribute("telemetry.sdk.name", "fsoc-melt")
+		}
 		for _, m := range entity.Metrics {
 			et := time.Now()
 			if len(m.DataPoints) == 0 {


### PR DESCRIPTION
## Description

Allows you to attach your own telemetry.sdk.name in mock .yaml, of which specific types can be required to generate entities.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
