### PR TITLE
ORION-1170: add --stable flag for push and validate + cleanup

### DIFF
--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -37,12 +37,11 @@ var solutionPushCmd = &cobra.Command{
 	Use:   "push",
 	Args:  cobra.ExactArgs(0),
 	Short: "Deploy your solution",
-	// TODO: update link for tagging to official documentation when available
 	Long: `This command allows the current tenant specified in the profile to deploy a solution to the FSO Platform.
 The solution manifest for the solution must be in the current directory.  A few more important details:
 (1) The 'tags' flag is a free-form flag which means you can provide any string as a value. That being said, 'stable' is a reserved key-word for production-ready bundles.
 (2) Use caution when supplying the tag value to the solution bundle to upload as typos can result in misleading validation results.
-(3) For more info on tags, please visit: 
+(3) For more info on tags, please visit: https://developer.cisco.com/docs/fso/#!tag-a-solution
 `,
 	Example: `
   fsoc solution push

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -15,7 +15,6 @@
 package solution
 
 import (
-	// "archive/zip"
 	"bytes"
 	"fmt"
 	"io"
@@ -38,27 +37,29 @@ var solutionPushCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	Short: "Deploy your solution",
 	Long: `This command allows the current tenant specified in the profile to deploy a solution to the FSO Platform.
-The solution manifest for the solution must be in the current directory.  A few more important details:
-(1) The 'tags' flag is a free-form flag which means you can provide any string as a value. That being said, 'stable' is a reserved key-word for production-ready bundles.
-(2) Use caution when supplying the tag value to the solution bundle to upload as typos can result in misleading validation results.
-(3) For more info on tags, please visit: https://developer.cisco.com/docs/fso/#!tag-a-solution
+The solution manifest for the solution must be in the current directory.
+
+Important details on solution tags:
+(1) A tag must be associated with the solution being uploaded.  All subsequent solution upload requests should use this same tag
+(2) Use caution when supplying the tag value to the solution to upload as typos can result in misleading validation results
+(3) 'stable' is a reserved tag value keyword for production-ready versions and hence should be used appropriately
+(4) For more info on tags, please visit: https://developer.cisco.com/docs/fso/#!tag-a-solution
 `,
 	Example: `
-  fsoc solution push
-  fsoc solution push --wait
+  fsoc solution push --tag=stable
+  fsoc solution push --wait --tag=dev
   fsoc solution push --bump --wait=60
-  fsoc solution push --tag=dev
-  fsoc solution push --stable`,
+  fsoc solution push --stable --wait`,
 	Run:              pushSolution,
 	TraverseChildren: true,
 }
 
 func getSolutionPushCmd() *cobra.Command {
 	solutionPushCmd.Flags().
-		String("tag", "", "Tag to associate with provided solution.  'stable' is a reserved keyword for production-ready versions and hence should be used with caution.")
+		String("tag", "", "Free-form string tag to associate with provided solution")
 
 	solutionPushCmd.Flags().
-		Bool("stable", false, "Automatically associate the 'stable' tag with solution bundle to be deployed.  Note: 'stable' is a reserved keyword for production-ready versions and hence should be used with caution.")
+		Bool("stable", false, "Mark the solution as production-ready.  This is equivalent to supplying --tag=stable")
 
 	solutionPushCmd.Flags().IntP("wait", "w", -1, "Wait (in seconds) for the solution to be deployed")
 	solutionPushCmd.Flag("wait").NoOptDefVal = "300"

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -52,17 +52,21 @@ var solutionValidateCmd = &cobra.Command{
 	Use:   "validate",
 	Args:  cobra.ExactArgs(0),
 	Short: "Validate solution",
-	Long:  `This command allows the current tenant specified in the profile to upload the solution in the current directory just to validate its contents.`,
+	Long:  `This command allows the current tenant specified in the profile to upload the solution in the current directory just to validate its contents.  The --stable flag provides a default value of 'stable' for the tag associated with the given solution bundle.  `,
 	Example: `  fsoc solution validate
-  fsoc solution validate --bump`,
+  fsoc solution validate --bump --tag preprod
+  fsoc solution validate --tag dev
+  fsoc solution validate --stable`,
 	Run:              validateSolution,
 	TraverseChildren: true,
 }
 
 func getSolutionValidateCmd() *cobra.Command {
 	solutionValidateCmd.Flags().
-		String("tag", "stable", "Tag to associate with provided solution.  If no value is provided, it will default to 'stable'.")
-	_ = solutionValidateCmd.Flags().MarkHidden("tag") // WIP
+		String("tag", "", "Tag to associate with provided solution.  Ensure tag used for validation & upload are same.")
+
+	solutionValidateCmd.Flags().
+		Bool("stable", false, "Automatically associate the 'stable' tag with solution bundle to be validate.  This should only be used for validating solutions uploaded with the 'stable' tag.")
 
 	solutionValidateCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before validation")
@@ -71,6 +75,7 @@ func getSolutionValidateCmd() *cobra.Command {
 		String("solution-bundle", "", "The fully qualified path name for the solution bundle .zip file that you want to validate")
 	_ = solutionValidateCmd.Flags().MarkDeprecated("solution-bundle", "it is no longer available.")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
+	solutionValidateCmd.MarkFlagsMutuallyExclusive("tag", "stable")
 
 	return solutionValidateCmd
 }
@@ -81,6 +86,11 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
 	solutionTagFlag, _ := cmd.Flags().GetString("tag")
+	pushWithStableTag, _ := cmd.Flags().GetBool("stable")
+
+	if pushWithStableTag {
+		solutionTagFlag = "stable"
+	}
 
 	if solutionBundlePath != "" {
 		log.Fatalf("The --solution-bundle flag is no longer available; please use direct validate instead.")


### PR DESCRIPTION
## Description

Adding functionality for providing a --stable flag to push and validate that supplies tag: stable.  Also improved the --help command output.  Still TODO: add link to placeholder page for solution tagging documentation for the output of the push and validate --help commands.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
