### PR TITLE
Fix --config flag handling

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -112,19 +112,19 @@ func getConfig() configFileContents {
 	return c
 }
 
-// listContexts returns a list of context names which begin with `toComplete`,
+// ListContexts returns a list of context names which begin with `prefix`,
 // used for the command line autocompletion
-// func listContexts(toComplete string) []string {
-// 	config := getConfig()
-// 	var ret []string
-// 	for _, c := range config.Contexts {
-// 		name := c.Name
-// 		if strings.HasPrefix(name, toComplete) {
-// 			ret = append(ret, name)
-// 		}
-// 	}
-// 	return ret
-// }
+func ListContexts(prefix string) []string {
+	config := getConfig()
+	var ret []string
+	for _, c := range config.Contexts {
+		name := c.Name
+		if strings.HasPrefix(name, prefix) {
+			ret = append(ret, name)
+		}
+	}
+	return ret
+}
 
 func updateConfigFile(keyValues map[string]interface{}) {
 	var err error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -87,10 +87,13 @@ func init() {
 	rootCmd.SetErr(os.Stderr)
 	rootCmd.SetIn(os.Stdin)
 
-	rootCmd.RegisterFlagCompletionFunc("profile",
+	err := rootCmd.RegisterFlagCompletionFunc("profile",
 		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return config.ListContexts(toComplete), cobra.ShellCompDirectiveDefault
 		})
+	if err != nil {
+		log.Warnf("(likely bug) Failed to register completion function for --profile: %v", err)
+	}
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,9 +108,9 @@ func initConfig() {
 
 		// Search config in home directory with name ".fsoc" (without extension).
 		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
 		viper.SetConfigName(".fsoc")
 	}
+	viper.SetConfigType("yaml")
 
 	viper.AutomaticEnv() // read in environment variables that match
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,7 +55,7 @@ Examples:
   fsoc solution list
   fsoc solution list -o json
 
-For more information, see https://github.com/cisco-open/fsoc 
+For more information, see https://github.com/cisco-open/fsoc
 
 NOTE: fsoc is in alpha; breaking changes may occur`,
 	PersistentPreRun:  preExecHook,
@@ -86,6 +86,11 @@ func init() {
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.SetErr(os.Stderr)
 	rootCmd.SetIn(os.Stdin)
+
+	rootCmd.RegisterFlagCompletionFunc("profile",
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return config.ListContexts(toComplete), cobra.ShellCompDirectiveDefault
+		})
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
## Description

Fix support for non-default config file location using the `--config` flag. Keep filename without extension or with .yaml/.yml.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
