### PR TITLE
refactored solution name as argument, removed bundle flag

### DIFF
--- a/cmd/solution/author.go
+++ b/cmd/solution/author.go
@@ -63,6 +63,7 @@ type apiItemList struct {
 
 var authorCmd = &cobra.Command{
 	Use:    "author [flags]",
+	Args:   cobra.ExactArgs(0),
 	Short:  "Open authoring tool for editing template files",
 	Long:   "This command provides access to the FSO platform user interface authoring tool for editing a solution's templates interactively. It starts a background web server to provide access to the template files and opens the authoring tool in your default browser. This command currently works only with localhost-based development environments.",
 	Run:    authorRunWrapper,

--- a/cmd/solution/bump.go
+++ b/cmd/solution/bump.go
@@ -28,10 +28,8 @@ var solutionBumpCmd = &cobra.Command{
 	Use:   "bump",
 	Short: "Increment the patch version of the solution",
 	Long: `Increment the patch version of the solution in the manifest to prepare
-it for validation or push.
-
-Example:
-  fsoc solution bump`,
+it for validation or push.`,
+	Example:          `  fsoc solution bump`,
 	Args:             cobra.ExactArgs(0),
 	Run:              bumpSolutionVersion,
 	TraverseChildren: true,

--- a/cmd/solution/check.go
+++ b/cmd/solution/check.go
@@ -32,12 +32,12 @@ import (
 
 var solutionCheckCmd = &cobra.Command{
 	Use:   "check",
+	Args:  cobra.ExactArgs(0),
 	Short: "Validate your solution component definitions",
 	Long: `This command allows the current tenant specified in the profile to build and package a solution bundle to be deployed into the FSO Platform.
 
 Example:
   fsoc solution check --entities --metrics`,
-	Args:             cobra.ExactArgs(0),
 	Run:              checkSolution,
 	TraverseChildren: true,
 }

--- a/cmd/solution/check.go
+++ b/cmd/solution/check.go
@@ -31,13 +31,11 @@ import (
 )
 
 var solutionCheckCmd = &cobra.Command{
-	Use:   "check",
-	Args:  cobra.ExactArgs(0),
-	Short: "Validate your solution component definitions",
-	Long: `This command allows the current tenant specified in the profile to build and package a solution bundle to be deployed into the FSO Platform.
-
-Example:
-  fsoc solution check --entities --metrics`,
+	Use:              "check",
+	Args:             cobra.ExactArgs(0),
+	Short:            "Validate your solution component definitions",
+	Long:             `This command allows the current tenant specified in the profile to build and package a solution bundle to be deployed into the FSO Platform.`,
+	Example:          `  fsoc solution check --entities --metrics`,
 	Run:              checkSolution,
 	TraverseChildren: true,
 }

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -1,20 +1,21 @@
 package solution
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 
 	"github.com/cisco-open/fsoc/cmd/config"
+	"github.com/cisco-open/fsoc/output"
 	"github.com/cisco-open/fsoc/platform/api"
 )
 
 var solutionDescribeCmd = &cobra.Command{
 	Use:   "describe <solution-name>",
-	Short: "",
-	Long:  ``,
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Describe solution",
+	Long:  `Obtain metadata about a solution`,
 	Run:   solutionDescribe,
 }
 
@@ -32,22 +33,13 @@ type Solution struct {
 func getSolutionDescribeCmd() *cobra.Command {
 	solutionDescribeCmd.Flags().
 		String("solution", "", "The name of the solution to describe")
-	_ = solutionDescribeCmd.Flags().MarkDeprecated("solution", "The --solution flag is deprecated, please use argument instead.")
-	//_ = solutionDescribeCmd.MarkFlagRequired("solution")
+	_ = solutionDescribeCmd.Flags().MarkDeprecated("solution", "please use argument instead.")
 
 	return solutionDescribeCmd
 }
 
 func solutionDescribe(cmd *cobra.Command, args []string) {
-	log.Info("Fetching the details of the specified solutions...")
-	solution, _ := cmd.Flags().GetString("solution")
-	if len(args) > 0 {
-		solution = args[0]
-	} else {
-		if len(solution) == 0 {
-			log.Fatal("A non-empty \"solution-name\" argument is required.")
-		}
-	}
+	solution := getSolutionNameFromArgs(cmd, args, "solution")
 
 	cfg := config.GetCurrentContext()
 	layerID := cfg.Tenant
@@ -57,19 +49,15 @@ func solutionDescribe(cmd *cobra.Command, args []string) {
 		"layer-id":   layerID,
 	}
 
-	log.Infof("Getting details of the '%s' solution", solution)
+	log.WithField("solution", solution).Info("Getting solution details")
 	var res Solution
-	_ = api.JSONGet(getSolutionDescribeUrl(url.PathEscape(solution)), &res, &api.Options{Headers: headers})
-	fmt.Printf("ID: %s\n", res.ID)
-	fmt.Printf("LayerID: %s\n", res.LayerID)
-	fmt.Printf("layerType: %s\n", res.LayerType)
-	fmt.Printf("ObjectMimeType: %s\n", res.ObjectMimeType)
-	fmt.Printf("TargetObjectId: %s\n", res.TargetObjectId)
-	fmt.Printf("CreatedAt: %s\n", res.CreatedAt)
-	fmt.Printf("UpdatedAt: %s\n", res.UpdatedAt)
+	err := api.JSONGet(getSolutionDescribeUrl(url.PathEscape(solution)), &res, &api.Options{Headers: headers})
+	if err != nil {
+		log.Fatalf("Cannot get solution details: %v", err)
+	}
+	output.PrintCmdOutput(cmd, res)
 }
 
 func getSolutionDescribeUrl(id string) string {
-	//println(id)
 	return "objstore/v1beta/objects/extensibility:solution/" + id
 }

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -12,11 +12,12 @@ import (
 )
 
 var solutionDescribeCmd = &cobra.Command{
-	Use:   "describe <solution-name>",
-	Args:  cobra.MaximumNArgs(1),
-	Short: "Describe solution",
-	Long:  `Obtain metadata about a solution`,
-	Run:   solutionDescribe,
+	Use:     "describe <solution-name>",
+	Args:    cobra.MaximumNArgs(1),
+	Short:   "Describe solution",
+	Long:    `Obtain metadata about a solution`,
+	Example: `  fsoc solution describe spacefleet`,
+	Run:     solutionDescribe,
 }
 
 type Solution struct {

--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Cisco Systems, Inc.
+// Copyright 2023 Cisco Systems, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,33 +24,25 @@ import (
 )
 
 var solutionDownloadCmd = &cobra.Command{
-	Use:   "download <name>",
-	Short: "Download solution",
-	Long: `This command allows the current tenant specified in the profile to download a solution bundle archive into the current directory or the directory specified in command argument.
-
-Example: fsoc solution download --name=spacefleet`,
+	Use:              "download <solution-name>",
 	Args:             cobra.MaximumNArgs(1),
+	Short:            "Download solution",
+	Long:             `This downloads the indicated solution into the current directory. Also see the "fork" command.`,
+	Example:          `  fsoc solution download spacefleet`,
 	Run:              downloadSolution,
 	TraverseChildren: true,
 }
 
 func getSolutionDownloadCmd() *cobra.Command {
 	solutionDownloadCmd.Flags().String("name", "", "name of the solution to download (required)")
-	_ = solutionDownloadCmd.Flags().MarkDeprecated("name", "The --name flag is deprecated, please use argument instead.")
-	//_ = solutionDownloadCmd.MarkFlagRequired("name")
+	_ = solutionDownloadCmd.Flags().MarkDeprecated("name", "please use argument instead.")
+
 	return solutionDownloadCmd
 }
 
 func downloadSolution(cmd *cobra.Command, args []string) {
-	solutionName, _ := cmd.Flags().GetString("name")
-	if len(args) > 0 {
-		solutionName = args[0]
-	} else {
-		if len(solutionName) == 0 {
-			log.Fatalf("Solution name cannot be empty")
-		}
-	}
-	var solutionNameWithZipExtension = getSolutionNameWithZip(solutionName)
+	solutionName := getSolutionNameFromArgs(cmd, args, "name")
+	solutionNameWithZipExtension := getSolutionNameWithZip(solutionName)
 
 	headers := map[string]string{
 		"stage":            "STABLE",

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -29,6 +29,7 @@ import (
 
 var solutionExtendCmd = &cobra.Command{
 	Use:   "extend",
+	Args:  cobra.ExactArgs(0),
 	Short: "Extends your solution package by adding new components",
 	Long: `This command allows you to easily add new components to your solution package.
 

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -28,14 +28,11 @@ import (
 )
 
 var solutionExtendCmd = &cobra.Command{
-	Use:   "extend",
-	Args:  cobra.ExactArgs(0),
-	Short: "Extends your solution package by adding new components",
-	Long: `This command allows you to easily add new components to your solution package.
-
-Example:
-  fsoc solution extend --add-knowledge=<knowldgetypename>`,
-
+	Use:              "extend",
+	Args:             cobra.ExactArgs(0),
+	Short:            "Extends your solution package by adding new components",
+	Long:             `This command allows you to easily add new components to your solution package.`,
+	Example:          `  fsoc solution extend --add-knowledge=<knowldgetypename>`,
 	Run:              addSolutionComponent,
 	TraverseChildren: true,
 }

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -32,11 +32,12 @@ import (
 )
 
 var solutionForkCmd = &cobra.Command{
-	Use:   "fork <solution-name> <target-name>",
-	Args:  cobra.MaximumNArgs(2),
-	Short: "Fork a solution into the specified folder",
-	Long:  `This command downloads the specified solution into the current directory and changes its name to <target-name>`,
-	Run:   solutionForkCommand,
+	Use:     "fork <solution-name> <target-name>",
+	Args:    cobra.MaximumNArgs(2),
+	Short:   "Fork a solution into the specified folder",
+	Long:    `This command downloads the specified solution into the current directory and changes its name to <target-name>`,
+	Example: `  fsoc solution fork spacefleet myfleet`,
+	Run:     solutionForkCommand,
 }
 
 func GetSolutionForkCommand() *cobra.Command {
@@ -54,7 +55,7 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 		solutionName, forkName = args[0], args[1]
 	} else if len(args) != 0 {
 		_ = cmd.Help()
-		log.Fatal("Invalid arguments")
+		log.Fatal("Exactly 2 arguments required.")
 	}
 	if solutionName == "" || forkName == "" {
 		log.Fatalf("<solution-name> and <target-name> cannot be empty")

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -32,17 +32,18 @@ import (
 )
 
 var solutionForkCmd = &cobra.Command{
-	Use:   "fork <name> <source-name>",
-	Short: "Fork a solution in the specified folder",
-	Long:  `This command will download the solution into this folder and change the name of the manifest to the specified name`,
+	Use:   "fork <solution-name> <target-name>",
+	Args:  cobra.MaximumNArgs(2),
+	Short: "Fork a solution into the specified folder",
+	Long:  `This command downloads the specified solution into the current directory and changes its name to <target-name>`,
 	Run:   solutionForkCommand,
 }
 
 func GetSolutionForkCommand() *cobra.Command {
 	solutionForkCmd.Flags().String("source-name", "", "name of the solution that needs to be downloaded")
-	_ = solutionForkCmd.Flags().MarkDeprecated("source-name", "The --source-name flag is deprecated, please use argument instead.")
+	_ = solutionForkCmd.Flags().MarkDeprecated("source-name", "please use argument instead.")
 	solutionForkCmd.Flags().String("name", "", "name of the solution to copy it to")
-	_ = solutionForkCmd.Flags().MarkDeprecated("name", "The --name flag is deprecated, please use argument instead.")
+	_ = solutionForkCmd.Flags().MarkDeprecated("name", "please use argument instead.")
 	return solutionForkCmd
 }
 
@@ -51,11 +52,14 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 	forkName, _ := cmd.Flags().GetString("name")
 	if len(args) == 2 {
 		solutionName, forkName = args[0], args[1]
-	} else {
-		if solutionName == "" || forkName == "" {
-			log.Fatalf("name or source-name cannot be empty")
-		}
+	} else if len(args) != 0 {
+		_ = cmd.Help()
+		log.Fatal("Invalid arguments")
 	}
+	if solutionName == "" || forkName == "" {
+		log.Fatalf("<solution-name> and <target-name> cannot be empty")
+	}
+	forkName = strings.ToLower(forkName)
 
 	currentDirectory, err := filepath.Abs(".")
 	if err != nil {

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -27,18 +27,16 @@ import (
 )
 
 var solutionInitCmd = &cobra.Command{
-	Use:   "init <name>",
+	Use:   "init <solution-name>",
+	Args:  cobra.MaximumNArgs(1),
 	Short: "Create a new solution",
 	Long: `This command creates a skeleton of a solution in the current directory.
 
-Example:
-
-   fsoc solution init --name=testSolution --include-service --include-knowledge
-
-Creates a subdirectory named "testSolution" in the current directory and populates
+It creates a subdirectory named <solution-name> in the current directory and populates
 it with a solution manifest and objects for it. The optional --include-... flags
 define what objects are added to the solution. Once the solution is created,
 the "solution extend" command can be used to add more objects.`,
+	Example:          `  fsoc solution init --name=testSolution --include-service --include-knowledge`,
 	Run:              generateSolutionPackage,
 	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
 	TraverseChildren: true,
@@ -54,7 +52,7 @@ the "solution extend" command can be used to add more objects.`,
 func getInitSolutionCmd() *cobra.Command {
 	solutionInitCmd.Flags().
 		String("name", "", "The name of the new solution (required)")
-	_ = solutionInitCmd.Flags().MarkDeprecated("name", "The --name flag is deprecated, please use argument instead.")
+	_ = solutionInitCmd.Flags().MarkDeprecated("name", "please use argument instead.")
 
 	solutionInitCmd.Flags().
 		Bool("include-service", true, "Add a service component definition to this solution")
@@ -65,20 +63,13 @@ func getInitSolutionCmd() *cobra.Command {
 }
 
 func generateSolutionPackage(cmd *cobra.Command, args []string) {
-	solutionName, _ := cmd.Flags().GetString("name")
+	solutionName := getSolutionNameFromArgs(cmd, args, "name")
 	solutionName = strings.ToLower(solutionName)
-	if len(args) > 0 {
-		solutionName = args[0]
-	} else {
-		if len(solutionName) == 0 {
-			log.Fatal("A non-empty \"name\" argument is required.")
-		}
-	}
 
-	output.PrintCmdStatus(cmd, fmt.Sprintf("Preparing the %s solution package folder structure... \n", solutionName))
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Preparing the solution folder structure for %q... \n", solutionName))
 
 	if err := os.Mkdir(solutionName, os.ModePerm); err != nil {
-		log.Fatalf("Solution init failed - %v", err)
+		log.Fatal(err.Error())
 	}
 
 	manifest := createInitialSolutionManifest(solutionName)

--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -27,10 +27,9 @@ var solutionListCmd = &cobra.Command{
 	Use:   "list",
 	Args:  cobra.ExactArgs(0),
 	Short: "List all solutions available in this tenant",
-	Long: `This command list all the solutions that are deployed in the current tenant specified in the profile.
-
-Usage:
-	fsoc solution list`,
+	Long:  `This command list all the solutions that are deployed in the current tenant specified in the profile.`,
+	Example: `  fsoc solution list
+  fsoc solution list -o json`,
 	Run:              getSolutionList,
 	TraverseChildren: true,
 	Annotations: map[string]string{

--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -25,6 +25,7 @@ import (
 
 var solutionListCmd = &cobra.Command{
 	Use:   "list",
+	Args:  cobra.ExactArgs(0),
 	Short: "List all solutions available in this tenant",
 	Long: `This command list all the solutions that are deployed in the current tenant specified in the profile.
 

--- a/cmd/solution/name.go
+++ b/cmd/solution/name.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package solution
+
+import (
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+// getSolutionNameFromArgs gets the solution name from the command line, either from
+// the first positional argument or from a flag (deprecated but kepts for backward compatibility).
+// The flagName is optional (use "" to omit).
+// Prints error message and terminates if the name is missing/empty
+func getSolutionNameFromArgs(cmd *cobra.Command, args []string, flagName string) string {
+	// get solution name from a flag, if provided (deprecated but kept for backward compatibility)
+	var nameFromFlag string
+	if flagName != "" {
+		var err error
+		nameFromFlag, err = cmd.Flags().GetString(flagName)
+		if err != nil {
+			log.Fatalf("Error parsing flag %q: %v", flagName, err)
+		}
+	}
+
+	// get solution name from the first positional argument and
+	// return it (or fail if flag was provided as well)
+	var name string
+	if len(args) > 0 {
+		name = args[0]
+	}
+	if name != "" {
+		if nameFromFlag != "" {
+			log.Fatal("Solution name must be specified either as a positional argument or with a flag but not both")
+		}
+		return name
+	}
+
+	// return the solution name from flag, if provided
+	if nameFromFlag != "" {
+		return nameFromFlag
+	}
+
+	// fail
+	log.Fatal("A non-empty <solution-name> argument is required.")
+	return "" // unreachable
+}

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -30,53 +30,15 @@ import (
 )
 
 var solutionPackageCmd = &cobra.Command{
-	Use:   "package",
-	Short: "Build and package a solution",
-	Long: `This command allows the current tenant specified in the profile to build and package a solution bundle to be deployed into the FSO Platform.
-
-Usage:
-	fsoc solution package --solution-package=<solution-package-root-path>`,
-	Args:             cobra.ExactArgs(0),
-	Run:              packageSolution,
-	TraverseChildren: true,
+	Use:        "package",
+	Deprecated: `please use "push" or "validate" directly.`,
 }
 
 func getSolutionPackageCmd() *cobra.Command {
-	solutionPackageCmd.Flags().
-		String("solution-package", "", "The fully qualified path name for the solution package .zip file")
-	_ = solutionPackageCmd.MarkFlagRequired("solution-package")
-
 	return solutionPackageCmd
-
 }
 
-func packageSolution(cmd *cobra.Command, args []string) {
-
-	solutionPackagePath, _ := cmd.Flags().GetString("solution-package")
-	if solutionPackagePath == "" {
-		log.Fatal("solution-package cannot be empty, use --solution-package=<solution-package-file-path>")
-	}
-	if !isSolutionPackageRoot(solutionPackagePath) {
-		log.Fatal("solution-package path doesn't point to a solution package root folder")
-	}
-	manifest, err := getSolutionManifest(solutionPackagePath)
-	if err != nil {
-		log.Fatalf("Failed to read solution manifest: %v", err)
-	}
-
-	var message string
-	message = fmt.Sprintf("Generating solution %s - %s bundle archive \n", manifest.Name, manifest.SolutionVersion)
-	log.WithFields(log.Fields{
-		"solution-package": solutionPackagePath,
-	}).Info(message)
-
-	output.PrintCmdStatus(cmd, message)
-	solutionArchive := generateZip(cmd, solutionPackagePath)
-	solutionArchive.Close()
-
-	message = fmt.Sprintf("Solution %s - %s bundle is ready. \n", manifest.Name, manifest.SolutionVersion)
-	output.PrintCmdStatus(cmd, message)
-}
+// Helper functions for managing solution directory and zip bundle
 
 func generateZip(cmd *cobra.Command, sltnPackagePath string) *os.File {
 	solutionName := filepath.Base(sltnPackagePath)

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -47,11 +47,9 @@ var solutionStatusCmd = &cobra.Command{
 	Use:   "status <solution-name> [flags]",
 	Args:  cobra.MaximumNArgs(1),
 	Short: "Get the installation/upload status of a solution",
-	Long: `This command provides the ability to see the current installation and upload status of a solution.
-	
-Example:
-  fsoc solution status spacefleet --status-type=all
-`,
+	Long:  `This command provides the ability to see the current installation and upload status of a solution.`,
+	Example: `  fsoc solution status spacefleet
+  fsoc solution status spacefleet --status-type=install`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := getSolutionStatus(cmd, args); err != nil {
 			log.Fatalf(err.Error())

--- a/cmd/solution/subscribe.go
+++ b/cmd/solution/subscribe.go
@@ -30,13 +30,11 @@ type subscriptionStruct struct {
 }
 
 var solutionSubscribeCmd = &cobra.Command{
-	Use:   "subscribe",
-	Short: "Subscribe to a solution",
-	Long: `This command allows the current tenant specified in the profile to subscribe to a solution.
-
-Example:
-	fsoc solution subscribe --name=spacefleet`,
-	Args:             cobra.ExactArgs(0),
+	Use:              "subscribe <solution-name>",
+	Args:             cobra.MaximumNArgs(1),
+	Short:            "Subscribe to a solution",
+	Long:             `This command allows the current tenant specified in the profile to subscribe to a solution.`,
+	Example:          `	fsoc solution subscribe spacefleet`,
 	Run:              subscribeToSolution,
 	TraverseChildren: true,
 }
@@ -44,17 +42,14 @@ Example:
 func getSubscribeSolutionCmd() *cobra.Command {
 	solutionSubscribeCmd.Flags().
 		String("name", "", "The name of the solution the tenant is subscribing to")
-	_ = solutionSubscribeCmd.MarkFlagRequired("name")
+	_ = solutionSubscribeCmd.Flags().MarkDeprecated("name", "please use argument instead.")
 
 	return solutionSubscribeCmd
 
 }
 
 func manageSubscription(cmd *cobra.Command, args []string, isSubscribed bool) {
-	solutionName, _ := cmd.Flags().GetString("name")
-	if solutionName == "" {
-		log.Fatal("Solution name cannot be empty, use --name=<solution>")
-	}
+	solutionName := getSolutionNameFromArgs(cmd, args, "name")
 
 	var message string
 	if isSubscribed {
@@ -62,9 +57,7 @@ func manageSubscription(cmd *cobra.Command, args []string, isSubscribed bool) {
 	} else {
 		message = "Unsubscribing from solution"
 	}
-	log.WithFields(log.Fields{
-		"solution": solutionName,
-	}).Info(message)
+	log.WithField("solution", solutionName).Info(message)
 
 	cfg := config.GetCurrentContext()
 	layerID := cfg.Tenant

--- a/cmd/solution/unsubscribe.go
+++ b/cmd/solution/unsubscribe.go
@@ -25,13 +25,11 @@ import (
 )
 
 var solutionUnsubscribeCmd = &cobra.Command{
-	Use:   "unsubscribe",
-	Short: "Unsubscribe from a solution",
-	Long: `This command allows the current tenant specified in the profile to unsubscribe from a solution.
-
-Example:
-  fsoc solution unsubscribe --name=spacefleet`,
-	Args:             cobra.ExactArgs(0),
+	Use:              "unsubscribe <solution-name>",
+	Args:             cobra.MaximumNArgs(1),
+	Short:            "Unsubscribe from a solution",
+	Long:             `This command allows the current tenant specified in the profile to unsubscribe from a solution.`,
+	Example:          `  fsoc solution unsubscribe spacefleet`,
 	Run:              unsubscribeFromSolution,
 	TraverseChildren: true,
 }
@@ -39,24 +37,21 @@ Example:
 func getUnsubscribeSolutionCmd() *cobra.Command {
 	solutionUnsubscribeCmd.Flags().
 		String("name", "", "The name of the solution the tenant is unsubscribing from")
-	_ = solutionUnsubscribeCmd.MarkFlagRequired("name")
+	_ = solutionUnsubscribeCmd.Flags().MarkDeprecated("name", "please use argument instead.")
 
 	return solutionUnsubscribeCmd
 
 }
 
 func unsubscribeFromSolution(cmd *cobra.Command, args []string) {
-	solutionName, _ := cmd.Flags().GetString("name")
-	if solutionName == "" {
-		log.Fatal("Solution name cannot be empty, use --name=<solution>")
-	}
+	solutionName := getSolutionNameFromArgs(cmd, args, "name")
 
 	isSystemSolution, err := isSystemSolution(solutionName)
 	if err != nil {
 		log.Fatalf("Failed to get solution status: %v", err)
 	}
 	if isSystemSolution {
-		log.Fatalf("Cannot unsubscribe tenant from solution %s because it is a system solution\n", solutionName)
+		log.Fatalf("Cannot unsubscribe tenant from solution %s because it is a system solution", solutionName)
 	} else {
 		manageSubscription(cmd, args, false)
 	}


### PR DESCRIPTION
## Description

* changed solution commands to use positional argument(s) for solution names rather than flags (deprecating but keeping the flags for backward compatibility)
* BREAKING CHANGE: removed the `solution package` command, as it is no longer needed (commands prepare the bundle themselves)
* BREAKING CHANGE: removed the `--solution-bundle` flag from commands that were taking it, discontinuing support for prepared zips

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [X] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
