### PR TITLE
Revert "ORION-1115: add support for providing tag to solution push + solution validate FSOC-140: fix solution status message output"

### DIFF
--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -42,8 +42,7 @@ The solution manifest for the solution must be in the current directory.`,
 	Example: `
   fsoc solution push
   fsoc solution push -w
-  fsoc solution push -w=60
-  fsoc solution push -tag=dev`,
+  fsoc solution push -w=60`,
 	Run:              pushSolution,
 	TraverseChildren: true,
 }
@@ -55,9 +54,6 @@ func getSolutionPushCmd() *cobra.Command {
 
 	solutionPushCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before deploying")
-
-	solutionPushCmd.Flags().
-		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 
 	solutionPushCmd.Flags().
 		String("solution-bundle", "", "fully qualified path name for the solution bundle .zip file")
@@ -76,7 +72,6 @@ func pushSolution(cmd *cobra.Command, args []string) {
 
 	waitFlag, _ := cmd.Flags().GetInt("wait")
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
-	solutionTagFlag, _ := cmd.Flags().GetString("tag")
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	var solutionArchivePath string
 
@@ -116,7 +111,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	solutionArchive := generateZip(cmd, manifestPath)
 	solutionArchivePath = filepath.Base(solutionArchive.Name())
 
-	message := fmt.Sprintf("Deploying solution %s version %s with tag %s", manifest.Name, manifest.SolutionVersion, solutionTagFlag)
+	message := fmt.Sprintf("Deploying solution %s version %s", manifest.Name, manifest.SolutionVersion)
 	log.WithFields(log.Fields{"solution": manifest.Name, "version": manifest.SolutionVersion}).Info("Deploying solution")
 
 	file, err := os.Open(solutionArchivePath)
@@ -141,7 +136,8 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	writer.Close()
 
 	headers := map[string]string{
-		"tag":          solutionTagFlag,
+		"stage":        "STABLE",
+		"tag":          "stable",
 		"operation":    "UPLOAD",
 		"Content-Type": writer.FormDataContentType(),
 	}

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -17,7 +17,6 @@ package solution
 import (
 	"fmt"
 	"net/url"
-	"reflect"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
@@ -26,23 +25,6 @@ import (
 	"github.com/cisco-open/fsoc/output"
 	"github.com/cisco-open/fsoc/platform/api"
 )
-
-type SubscriptionStatusData struct {
-	IsDeleted    string `json:"isDeleted,omitempty"`
-	SolutionID   string `json:"solutionID,omitempty"`
-	SolutionName string `json:"solutionName,omitempty"`
-	Tag          string `json:"tag,omitempty"`
-	TenantId     string `json:"tenantId,omitempty"`
-}
-
-type SubscriptionStatusItem struct {
-	SubscriptionStatusData SubscriptionStatusData `json:"data"`
-	CreatedAt              string                 `json:"createdAt"`
-}
-
-type SubscriptionStatusResponseBlob struct {
-	Items []SubscriptionStatusItem `json:"items"`
-}
 
 type StatusData struct {
 	InstallTime       string `json:"installTime,omitempty"`
@@ -109,45 +91,20 @@ func getObject(url string, headers map[string]string) StatusItem {
 	}
 }
 
-func getEnvironmentSubscriptionObject(url string, headers map[string]string) SubscriptionStatusItem {
-	var res SubscriptionStatusResponseBlob
-	var emptyData SubscriptionStatusItem
-
-	err := api.JSONGet(url, &res, &api.Options{Headers: headers})
-
-	if err != nil {
-		log.Fatalf("Error fetching environment:subscription object %q: %v", url, err)
-	}
-
-	if len(res.Items) > 0 {
-		return res.Items[0]
-	} else {
-		return emptyData
-	}
-}
-
-func fetchValuesAndPrint(operation string, solutionNameAndVersionQuery string, subscriptionStatusQuery string, solutionName string, requestHeaders map[string]string, cmd *cobra.Command) {
-	uploadStatusItem := getObject(fmt.Sprintf(getSolutionReleaseUrl(), solutionNameAndVersionQuery), requestHeaders)
-	installStatusItem := getObject(fmt.Sprintf(getSolutionInstallUrl(), solutionNameAndVersionQuery), requestHeaders)
-	subscriptionStatusItem := getEnvironmentSubscriptionObject(fmt.Sprintf(getEnvironmentSubscriptionUrl(), subscriptionStatusQuery), requestHeaders)
+func fetchValuesAndPrint(operation string, query string, requestHeaders map[string]string, cmd *cobra.Command) {
+	uploadStatusItem := getObject(fmt.Sprintf(getSolutionReleaseUrl(), query), requestHeaders)
+	installStatusItem := getObject(fmt.Sprintf(getSolutionInstallUrl(), query), requestHeaders)
 
 	installStatusData := installStatusItem.StatusData
 	uploadStatusData := uploadStatusItem.StatusData
 	uploadStatusTimestamp := uploadStatusItem.CreatedAt
-	isTenantSubscribedToSolution := (!subscriptionStatusItem.IsEmpty() && subscriptionStatusItem.SubscriptionStatusData.IsDeleted == "false")
 
 	headers := []string{"Solution Name"}
-	values := []string{solutionName}
+	values := []string{uploadStatusData.SolutionName}
 
 	appendValue := func(header, value string) {
 		headers = append(headers, header)
 		values = append(values, value)
-	}
-
-	if isTenantSubscribedToSolution {
-		appendValue("Solution Subscription Status", "Subscribed")
-	} else {
-		appendValue("Solution Subscription Status", "Not Subscribed")
 	}
 
 	if operation == "upload" {
@@ -155,22 +112,14 @@ func fetchValuesAndPrint(operation string, solutionNameAndVersionQuery string, s
 		appendValue("Upload Timestamp", uploadStatusTimestamp)
 	} else if operation == "install" {
 		appendValue("Solution Install Version", installStatusData.SolutionVersion)
-		if isTenantSubscribedToSolution {
-			appendValue("Solution Install Successful?", fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
-		} else {
-			appendValue("Solution Install Successful?", "")
-		}
+		appendValue("Solution Install Successful?", fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
 		appendValue("Solution Install Time", installStatusData.InstallTime)
 		appendValue("Solution Install Message", installStatusData.InstallMessage)
 	} else {
 		appendValue("Solution Upload Version", uploadStatusData.SolutionVersion)
 		appendValue("Upload Timestamp", uploadStatusTimestamp)
 		appendValue("Solution Install Version", installStatusData.SolutionVersion)
-		if isTenantSubscribedToSolution {
-			appendValue("Solution Install Successful?", fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
-		} else {
-			appendValue("Solution Install Successful?", "")
-		}
+		appendValue("Solution Install Successful?", fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
 		appendValue("Solution Install Time", installStatusData.InstallTime)
 		appendValue("Solution Install Message", installStatusData.InstallMessage)
 	}
@@ -183,10 +132,7 @@ func fetchValuesAndPrint(operation string, solutionNameAndVersionQuery string, s
 }
 
 func getSolutionStatus(cmd *cobra.Command, args []string) error {
-	var solutionVersionFilter string
-	var solutionNameFilter string
-	var solutionNameAndVersionFilter string
-	var solutionNameAndTenantIdFilter string
+	var filterQuery string
 	cfg := config.GetCurrentContext()
 
 	layerType := "TENANT"
@@ -198,26 +144,18 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	}
 	solutionVersion, _ := cmd.Flags().GetString("solution-version")
 	statusTypeToFetch, _ := cmd.Flags().GetString("status-type")
-	solutionVersionFilter = fmt.Sprintf(`data.solutionVersion eq "%s"`, solutionVersion)
-	solutionNameFilter = fmt.Sprintf(`data.solutionName eq "%s"`, solutionName)
 
 	if solutionVersion != "" {
-		solutionNameAndVersionFilter = fmt.Sprintf(`%s and %s`, solutionNameFilter, solutionVersionFilter)
+		filterQuery = fmt.Sprintf(`data.solutionName eq "%s" and data.solutionVersion eq "%s"`, solutionName, solutionVersion)
 	} else {
-		solutionNameAndVersionFilter = solutionNameFilter
+		filterQuery = fmt.Sprintf(`data.solutionName eq "%s"`, solutionName)
 	}
-	solutionNameAndTenantIdFilter = fmt.Sprintf(`%s and data.tenantId eq "%s"`, solutionNameFilter, cfg.Tenant)
 
-	solutionNameAndVersionQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(solutionNameAndVersionFilter))
-	solutionNameAndTenantIdQuery := fmt.Sprintf("?order=%s&filter=%s", url.QueryEscape("desc"), url.QueryEscape(solutionNameAndTenantIdFilter))
+	query := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(filterQuery))
 
-	fetchValuesAndPrint(statusTypeToFetch, solutionNameAndVersionQuery, solutionNameAndTenantIdQuery, solutionName, headers, cmd)
+	fetchValuesAndPrint(statusTypeToFetch, query, headers, cmd)
 
 	return nil
-}
-
-func (s SubscriptionStatusItem) IsEmpty() bool {
-	return reflect.DeepEqual(s, SubscriptionStatusItem{})
 }
 
 func getSolutionReleaseUrl() string {
@@ -226,8 +164,4 @@ func getSolutionReleaseUrl() string {
 
 func getSolutionInstallUrl() string {
 	return "objstore/v1beta/objects/extensibility:solutionInstall%s"
-}
-
-func getEnvironmentSubscriptionUrl() string {
-	return "objstore/v1beta/objects/environment:subscription%s"
 }

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -64,8 +64,6 @@ func getSolutionValidateCmd() *cobra.Command {
 
 	solutionValidateCmd.Flags().
 		String("solution-bundle", "", "The fully qualified path name for the solution bundle .zip file that you want to validate")
-	solutionValidateCmd.Flags().
-		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 	_ = solutionValidateCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 
@@ -77,7 +75,6 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	var solutionArchivePath string
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
-	solutionTagFlag, _ := cmd.Flags().GetString("tag")
 
 	if solutionBundlePath != "" {
 		log.Fatalf("The --solution-bundle flag is no longer available; please use direct validate instead.")
@@ -135,7 +132,8 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	writer.Close()
 
 	headers := map[string]string{
-		"tag":          solutionTagFlag,
+		"stage":        "STABLE",
+		"tag":          "stable",
 		"operation":    "VALIDATE",
 		"Content-Type": writer.FormDataContentType(),
 	}
@@ -148,7 +146,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	}
 
 	if res.Valid {
-		message = fmt.Sprintf("Solution %s version %s and tag %s was successfully validated.\n", manifest.Name, manifest.SolutionVersion, solutionTagFlag)
+		message = fmt.Sprintf("Solution %s version %s was successfully validated.\n", manifest.Name, manifest.SolutionVersion)
 		//message = fmt.Sprintf("Solution bundle %s validated successfully.\n", solutionArchivePath)
 	} else {
 		message = getSolutionValidationErrorsString(res.Errors.Total, res.Errors)


### PR DESCRIPTION
Reverts cisco-open/fsoc#82 as there are additional requirements to the `--tag` support being worked on in PR #85 