### PR TITLE
Commands for solution testing

### DIFF
--- a/cmd/solution/solution.go
+++ b/cmd/solution/solution.go
@@ -58,6 +58,7 @@ func NewSubCmd() *cobra.Command {
 	solutionCmd.AddCommand(getSolutionDescribeCmd())
 	solutionCmd.AddCommand(getSolutionBumpCmd())
 	solutionCmd.AddCommand(getSolutionTestCmd())
+	solutionCmd.AddCommand(getSolutionTestStatusCmd())
 	solutionListCmd.Flags().StringP("output", "o", "", "Output format (human*, json, yaml)")
 
 	return solutionCmd

--- a/cmd/solution/solution.go
+++ b/cmd/solution/solution.go
@@ -57,6 +57,7 @@ func NewSubCmd() *cobra.Command {
 	solutionCmd.AddCommand(getSolutionStatusCmd())
 	solutionCmd.AddCommand(getSolutionDescribeCmd())
 	solutionCmd.AddCommand(getSolutionBumpCmd())
+	solutionCmd.AddCommand(getSolutionTestCmd())
 	solutionListCmd.Flags().StringP("output", "o", "", "Output format (human*, json, yaml)")
 
 	return solutionCmd

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -32,7 +32,7 @@ var solutionTestCmd = &cobra.Command{
 	Use:              "test",
 	Args:             cobra.ExactArgs(0),
 	Short:            "Test Solution",
-	Long:             "This command allows the current tenant specified in the profile to run tests against an already-deployed solution",
+	Long:             "This command allows the current tenant specified in the profile to run tests against an already deployed solution",
 	Example:          `  fsoc solution test`,
 	Run:              testSolution,
 	TraverseChildren: true,
@@ -42,7 +42,7 @@ var solutionTestStatusCmd = &cobra.Command{
 	Use:              "test-status",
 	Args:             cobra.ExactArgs(0),
 	Short:            "Status of Solution Test",
-	Long:             "This command allows the current tenant specified in the profile to check status of the solution-test already run by `fsoc solution test` command",
+	Long:             "This command allows the current tenant specified in the profile to check the status of a test-run already initiated via the `fsoc solution test` command",
 	Example:          ` fsoc solution test-status`,
 	Run:              testSolutionStatus,
 	TraverseChildren: true,
@@ -57,7 +57,7 @@ func getSolutionTestCmd() *cobra.Command {
 }
 
 func getSolutionTestStatusCmd() *cobra.Command {
-	solutionTestStatusCmd.Flags().String("test-run-id", "", "The test-run-id provided by `fsoc solution test` command. If no value is provided, it will default to 'current' test-run-id saved locally - it may or may not be present. So it is advised that test-run-id is always supplied.")
+	solutionTestStatusCmd.Flags().String("test-run-id", "", "The test-run-id provided by `fsoc solution test` command. So it is advised that test-run-id is always supplied.")
 	return solutionTestStatusCmd
 }
 
@@ -173,10 +173,9 @@ func testSolution(cmd *cobra.Command, args []string) {
 }
 
 // Implementation for `fsoc solution test-status` command.
-// This command takes 1 argument, called `test-run-id` which is a string that represents a solution test run by `fsoc solution test` command.
-// If no `test-run-id` string is provided, then the command will try to use locally stored test-run-id from previously run test.
+// This command takes 1 mandatory argument, called `test-run-id` which is a string that represents a solution test-run already initiated via `fsoc solution test` command.
 // It is therefore recommended that `fsoc solution test` command is run before this command, and the `test-run-id` returned from it is used here.
-// The command will read the supplied test-run-id; Call test-runner server-side component, that runs the solution tests; Get the latest status of the test and print it in a user-readable notation.
+// The command will read the supplied test-run-id; Call test-runner server-side component, that runs the solution tests; Get the latest status of the test-run and print it in a user-friendly notation.
 func testSolutionStatus(cmd *cobra.Command, args []string) {
 	// Read the test-run-id
 	suppliedTestId, _ := cmd.Flags().GetString("test-run-id")

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -162,6 +162,13 @@ func testSolutionStatus(cmd *cobra.Command, args []string) {
 	}
 
 	// Print the result in JSON format
+	for i := range res.StatusMessages {
+		statusMessage := res.StatusMessages[i].Message
+		if strings.Contains(statusMessage, "\n") {
+			res.StatusMessages[i].Statuses = strings.Split(statusMessage, "\n")
+			res.StatusMessages[i].Message = ""
+		}
+	}
 	resJsonBytes, err := json.MarshalIndent(res, "", "  ")
 	if err != nil {
 		log.Fatalf("JSON marshal failed: %v", err)

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 
 	"github.com/apex/log"
+	"github.com/cisco-open/fsoc/output"
+	"github.com/cisco-open/fsoc/platform/api"
 	"github.com/spf13/cobra"
 )
 
@@ -102,6 +104,12 @@ func testSolution(cmd *cobra.Command, args []string) {
 	fmt.Printf("\nTest Objects file:- %s", testObjectsStr)
 
 	// Send this payload to Test Runner and print the id returned by it
+	var res SolutionTestResult
+	err = api.JSONPut(getSolutionTestUrl(), testObjects, &res, nil)
+	if err != nil {
+		log.Fatalf("Solution Test request failed: %v", err)
+	}
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution Test data sent to test-runner successfully. Test ID - %s", res.ID))
 }
 
 func isTestPackageRoot(path string) bool {
@@ -143,4 +151,8 @@ func readFileLocation(path string) (string, error) {
 		return "", err
 	}
 	return string(jsonStr), nil
+}
+
+func getSolutionTestUrl() string {
+	return "rest/kirby-solution-testing-poc/kirby-solution-testing-poc-function/solution/v1/test"
 }

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -57,7 +57,7 @@ func getSolutionTestCmd() *cobra.Command {
 }
 
 func getSolutionTestStatusCmd() *cobra.Command {
-	solutionTestStatusCmd.Flags().String("test-run-id", "", "The test-run-id provided by `fsoc solution test` command. So it is advised that test-run-id is always supplied.")
+	solutionTestStatusCmd.Flags().String("test-run-id", "", "The test-run-id returned by `fsoc solution test` command")
 	return solutionTestStatusCmd
 }
 

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -1,0 +1,146 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+var solutionTestCmd = &cobra.Command{
+	Use:              "test",
+	Args:             cobra.ExactArgs(0),
+	Short:            "Test Solution",
+	Long:             "This command allows the current tenant specified in the profile to run tests against an already-deployed solution",
+	Example:          `  fsoc solution test`,
+	Run:              testSolution,
+	TraverseChildren: true,
+}
+
+func getSolutionTestCmd() *cobra.Command {
+	solutionTestCmd.Flags().String("test-bundle", "", "The fully qualified path name for the test bundle directory. If no value is provided, it will default to 'current' - meaning current directory, where this command is running.")
+	return solutionTestCmd
+}
+
+func testSolution(cmd *cobra.Command, args []string) {
+	var testBundleDir string
+	testBundlePath, _ := cmd.Flags().GetString("test-bundle")
+
+	// Get Test Bundle Directory
+	currentDir, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	if testBundlePath == "" {
+		testBundleDir = currentDir
+	} else {
+		testBundleDir = testBundlePath
+	}
+	fmt.Printf("\nTest Bundle Directory - %s", testBundleDir)
+
+	// Read Test Objects JSON
+	if !isTestPackageRoot(testBundleDir) {
+		log.Fatalf("No test-objects file found in %q; please run this command in a folder with a test-objects file or use the --test-bundle flag", testBundleDir)
+	}
+	testObjects, err := getTestObjects(testBundleDir)
+	if err != nil {
+		log.Fatalf("Failed to read the test objects file in %q: %v", testBundleDir, err)
+	}
+
+	// Replace any file references in input, assertions with contents of those files
+	for i := range testObjects.Tests {
+		testObj := testObjects.Tests[i]
+		setup := testObj.Setup
+		if setup.Location != "" {
+			setup.Input, err = readFileLocation(fmt.Sprintf("%s/%s", testBundleDir, setup.Location))
+			if err != nil {
+				log.Fatalf("Failed to load JSON in place of file ref %q: %v", setup.Location, err)
+			}
+			setup.Location = ""
+			setup.Type = ""
+			testObj.Setup = setup
+		}
+		for k := range testObj.Assertions {
+			assertion := testObj.Assertions[k]
+			for l := range assertion.Transforms {
+				transform := assertion.Transforms[l]
+				if transform.Location != "" {
+					transform.Expression, err = readFileLocation(fmt.Sprintf("%s/%s", testBundleDir, transform.Location))
+					if err != nil {
+						log.Fatalf("Failed to load JSON in place of file ref %q: %v", transform.Location, err)
+					}
+					transform.Location = ""
+					assertion.Transforms[l] = transform
+				}
+			}
+			testObj.Assertions[k] = assertion
+		}
+		testObjects.Tests[i] = testObj
+	}
+
+	testObjectsStr, err := json.MarshalIndent(testObjects, "", "  ")
+	if err != nil {
+		log.Fatalf("Failed to marshal testObjects into a JSON string: %v", err)
+	}
+	fmt.Printf("\nTest Objects file:- %s", testObjectsStr)
+
+	// Send this payload to Test Runner and print the id returned by it
+}
+
+func isTestPackageRoot(path string) bool {
+	testObjectsPath := fmt.Sprintf("%s/test-objects.json", path)
+	testObjectsFile, err := os.Open(testObjectsPath)
+	if err != nil {
+		log.Errorf("The folder %s is not a solution test root folder", path)
+		return false
+	}
+	testObjectsFile.Close()
+	return true
+}
+
+func getTestObjects(path string) (*SolutionTestObjects, error) {
+	testObjectsPath := fmt.Sprintf("%s/test-objects.json", path)
+	testObjectsFile, err := os.Open(testObjectsPath)
+	if err != nil {
+		return nil, fmt.Errorf("%q is not a solution test root folder", path)
+	}
+	defer testObjectsFile.Close()
+
+	testObjectBytes, err := io.ReadAll(testObjectsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	var testObjects *SolutionTestObjects
+	err = json.Unmarshal(testObjectBytes, &testObjects)
+	if err != nil {
+		return nil, err
+	}
+
+	return testObjects, nil
+}
+
+func readFileLocation(path string) (string, error) {
+	jsonStr, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonStr), nil
+}

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -57,7 +57,7 @@ func getSolutionTestCmd() *cobra.Command {
 }
 
 func getSolutionTestStatusCmd() *cobra.Command {
-	solutionTestStatusCmd.Flags().String("test-id", "", "The test-id provided by `fsoc solution test` command. If no value is provided, it will default to 'current' test-id saved locally - it may or may not be present. So it is advised that test-id is always supplied.")
+	solutionTestStatusCmd.Flags().String("test-run-id", "", "The test-run-id provided by `fsoc solution test` command. If no value is provided, it will default to 'current' test-run-id saved locally - it may or may not be present. So it is advised that test-run-id is always supplied.")
 	return solutionTestStatusCmd
 }
 
@@ -67,8 +67,8 @@ func getSolutionTestStatusCmd() *cobra.Command {
 // The command looks for a file called `test-objects.json` in the `test-bundle` directory. This file should contain payload that will be sent to the test-runner server-side component to run the solution test.
 // All the file references present in `test-objects.json` should be relative paths to other files inside `test-bundle` path.
 // The command will try to read those files and replace file refereces in `test-objects.json` with actual file contents.
-// Once all this parsing is done, the command will prepare the payload for test-runner; Make http call to it and print the `test-id“ string that it gets from the test-runner.
-// The test-id returned by this command should be used to check status of the test using `fsoc solution test-status` command.
+// Once all this parsing is done, the command will prepare the payload for test-runner; Make http call to it and print the `test-run-id“ string that it gets from the test-runner.
+// The test-run-id returned by this command should be used to check status of the test using `fsoc solution test-status` command.
 func testSolution(cmd *cobra.Command, args []string) {
 	var testBundleDir string
 	testBundlePath, _ := cmd.Flags().GetString("test-bundle")
@@ -173,18 +173,18 @@ func testSolution(cmd *cobra.Command, args []string) {
 }
 
 // Implementation for `fsoc solution test-status` command.
-// This command takes 1 argument, called `test-id` which is a string that represents a solution test run by `fsoc solution test` command.
-// If no `test-id` string is provided, then the command will try to use locally stored test-id from previously run test.
-// It is therefore recommended that `fsoc solution test` command is run before this command, and the `test-id` returned from it is used here.
-// The command will read the supplied test-id; Call test-runner server-side component, that runs the solution tests; Get the latest status of the test and print it in a user-readable notation.
+// This command takes 1 argument, called `test-run-id` which is a string that represents a solution test run by `fsoc solution test` command.
+// If no `test-run-id` string is provided, then the command will try to use locally stored test-run-id from previously run test.
+// It is therefore recommended that `fsoc solution test` command is run before this command, and the `test-run-id` returned from it is used here.
+// The command will read the supplied test-run-id; Call test-runner server-side component, that runs the solution tests; Get the latest status of the test and print it in a user-readable notation.
 func testSolutionStatus(cmd *cobra.Command, args []string) {
-	// Read the test-id
-	suppliedTestId, _ := cmd.Flags().GetString("test-id")
+	// Read the test-run-id
+	suppliedTestId, _ := cmd.Flags().GetString("test-run-id")
 	if suppliedTestId == "" {
-		log.Fatal("Supplied test-id is null or empty.")
+		log.Fatal("Supplied test-run-id is null or empty.")
 	}
 
-	// Send the test-id to the test-runner and print the response
+	// Send the test-run-id to the test-runner and print the response
 	var res SolutionTestStatusResult
 	err := api.JSONGet(getSolutionTestStatusUrl(suppliedTestId), &res, nil)
 	if err != nil {
@@ -203,7 +203,7 @@ func testSolutionStatus(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("JSON marshal failed: %v", err)
 	}
-	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution Test Status received for test-id (%s): \n%v", suppliedTestId, string(resJsonBytes)))
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution Test Status received for test-run-id (%s): \n%v", suppliedTestId, string(resJsonBytes)))
 }
 
 func isTestPackageRoot(path string) bool {

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -55,7 +55,7 @@ func testSolution(cmd *cobra.Command, args []string) {
 	} else {
 		testBundleDir = testBundlePath
 	}
-	fmt.Printf("\nTest Bundle Directory - %s", testBundleDir)
+	// fmt.Printf("\nTest Bundle Directory - %s", testBundleDir)
 
 	// Read Test Objects JSON
 	if !isTestPackageRoot(testBundleDir) {
@@ -97,11 +97,11 @@ func testSolution(cmd *cobra.Command, args []string) {
 		testObjects.Tests[i] = testObj
 	}
 
-	testObjectsStr, err := json.MarshalIndent(testObjects, "", "  ")
-	if err != nil {
-		log.Fatalf("Failed to marshal testObjects into a JSON string: %v", err)
-	}
-	fmt.Printf("\nTest Objects file:- %s", testObjectsStr)
+	// testObjectsStr, err := json.MarshalIndent(testObjects, "", "  ")
+	// if err != nil {
+	// 	log.Fatalf("Failed to marshal testObjects into a JSON string: %v", err)
+	// }
+	// fmt.Printf("\nTest Objects file:- %s", testObjectsStr)
 
 	// Send this payload to Test Runner and print the id returned by it
 	var res SolutionTestResult

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -51,7 +51,7 @@ var solutionTestStatusCmd = &cobra.Command{
 func getSolutionTestCmd() *cobra.Command {
 	solutionTestCmd.Flags().String("test-bundle", "", "The fully qualified path name for the test bundle directory. If no value is provided, it will default to 'current' - meaning current directory, where this command is running.")
 	solutionTestCmd.Flags().String("initial-delay", "", "Time duration (in seconds) that the Test Runner should wait before making first call to UQL")
-	solutionTestCmd.Flags().String("retry-count", "", "Number of times the Test Runner should call UQL to get latest data")
+	solutionTestCmd.Flags().String("max-retry-count", "", "Maximum Number of times the Test Runner should call UQL to get latest data. Depending on the error code returned by UQL, retry will be initiated.")
 	solutionTestCmd.Flags().String("retry-delay", "", "Time duration (in seconds) that the Test Runner should wait between retries")
 	return solutionTestCmd
 }
@@ -73,7 +73,7 @@ func testSolution(cmd *cobra.Command, args []string) {
 	var testBundleDir string
 	testBundlePath, _ := cmd.Flags().GetString("test-bundle")
 	initialDelay, _ := cmd.Flags().GetString("initial-delay")
-	retryCount, _ := cmd.Flags().GetString("retry-count")
+	maxRetryCount, _ := cmd.Flags().GetString("max-retry-count")
 	retryDelay, _ := cmd.Flags().GetString("retry-delay")
 
 	// Get Test Bundle Directory
@@ -139,7 +139,7 @@ func testSolution(cmd *cobra.Command, args []string) {
 		testObjects.Tests[i] = testObj
 	}
 
-	// Set initial-delay, retry-count, retry-delay
+	// Set initial-delay, max-retry-count, retry-delay
 	if initialDelay != "" {
 		testObjectsInt, err := strconv.Atoi(initialDelay)
 		if err != nil {
@@ -147,12 +147,12 @@ func testSolution(cmd *cobra.Command, args []string) {
 		}
 		testObjects.InitialDelay = testObjectsInt
 	}
-	if retryCount != "" {
-		retryCountInt, err := strconv.Atoi(retryCount)
+	if maxRetryCount != "" {
+		maxRetryCountInt, err := strconv.Atoi(maxRetryCount)
 		if err != nil {
-			log.Fatalf("Error while reading integer value from string %s: %v", retryCount, err)
+			log.Fatalf("Error while reading integer value from string %s: %v", maxRetryCount, err)
 		}
-		testObjects.RetryCount = retryCountInt
+		testObjects.MaxRetryCount = maxRetryCountInt
 	}
 	if retryDelay != "" {
 		retryDelayInt, err := strconv.Atoi(retryDelay)

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -4,14 +4,13 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package solution
 
 import (
@@ -36,11 +35,36 @@ var solutionTestCmd = &cobra.Command{
 	TraverseChildren: true,
 }
 
+var solutionTestStatusCmd = &cobra.Command{
+	Use:              "test-status",
+	Args:             cobra.ExactArgs(0),
+	Short:            "Status of Solution Test",
+	Long:             "This command allows the current tenant specified in the profile to check status of the solution-test already run by `fsoc solution test` command",
+	Example:          ` fsoc solution test-status`,
+	Run:              testSolutionStatus,
+	TraverseChildren: true,
+}
+
+var testId string
+
 func getSolutionTestCmd() *cobra.Command {
 	solutionTestCmd.Flags().String("test-bundle", "", "The fully qualified path name for the test bundle directory. If no value is provided, it will default to 'current' - meaning current directory, where this command is running.")
 	return solutionTestCmd
 }
 
+func getSolutionTestStatusCmd() *cobra.Command {
+	solutionTestStatusCmd.Flags().String("test-id", "", "The test-id provided by `fsoc solution test` command. If no value is provided, it will default to 'current' test-id saved locally - it may or may not be present. So it is advised that test-id is always supplied.")
+	return solutionTestStatusCmd
+}
+
+// Implementation for `fsoc solution test` command.
+// This command takes 1 argument, called `test-bundle`, which is a path to a directory where the files necessary to run the solution test are present.
+// If no `test-bundle` path is provided, the command will use current directoy as `test-bundle` path.
+// The command looks for a file called `test-objects.json` in the `test-bundle` directory. This file should contain payload that will be sent to the test-runner server-side component to run the solution test.
+// All the file references present in `test-objects.json` should be relative paths to other files inside `test-bundle` path.
+// The command will try to read those files and replace file refereces in `test-objects.json` with actual file contents.
+// Once all this parsing is done, the command will prepare the payload for test-runner; Make http call to it and print the `test-id“ string that it gets from the test-runner.
+// The test-id returned by this command should be used to check status of the test using `fsoc solution test-status` command.
 func testSolution(cmd *cobra.Command, args []string) {
 	var testBundleDir string
 	testBundlePath, _ := cmd.Flags().GetString("test-bundle")
@@ -51,6 +75,7 @@ func testSolution(cmd *cobra.Command, args []string) {
 		log.Fatal(err.Error())
 	}
 	if testBundlePath == "" {
+		fmt.Println("Supplied test-bundle path is empty. Using current directoty to look for test-bundle.")
 		testBundleDir = currentDir
 	} else {
 		testBundleDir = testBundlePath
@@ -109,7 +134,36 @@ func testSolution(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Solution Test request failed: %v", err)
 	}
-	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution Test data sent to test-runner successfully. Test ID - %s", res.ID))
+	testId := res.ID
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution Test data sent to test-runner successfully. Test ID - %s", testId))
+}
+
+// Implementation for `fsoc solution test-status` command.
+// This command takes 1 argument, called `test-id` which is a string that represents a solution test run by `fsoc solution test` command.
+// If no `test-id` string is provided, then the command will try to use locally stored test-id from previously run test.
+// It is therefore recommended that `fsoc solution test` command is run before this command, and the `test-id` returned from it is used here.
+// The command will read the supplied test-id; Call test-runner server-side component, that runs the solution tests; Get the latest status of the test and print it in a user-readable notation.
+func testSolutionStatus(cmd *cobra.Command, args []string) {
+	// Read the test-id
+	suppliedTestId, _ := cmd.Flags().GetString("test-id")
+	if suppliedTestId == "" {
+		fmt.Println("Supplied test-id is null or empty.")
+		suppliedTestId = testId
+		if suppliedTestId == "" {
+			log.Fatalf("No local test-id saved as well. Exiting...")
+		}
+		fmt.Printf("Using locally saved test-id (%s) to check test status", suppliedTestId)
+	} else {
+		fmt.Printf("Using supplied test-id (%s) to check test status", suppliedTestId)
+	}
+
+	// Send the test-id to the test-runner and print the response
+	var res SolutionTestStatusResult
+	err := api.JSONGet(getSolutionTestStatusUrl(testId), &res, nil)
+	if err != nil {
+		log.Fatalf("Solution Test Status request failed: %v", err)
+	}
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution Test Status received for test-id (%s): %s", testId, res.Status))
 }
 
 func isTestPackageRoot(path string) bool {
@@ -154,5 +208,13 @@ func readFileLocation(path string) (string, error) {
 }
 
 func getSolutionTestUrl() string {
-	return "rest/kirby-solution-testing-poc/kirby-solution-testing-poc-function/solution/v1/test"
+	return fmt.Sprintf("%s/solution/v1/test", getBaseUrl())
+}
+
+func getSolutionTestStatusUrl(testId string) string {
+	return fmt.Sprintf("%s/solution/v1/status/%s", getBaseUrl(), testId)
+}
+
+func getBaseUrl() string {
+	return "rest/kirby-solution-testing-poc/kirby-solution-testing-poc-function"
 }

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
 	"github.com/cisco-open/fsoc/output"
 	"github.com/cisco-open/fsoc/platform/api"
-	"github.com/spf13/cobra"
 )
 
 var solutionTestCmd = &cobra.Command{

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -226,6 +226,7 @@ type SolutionTestStatusResult struct {
 }
 
 type StatusMessage struct {
-	Timestamp string `json:"timestamp"`
-	Message   string `json:"message"`
+	Timestamp string   `json:"timestamp"`
+	Message   string   `json:"message,omitempty"`
+	Statuses  []string `json:"statuses,omitempty"`
 }

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -187,30 +187,34 @@ type SolutionList struct {
 }
 
 type SolutionTestObjects struct {
-	Tests []SolutionTestObject `json:"tests,omitempty"`
+	Tests []SolutionTestObject `json:"tests"`
 }
 
 type SolutionTestObject struct {
 	Name        string                  `json:"name,omitempty"`
-	Type        string                  `json:"type,omitempty"`
+	Type        string                  `json:"type"`
 	Description string                  `json:"description,omitempty"`
-	Setup       SolutionTestSetup       `json:"setup,omitempty"`
-	Assertions  []SolutionTestAssertion `json:"assertions,omitempty"`
+	Setup       SolutionTestSetup       `json:"setup"`
+	Assertions  []SolutionTestAssertion `json:"assertions"`
 }
 
 type SolutionTestSetup struct {
-	Type     string `json:"type,omitempty"`
+	Type     string `json:"type"`
 	Input    string `json:"input,omitempty"`
 	Location string `json:"location,omitempty"`
 }
 
 type SolutionTestAssertion struct {
-	UQL        string                           `json:"uql,omitempty"`
-	Transforms []SolutionTestAssertionTransform `json:"transforms,omitempty"`
+	UQL        string                           `json:"uql"`
+	Transforms []SolutionTestAssertionTransform `json:"transforms"`
 }
 
 type SolutionTestAssertionTransform struct {
-	Type       string `json:"type,omitempty"`
+	Type       string `json:"type"`
 	Expression string `json:"expression,omitempty"`
 	Location   string `json:"location,omitempty"`
+}
+
+type SolutionTestResult struct {
+	ID string `json:"testId"`
 }

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -218,3 +218,7 @@ type SolutionTestAssertionTransform struct {
 type SolutionTestResult struct {
 	ID string `json:"testId"`
 }
+
+type SolutionTestStatusResult struct {
+	Status string
+}

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -192,16 +192,16 @@ type SolutionTestObjects struct {
 
 type SolutionTestObject struct {
 	Name        string                  `json:"name,omitempty"`
-	Type        string                  `json:"type"`
+	Type        string                  `json:"type,omitempty"`
 	Description string                  `json:"description,omitempty"`
 	Setup       SolutionTestSetup       `json:"setup"`
 	Assertions  []SolutionTestAssertion `json:"assertions"`
 }
 
 type SolutionTestSetup struct {
-	Type     string `json:"type"`
-	Input    string `json:"input,omitempty"`
-	Location string `json:"location,omitempty"`
+	Type     string      `json:"type"`
+	Input    interface{} `json:"input,omitempty"`
+	Location string      `json:"location,omitempty"`
 }
 
 type SolutionTestAssertion struct {
@@ -212,13 +212,20 @@ type SolutionTestAssertion struct {
 type SolutionTestAssertionTransform struct {
 	Type       string `json:"type"`
 	Expression string `json:"expression,omitempty"`
+	Message    string `json:"message,omitempty"`
 	Location   string `json:"location,omitempty"`
 }
 
 type SolutionTestResult struct {
-	ID string `json:"testId"`
+	ID string `json:"testRunId"`
 }
 
 type SolutionTestStatusResult struct {
-	Status string
+	Complete       bool            `json:"completed"`
+	StatusMessages []StatusMessage `json:"statusMessages"`
+}
+
+type StatusMessage struct {
+	Timestamp string `json:"timestamp"`
+	Message   string `json:"message"`
 }

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -187,7 +187,10 @@ type SolutionList struct {
 }
 
 type SolutionTestObjects struct {
-	Tests []SolutionTestObject `json:"tests"`
+	Tests        []SolutionTestObject `json:"tests"`
+	InitialDelay int                  `json:"initialDelay,omitempty"`
+	RetryCount   int                  `json:"retryCount,omitempty"`
+	RetryDelay   int                  `json:"retryDelay,omitempty"`
 }
 
 type SolutionTestObject struct {

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -185,3 +185,32 @@ type Solution struct {
 type SolutionList struct {
 	Items []Solution `json:"items"`
 }
+
+type SolutionTestObjects struct {
+	Tests []SolutionTestObject `json:"tests,omitempty"`
+}
+
+type SolutionTestObject struct {
+	Name        string                  `json:"name,omitempty"`
+	Type        string                  `json:"type,omitempty"`
+	Description string                  `json:"description,omitempty"`
+	Setup       SolutionTestSetup       `json:"setup,omitempty"`
+	Assertions  []SolutionTestAssertion `json:"assertions,omitempty"`
+}
+
+type SolutionTestSetup struct {
+	Type     string `json:"type,omitempty"`
+	Input    string `json:"input,omitempty"`
+	Location string `json:"location,omitempty"`
+}
+
+type SolutionTestAssertion struct {
+	UQL        string                           `json:"uql,omitempty"`
+	Transforms []SolutionTestAssertionTransform `json:"transforms,omitempty"`
+}
+
+type SolutionTestAssertionTransform struct {
+	Type       string `json:"type,omitempty"`
+	Expression string `json:"expression,omitempty"`
+	Location   string `json:"location,omitempty"`
+}

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -187,10 +187,10 @@ type SolutionList struct {
 }
 
 type SolutionTestObjects struct {
-	Tests        []SolutionTestObject `json:"tests"`
-	InitialDelay int                  `json:"initialDelay,omitempty"`
-	RetryCount   int                  `json:"retryCount,omitempty"`
-	RetryDelay   int                  `json:"retryDelay,omitempty"`
+	Tests         []SolutionTestObject `json:"tests"`
+	InitialDelay  int                  `json:"initialDelay,omitempty"`
+	MaxRetryCount int                  `json:"retryCount,omitempty"`
+	RetryDelay    int                  `json:"retryDelay,omitempty"`
 }
 
 type SolutionTestObject struct {


### PR DESCRIPTION
## Description
This change will add following fsoc commands for solution testing. 
- fsoc solution test --test-bundle=\<directory-path-containing-test-data\>
- fsoc solution test status --test-id=\<test-id-returned-by-above-command\>

#### Context
- [Solution Testing PoC](https://confluence.corp.appdynamics.com/display/ARCH/Solution+Testing+POC)
- [Test Objects Wiki](https://confluence.corp.appdynamics.com/display/ARCH/Test+Objects#TestObjects-FSOCcommands)

#### Example Use
1. Solution Test
Input to the command - 
```
solution-testing-poc-data
├── input
│   └── metric_spec.json
├── test-objects.json --> file with this name must be present
└── transforms
    └── metric_transform.txt
```
test-objects.json - 
```
{
  "tests": [
    {
      "name": "metric_test",
      "type": "endToEndTest", --> only supported type for now
      "description": "Tests metric upload",
      "setup": {
          "type": "singleUpload",
          "location": "input/metric_spec.json" --> relative path to file that contains input data for this test
      },
      "assertions": [
        {
          "uql": "since now - 1h FETCH attributes(service.name), attributes(service.namespace), metrics(apm:calls_min) FROM entities(apm:service_instance)[attributes('service.namespace') ~ 'zs-kirby-solution-testing-poc-function']",
          "transforms": [
            {
              "type": "RawUQLResult",
              "location": "transforms/metric_transform.txt" --> relative path to file that contains transform data for this test
            },
            {
              "type": "SimplifiedUQLResult",
              "expression": "$count(rows.metrics.metrics)=2"
            }
          ]
        }
      ]
    }
  ]
}
```
Initiate Solution Test by providing path to test-bundle
Command usage example - 
```bash
➜  ddanuj-fsoc-fork git:(CODEX-809) ./fsoc solution test --help
This command allows the current tenant specified in the profile to run tests against an already-deployed solution

Usage:
  fsoc solution test [flags]

Examples:
  fsoc solution test

Flags:
  -h, --help                   help for test
      --initial-delay string   Time duration (in seconds) that the Test Runner should wait before making first call to UQL
      --retry-count string     Number of times the Test Runner should call UQL to get latest data
      --retry-delay string     Time duration (in seconds) that the Test Runner should wait between retries
      --test-bundle string     The fully qualified path name for the test bundle directory. If no value is provided, it will default to 'current' - meaning current directory, where this command is running.
...
➜  ddanuj-fsoc-fork git:(CODEX-809) ./fsoc solution test --test-bundle=/Users/adoiphod/personal_workspace/solution-testing-poc-data --initial-delay=60 --retry-count=4 --retry-delay=15
✓ Platform API call (PUT /rest/kirby-solution-testing-poc/kirby-solution-testing-poc-function/solution/v1/test)
Solution Test data sent to test-runner successfully. Test ID - fbfec8f8-21bf-450a-83d5-dcaf13fb1d53%
```
2. Solution Test Status
Use test-id received command received from test command to check status of the test
Command usage example -
```bash
➜  ddanuj-fsoc-fork git:(CODEX-809) ./fsoc solution test-status --help
This command allows the current tenant specified in the profile to check status of the solution-test already run by `fsoc solution test` command

Usage:
  fsoc solution test-status [flags]

Examples:
 fsoc solution test-status

Flags:
  -h, --help                         help for test-status
      --test-id fsoc solution test   The test-id provided by fsoc solution test command. If no value is provided, it will default to 'current' test-id saved locally - it may or may not be present. So it is advised that test-id is always supplied.
...
➜  ddanuj-fsoc-fork git:(CODEX-809) ./fsoc solution test-status --test-id=fbfec8f8-21bf-450a-83d5-dcaf13fb1d53
✓ Platform API call (GET /rest/kirby-solution-testing-poc/kirby-solution-testing-poc-function/solution/v1/status/fbfec8f8-21bf-450a-83d5-dcaf13fb1d53)
Solution Test Status received for test-id (fbfec8f8-21bf-450a-83d5-dcaf13fb1d53):
{
  "completed": true,
  "statusMessages": [
    {
      "timestamp": "2023-05-05T04:40:55.341",
      "message": "Test Started"
    },
    {
      "timestamp": "2023-05-05T04:40:55.360702",
      "message": "Input successfully parsed"
    },
    {
      "timestamp": "2023-05-05T04:40:55.361451",
      "message": "Sending input-data to CIS"
    },
    {
      "timestamp": "2023-05-05T04:40:55.555669",
      "message": "Input data sent to CIS successfully. Starting UQL assertions in 60 seconds, allowing data to flow through the backend."
    },
    {
      "timestamp": "2023-05-05T04:41:55.557968",
      "message": "Calling UQL - Attempt 1"
    },
    {
      "timestamp": "2023-05-05T04:41:55.639892",
      "message": "Received Response from UQL. Applying transforms - Attempt 1"
    },
    {
      "timestamp": "2023-05-05T04:41:55.686225",
      "statuses": [
        "Transform - data[0][0]='solution-test-runner' | Result - true",
        "Transform - $count(rows.metrics.metrics)=2 | Result - false"
      ]
    },
    {
      "timestamp": "2023-05-05T04:42:10.687777",
      "message": "Calling UQL - Attempt 2"
    },
    {
      "timestamp": "2023-05-05T04:42:10.778958",
      "message": "Received Response from UQL. Applying transforms - Attempt 2"
    },
    {
      "timestamp": "2023-05-05T04:42:10.824264",
      "statuses": [
        "Transform - data[0][0]='solution-test-runner' | Result - true",
        "Transform - $count(rows.metrics.metrics)=2 | Result - false"
      ]
    },
    {
      "timestamp": "2023-05-05T04:42:25.825657",
      "message": "Calling UQL - Attempt 3"
    },
    {
      "timestamp": "2023-05-05T04:42:25.906890",
      "message": "Received Response from UQL. Applying transforms - Attempt 3"
    },
    {
      "timestamp": "2023-05-05T04:42:25.949506",
      "statuses": [
        "Transform - data[0][0]='solution-test-runner' | Result - true",
        "Transform - $count(rows.metrics.metrics)=2 | Result - false"
      ]
    },
    {
      "timestamp": "2023-05-05T04:42:40.951",
      "message": "Calling UQL - Attempt 4"
    },
    {
      "timestamp": "2023-05-05T04:42:41.038028",
      "message": "Received Response from UQL. Applying transforms - Attempt 4"
    },
    {
      "timestamp": "2023-05-05T04:42:41.077712",
      "statuses": [
        "Transform - data[0][0]='solution-test-runner' | Result - true",
        "Transform - $count(rows.metrics.metrics)=2 | Result - false"
      ]
    },
    {
      "timestamp": "2023-05-05T04:42:41.079821",
      "message": "Calling UQL - Retry attempts exhausted. Retry count - 4"
    }
  ]
}%
```
## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
