### PR TITLE
Fix output failures on null/emtpy results

### DIFF
--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -129,7 +129,7 @@ func listReports(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(reportRows) < 1 {
-		cmd.Println("No results found for given input")
+		output.PrintCmdStatus(cmd, "No results found for given input\n")
 		return nil
 	}
 

--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -73,7 +73,7 @@ You may specify also particular workloadId to fetch details for a single workloa
 	TraverseChildren: true,
 	Annotations: map[string]string{
 		output.TableFieldsAnnotation:  "WorkloadId: .WorkloadId, Name: .WorkloadAttributes[\"k8s.workload.name\"], Eligible: .ProfileAttributes[\"report_contents.optimizable\"], LastProfiled: .ProfileTimestamp",
-		output.DetailFieldsAnnotation: "WorkloadId: .WorkloadId, Cluster: .WorkloadAttributes[\"k8s.cluster.name\"], Namespace: .WorkloadAttributes[\"k8s.namespace.name\"], Name: .WorkloadAttributes[\"k8s.workload.name\"], Eligible: .ProfileAttributes[\"report_contents.optimizable\"], Blockers: .ProfileAttributes | with_entries(select(.key | startswith(\"report_contents.optimization_blockers\"))), LastProfiled: .ProfileTimestamp",
+		output.DetailFieldsAnnotation: "WorkloadId: .WorkloadId, Cluster: .WorkloadAttributes[\"k8s.cluster.name\"], Namespace: .WorkloadAttributes[\"k8s.namespace.name\"], Name: .WorkloadAttributes[\"k8s.workload.name\"], Eligible: .ProfileAttributes[\"report_contents.optimizable\"], Blockers: (.ProfileAttributes // {}) | with_entries(select(.key | startswith(\"report_contents.optimization_blockers\"))), LastProfiled: .ProfileTimestamp",
 	},
 }
 
@@ -126,6 +126,11 @@ func listReports(cmd *cobra.Command, args []string) error {
 	reportRows, err := extractReportData(resp)
 	if err != nil {
 		return fmt.Errorf("extractReportData: %w", err)
+	}
+
+	if len(reportRows) < 1 {
+		cmd.Println("No results found for given input")
+		return nil
 	}
 
 	output.PrintCmdOutput(cmd, struct {


### PR DESCRIPTION
## Description

- update DetailFieldsAnnotation to use empty object on with_entries if there is no profile for row
- Add check and output for no results from uql query

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
