### PR TITLE
Feature/optimize status command

### DIFF
--- a/cmd/optimize/status.go
+++ b/cmd/optimize/status.go
@@ -1,0 +1,98 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package optimize
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/cisco-open/fsoc/cmd/config"
+	"github.com/cisco-open/fsoc/cmdkit"
+	"github.com/cisco-open/fsoc/output"
+	"github.com/spf13/cobra"
+)
+
+type statusFlags struct {
+	cluster      string
+	namespace    string
+	workloadName string
+	optimizerId  string
+}
+
+func init() {
+	// TODO move this logic to optimize root when implementing unit tests
+	optimizeCmd.AddCommand(NewCmdStatus())
+}
+
+func NewCmdStatus() *cobra.Command {
+	flags := statusFlags{}
+	statusCmd := &cobra.Command{
+		Use:              "status",
+		Short:            "List onboarded optimizer configuration and status",
+		Long:             `TODO`,
+		Example:          "fsoc optimize status --workload-name frontend",
+		Args:             cobra.NoArgs,
+		RunE:             listStatus(&flags),
+		TraverseChildren: true,
+		Annotations: map[string]string{
+			output.TableFieldsAnnotation:  "OPTIMIZERID: .id, WORKLOADNAME: .data.optimizer.target.k8sDeployment.workloadName, STATUS: .data.optimizerState, SUSPENDED: .data.suspended, STAGE: .data.optimizationState, AGENT: .data.agentState, TUNING: .data.tuningState",
+			output.DetailFieldsAnnotation: "OPTIMIZERID: .id, CONTAINER: .data.optimizer.target.k8sDeployment.containerName, WORKLOADNAME: .data.optimizer.target.k8sDeployment.workloadName, NAMESPACE: .data.optimizer.target.k8sDeployment.namespaceName, CLUSTER: .data.optimizer.target.k8sDeployment.clusterName, STATUS: .data.optimizerState, SUSPENDED: .data.suspended, SUSPENSIONS: .data.optimizer.suspensions, RESTARTEDAT: .data.optimizer.restartTimestamp, STAGE: .data.optimizationState, AGENT: .data.agentState, TUNING: .data.tuningState",
+		},
+	}
+	statusCmd.Flags().StringVarP(&flags.cluster, "cluster", "c", "", "Filter statuses by kubernetes cluster name")
+	statusCmd.Flags().StringVarP(&flags.namespace, "namespace", "n", "", "Filter statuses by kubernetes namespace")
+	statusCmd.Flags().StringVarP(&flags.workloadName, "workload-name", "w", "", "Filter statuses by name of kubernetes workload")
+
+	statusCmd.Flags().StringVarP(&flags.optimizerId, "optimizer-id", "i", "", "Retrieve status for a specific optimizer by its ID (best used with -o detail)")
+	statusCmd.MarkFlagsMutuallyExclusive("optimizer-id", "cluster")
+	statusCmd.MarkFlagsMutuallyExclusive("optimizer-id", "namespace")
+	statusCmd.MarkFlagsMutuallyExclusive("optimizer-id", "workload-name")
+
+	return statusCmd
+}
+
+func listStatus(flags *statusFlags) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		objStoreUrl := "objstore/v1beta/objects/optimize:status"
+		headers := map[string]string{
+			"layer-type": "TENANT",
+			"layer-id":   config.GetCurrentContext().Tenant,
+		}
+
+		filterSegments := make([]string, 0, 4)
+		if flags.cluster != "" {
+			filterSegments = append(filterSegments, fmt.Sprintf("data.optimizer.target.k8sDeployment.clusterName eq %q", flags.cluster))
+		}
+		if flags.namespace != "" {
+			filterSegments = append(filterSegments, fmt.Sprintf("data.optimizer.target.k8sDeployment.namespaceName eq %q", flags.namespace))
+		}
+		if flags.workloadName != "" {
+			filterSegments = append(filterSegments, fmt.Sprintf("data.optimizer.target.k8sDeployment.workloadName eq %q", flags.workloadName))
+		}
+		if flags.optimizerId != "" {
+			filterSegments = append(filterSegments, fmt.Sprintf("id eq %q", flags.optimizerId))
+		}
+
+		filterCriteria := strings.Join(filterSegments, " and ")
+		if filterCriteria != "" {
+			query := fmt.Sprintf("filter=%s", url.QueryEscape(filterCriteria))
+			objStoreUrl = objStoreUrl + "?" + query
+		}
+
+		cmdkit.FetchAndPrint(cmd, objStoreUrl, &cmdkit.FetchAndPrintOptions{Headers: headers, IsCollection: true})
+		return nil
+	}
+}

--- a/cmd/optimize/status.go
+++ b/cmd/optimize/status.go
@@ -19,10 +19,11 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/cmdkit"
 	"github.com/cisco-open/fsoc/output"
-	"github.com/spf13/cobra"
 )
 
 type statusFlags struct {
@@ -40,9 +41,15 @@ func init() {
 func NewCmdStatus() *cobra.Command {
 	flags := statusFlags{}
 	statusCmd := &cobra.Command{
-		Use:              "status",
-		Short:            "List onboarded optimizer configuration and status",
-		Long:             `TODO`,
+		Use:   "status",
+		Short: "List onboarded optimizer configuration and status",
+		Long: `
+List optimization status and configuration
+	
+If no flags are provided, all onboarded optimizations will be listed
+You can optionally filter optimizations by cluster, namespace and/or workload name
+You may also specify a particular optimizer ID to fetch details for a single optimization (recommended with -o detail or -o yaml)
+`,
 		Example:          "fsoc optimize status --workload-name frontend",
 		Args:             cobra.NoArgs,
 		RunE:             listStatus(&flags),

--- a/output/output.go
+++ b/output/output.go
@@ -318,6 +318,23 @@ func createTable(v any, fields string) (*Table, error) {
 	// init empty custom table
 	table := Table{Headers: []string{}, Lines: [][]string{}}
 
+	// check for empty input to prevent panic logging and present an empty table using fields to derive the headers.
+	// only works on canonicalized input
+	if map_v, ok := v.(map[string]any); ok {
+		if items, ok := map_v["items"]; ok {
+			if array_items, ok := items.([]any); ok {
+				if len(array_items) == 0 {
+					split_fields := strings.Split(fields, ",")
+					table.Headers = make([]string, 0, len(split_fields))
+					for _, single_field := range split_fields {
+						table.Headers = append(table.Headers, strings.Split(single_field, ":")[0])
+					}
+					return &table, nil
+				}
+			}
+		}
+	}
+
 	// build order index to undo JQ's alphabetizing
 	orderIndex := makeFieldOrderIndex(fields)
 


### PR DESCRIPTION
## Description

This change implements the new command `fsoc optimize status` which, by default, outputs a table of high level info about the status of listed optimizations. It provides flags for filtering optimizations based on details of the optimized workload as well as retrieving a specific optimization by its ID. You may view the full configuration for the optimizer by specifying the `-o yaml` flag (I wasn't sure how to factor this information into the table format).

It also includes a fix for FetchAndPrint/PrintCmdOutput/createTable where an empty response data would produce confusing output when combined with the use of `output.TableFieldsAnnotation` eg.

```
   ⨯ error at data row -1 : keys cannot be applied to: null; likely a bug; use --output json or yaml for now
```

Empty data responses now produce a table with only headers to more accurately represent the returned data.

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
