### PR TITLE
Fix EOF error for `fsoc solution check --all` command

### DIFF
--- a/cmd/solution/check.go
+++ b/cmd/solution/check.go
@@ -125,7 +125,7 @@ func checkComponentDef(cmd *cobra.Command, compDef ComponentDef, cfg *config.Con
 	if err != nil {
 		log.Errorf("Couldn't marshal schema to json: %v", err)
 	}
-	schemaLoader, _ := gojsonschema.NewReaderLoader(w)
+	schemaLoader := gojsonschema.NewStringLoader(w.String())
 
 	compDefFile := openFile(compDef.ObjectsFile)
 	defer compDefFile.Close()
@@ -148,7 +148,7 @@ func checkComponentDef(cmd *cobra.Command, compDef ComponentDef, cfg *config.Con
 			if err != nil {
 				log.Errorf("Couldn't marshal object to json: %v", err)
 			}
-			documentLoader, _ := gojsonschema.NewReaderLoader(w)
+			documentLoader := gojsonschema.NewStringLoader(w.String())
 			validate(cmd, schemaLoader, documentLoader, compDef)
 		}
 	} else {


### PR DESCRIPTION
- Use gojsonschema.NewStringLoader() instead of NewReaderLoader()

## Description

```shell
solution$ fsoc solution check --all
   • Current token is no longer valid; trying to refresh
✓ Exchange service principal for auth token
✓ Platform API call, retry after login (GET /objstore/v1beta/types/fmm:namespace)
   ⨯ Schema validation failed: EOF
```
With Fix:
```shell
solution$ /Users/cnadimin/GitHub/cisco-open/fsoc/fsoc solution check --all
✓ Platform API call (GET /objstore/v1beta/types/fmm:namespace)
The components defined in the file "model/namespace.json" are valid definitions of type "fmm:namespace" 
✓ Platform API call (GET /objstore/v1beta/types/fmm:entity)
The components defined in the file "model/entities.json" are valid definitions of type "fmm:entity" 
✓ Platform API call (GET /objstore/v1beta/types/fmm:event)
The components defined in the file "events/events.json" are valid definitions of type "fmm:event" 
✓ Platform API call (GET /objstore/v1beta/types/fmm:extension)
The components defined in the file "model/extension.json" are valid definitions of type "fmm:extension" 
The components defined in the file "model/extension.json" are valid definitions of type "fmm:extension" 
✓ Platform API call (GET /objstore/v1beta/types/fmm:metric)
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
The components defined in the file "model/metrics.json" are valid definitions of type "fmm:metric" 
✓ Platform API call (GET /objstore/v1beta/types/fmm:metricAggregation)
The components defined in the file "model/metric-aggregations.json" are valid definitions of type "fmm:metricAggregation" 
solution$ 
```

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
