### PR TITLE
ORION-1115: add support for providing tag to solution push + solution validate FSOC-140: fix solution status message output

### DIFF
--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -43,7 +43,7 @@ The solution manifest for the solution must be in the current directory.`,
   fsoc solution push
   fsoc solution push -w
   fsoc solution push -w=60
-  fsoc solution push --solution-tag=dev`,
+  fsoc solution push -tag=dev`,
 	Run:              pushSolution,
 	TraverseChildren: true,
 }
@@ -57,7 +57,7 @@ func getSolutionPushCmd() *cobra.Command {
 		BoolP("bump", "b", false, "Increment the patch version before deploying")
 
 	solutionPushCmd.Flags().
-		String("solution-tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
+		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 
 	solutionPushCmd.Flags().
 		String("solution-bundle", "", "fully qualified path name for the solution bundle .zip file")
@@ -76,7 +76,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 
 	waitFlag, _ := cmd.Flags().GetInt("wait")
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
-	solutionTagFlag, _ := cmd.Flags().GetString("solution-tag")
+	solutionTagFlag, _ := cmd.Flags().GetString("tag")
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	var solutionArchivePath string
 

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -42,7 +42,8 @@ The solution manifest for the solution must be in the current directory.`,
 	Example: `
   fsoc solution push
   fsoc solution push -w
-  fsoc solution push -w=60`,
+  fsoc solution push -w=60
+  fsoc solution push --solution-tag=dev`,
 	Run:              pushSolution,
 	TraverseChildren: true,
 }
@@ -54,6 +55,9 @@ func getSolutionPushCmd() *cobra.Command {
 
 	solutionPushCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before deploying")
+
+	solutionPushCmd.Flags().
+		String("solution-tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 
 	solutionPushCmd.Flags().
 		String("solution-bundle", "", "fully qualified path name for the solution bundle .zip file")
@@ -72,6 +76,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 
 	waitFlag, _ := cmd.Flags().GetInt("wait")
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
+	solutionTagFlag, _ := cmd.Flags().GetString("solution-tag")
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	var solutionArchivePath string
 
@@ -111,7 +116,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	solutionArchive := generateZip(cmd, manifestPath)
 	solutionArchivePath = filepath.Base(solutionArchive.Name())
 
-	message := fmt.Sprintf("Deploying solution %s version %s", manifest.Name, manifest.SolutionVersion)
+	message := fmt.Sprintf("Deploying solution %s version %s with tag %s", manifest.Name, manifest.SolutionVersion, solutionTagFlag)
 	log.WithFields(log.Fields{"solution": manifest.Name, "version": manifest.SolutionVersion}).Info("Deploying solution")
 
 	file, err := os.Open(solutionArchivePath)
@@ -136,8 +141,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	writer.Close()
 
 	headers := map[string]string{
-		"stage":        "STABLE",
-		"tag":          "stable",
+		"tag":          solutionTagFlag,
 		"operation":    "UPLOAD",
 		"Content-Type": writer.FormDataContentType(),
 	}

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -64,7 +64,7 @@ func getSolutionValidateCmd() *cobra.Command {
 
 	solutionValidateCmd.Flags().
 		String("solution-bundle", "", "The fully qualified path name for the solution bundle .zip file that you want to validate")
-	solutionPushCmd.Flags().
+	solutionValidateCmd.Flags().
 		String("solution-tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 	_ = solutionValidateCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -65,7 +65,7 @@ func getSolutionValidateCmd() *cobra.Command {
 	solutionValidateCmd.Flags().
 		String("solution-bundle", "", "The fully qualified path name for the solution bundle .zip file that you want to validate")
 	solutionValidateCmd.Flags().
-		String("solution-tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
+		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 	_ = solutionValidateCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 
@@ -77,7 +77,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	var solutionArchivePath string
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
-	solutionTagFlag, _ := cmd.Flags().GetString("solution-tag")
+	solutionTagFlag, _ := cmd.Flags().GetString("tag")
 
 	if solutionBundlePath != "" {
 		log.Fatalf("The --solution-bundle flag is no longer available; please use direct validate instead.")

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -64,6 +64,8 @@ func getSolutionValidateCmd() *cobra.Command {
 
 	solutionValidateCmd.Flags().
 		String("solution-bundle", "", "The fully qualified path name for the solution bundle .zip file that you want to validate")
+	solutionPushCmd.Flags().
+		String("solution-tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 	_ = solutionValidateCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 
@@ -75,6 +77,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	var solutionArchivePath string
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
+	solutionTagFlag, _ := cmd.Flags().GetString("solution-tag")
 
 	if solutionBundlePath != "" {
 		log.Fatalf("The --solution-bundle flag is no longer available; please use direct validate instead.")
@@ -132,8 +135,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	writer.Close()
 
 	headers := map[string]string{
-		"stage":        "STABLE",
-		"tag":          "stable",
+		"tag":          solutionTagFlag,
 		"operation":    "VALIDATE",
 		"Content-Type": writer.FormDataContentType(),
 	}
@@ -146,7 +148,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	}
 
 	if res.Valid {
-		message = fmt.Sprintf("Solution %s version %s was successfully validated.\n", manifest.Name, manifest.SolutionVersion)
+		message = fmt.Sprintf("Solution %s version %s and tag %s was successfully validated.\n", manifest.Name, manifest.SolutionVersion, solutionTagFlag)
 		//message = fmt.Sprintf("Solution bundle %s validated successfully.\n", solutionArchivePath)
 	} else {
 		message = getSolutionValidationErrorsString(res.Errors.Total, res.Errors)


### PR DESCRIPTION
## Description

Added support for users to provide a value to the "tag" header that is used to decide with which tag a solution should be uploaded.  The default value for both of these is "stable" unless otherwise supplied by the --solution-tag flag.  

Fixed the output of the fsoc solution status command and also updated it to show the subscription status for the tenant making the request.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
