### PR TITLE
hide the --tag for solution push/validate commands

### DIFF
--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -41,23 +41,23 @@ var solutionPushCmd = &cobra.Command{
 The solution manifest for the solution must be in the current directory.`,
 	Example: `
   fsoc solution push
-  fsoc solution push -w
-  fsoc solution push -w=60
-  fsoc solution push -tag=dev`,
+  fsoc solution push --wait
+  fsoc solution push --bump --wait=60`,
+	//`fsoc solution push --tag=dev`,  // WIP
 	Run:              pushSolution,
 	TraverseChildren: true,
 }
 
 func getSolutionPushCmd() *cobra.Command {
+	solutionPushCmd.Flags().
+		String("tag", "stable", "Tag to associate with provided solution.  If no value is provided, it will default to 'stable'.")
+	solutionPushCmd.Flags().MarkHidden("tag") // WIP
 
-	solutionPushCmd.Flags().IntP("wait", "w", -1, "Wait (in seconds) for the solution to be deployed (not supported when uisng --solution-bundle)")
+	solutionPushCmd.Flags().IntP("wait", "w", -1, "Wait (in seconds) for the solution to be deployed")
 	solutionPushCmd.Flag("wait").NoOptDefVal = "300"
 
 	solutionPushCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before deploying")
-
-	solutionPushCmd.Flags().
-		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 
 	solutionPushCmd.Flags().
 		String("solution-bundle", "", "fully qualified path name for the solution bundle .zip file")
@@ -66,7 +66,6 @@ func getSolutionPushCmd() *cobra.Command {
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 
 	return solutionPushCmd
-
 }
 
 func pushSolution(cmd *cobra.Command, args []string) {

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -51,7 +51,7 @@ The solution manifest for the solution must be in the current directory.`,
 func getSolutionPushCmd() *cobra.Command {
 	solutionPushCmd.Flags().
 		String("tag", "stable", "Tag to associate with provided solution.  If no value is provided, it will default to 'stable'.")
-	solutionPushCmd.Flags().MarkHidden("tag") // WIP
+	_ = solutionPushCmd.Flags().MarkHidden("tag") // WIP
 
 	solutionPushCmd.Flags().IntP("wait", "w", -1, "Wait (in seconds) for the solution to be deployed")
 	solutionPushCmd.Flag("wait").NoOptDefVal = "300"

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -62,7 +62,7 @@ var solutionValidateCmd = &cobra.Command{
 func getSolutionValidateCmd() *cobra.Command {
 	solutionValidateCmd.Flags().
 		String("tag", "stable", "Tag to associate with provided solution.  If no value is provided, it will default to 'stable'.")
-	solutionValidateCmd.Flags().MarkHidden("tag") // WIP
+	_ = solutionValidateCmd.Flags().MarkHidden("tag") // WIP
 
 	solutionValidateCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before validation")

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -49,23 +49,26 @@ func getSolutionValidateUrl() string {
 }
 
 var solutionValidateCmd = &cobra.Command{
-	Use:              "validate",
-	Args:             cobra.ExactArgs(0),
-	Short:            "Validate solution",
-	Long:             `This command allows the current tenant specified in the profile to upload the solution in the current directory just to validate its contents.`,
-	Example:          `  fsoc solution validate`,
+	Use:   "validate",
+	Args:  cobra.ExactArgs(0),
+	Short: "Validate solution",
+	Long:  `This command allows the current tenant specified in the profile to upload the solution in the current directory just to validate its contents.`,
+	Example: `  fsoc solution validate
+  fsoc solution validate --bump`,
 	Run:              validateSolution,
 	TraverseChildren: true,
 }
 
 func getSolutionValidateCmd() *cobra.Command {
 	solutionValidateCmd.Flags().
+		String("tag", "stable", "Tag to associate with provided solution.  If no value is provided, it will default to 'stable'.")
+	solutionValidateCmd.Flags().MarkHidden("tag") // WIP
+
+	solutionValidateCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before validation")
 
 	solutionValidateCmd.Flags().
 		String("solution-bundle", "", "The fully qualified path name for the solution bundle .zip file that you want to validate")
-	solutionValidateCmd.Flags().
-		String("tag", "stable", "Tag to associate with provided solution bundle.  If no value is provided, it will default to 'stable'.")
 	_ = solutionValidateCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 


### PR DESCRIPTION
## Description

* Hide the --tag for solution push/validate commands while it is being worked on (as part of PR #85)
* Touch up the command help/examples

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
