### PR TITLE
ORION-1129: make tag argument required and don't supply default value - [WIP]

### DIFF
--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -36,7 +36,7 @@ It creates a subdirectory named <solution-name> in the current directory and pop
 it with a solution manifest and objects for it. The optional --include-... flags
 define what objects are added to the solution. Once the solution is created,
 the "solution extend" command can be used to add more objects.`,
-	Example:          `  fsoc solution init --name=testSolution --include-service --include-knowledge`,
+	Example:          `  fsoc solution init testSolution --include-service --include-knowledge`,
 	Run:              generateSolutionPackage,
 	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
 	TraverseChildren: true,

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -40,10 +40,9 @@ var solutionPushCmd = &cobra.Command{
 	Long: `This command allows the current tenant specified in the profile to deploy a solution to the FSO Platform.
 The solution manifest for the solution must be in the current directory.`,
 	Example: `
-  fsoc solution push
-  fsoc solution push -w
-  fsoc solution push -w=60
-  fsoc solution push -tag=dev`,
+  fsoc solution push --tag stable
+  fsoc solution push --tag stable -w
+  fsoc solution push --tag stable -w=60`,
 	Run:              pushSolution,
 	TraverseChildren: true,
 }
@@ -57,11 +56,12 @@ func getSolutionPushCmd() *cobra.Command {
 		BoolP("bump", "b", false, "Increment the patch version before deploying")
 
 	solutionPushCmd.Flags().
-		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
+		String("tag", "", "Tag to associate with provided solution bundle")
 
 	solutionPushCmd.Flags().
 		String("solution-bundle", "", "fully qualified path name for the solution bundle .zip file")
 	_ = solutionPushCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
+	_ = solutionPushCmd.MarkPersistentFlagRequired("tag")
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "wait")
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -64,10 +64,11 @@ type ResponseBlob struct {
 var solutionStatusCmd = &cobra.Command{
 	Use:   "status <solution-name> [flags]",
 	Args:  cobra.MaximumNArgs(1),
-	Short: "Get the installation/upload status of a solution",
-	Long:  `This command provides the ability to see the current installation and upload status of a solution.`,
+	Short: "Get the installation/upload/subscription status of a solution",
+	Long:  `This command provides the ability to see the current installation and upload status of a solution.  It also allows you to see whether or not your tenant is subscribed to that solution`,
 	Example: `  fsoc solution status spacefleet
-  fsoc solution status spacefleet --status-type=install`,
+  fsoc solution status spacefleet --status-type=install
+  fsoc solution status spacefleet --status-type=upload`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := getSolutionStatus(cmd, args); err != nil {
 			log.Fatalf(err.Error())

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -65,7 +65,8 @@ func getSolutionValidateCmd() *cobra.Command {
 	solutionValidateCmd.Flags().
 		String("solution-bundle", "", "The fully qualified path name for the solution bundle .zip file that you want to validate")
 	solutionValidateCmd.Flags().
-		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
+		String("tag", "", "Tag to associate with provided solution bundle.")
+	_ = solutionPushCmd.MarkPersistentFlagRequired("tag")
 	_ = solutionValidateCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -53,7 +53,7 @@ var solutionValidateCmd = &cobra.Command{
 	Args:             cobra.ExactArgs(0),
 	Short:            "Validate solution",
 	Long:             `This command allows the current tenant specified in the profile to upload the solution in the current directory just to validate its contents.`,
-	Example:          `  fsoc solution validate`,
+	Example:          `  fsoc solution validate --tag stable`,
 	Run:              validateSolution,
 	TraverseChildren: true,
 }


### PR DESCRIPTION
## Description

As a part of this PR, we are making it such that there is not a default value for the "tag" header supplied to the fsoc solution push command.   We are also marking the --tag argument as a required argument.  In c0, this value should be supplied as "stable" but will be different for other environments.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
