### PR TITLE
FSOC-134: add more information to the --type flag in knowledge commands

### DIFF
--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -44,7 +44,7 @@ Example:
 
 func getCreateObjectCmd() *cobra.Command {
 	objStoreInsertCmd.Flags().
-		String("type", "", "The fully qualified type name of the knowledge object to create")
+		String("type", "", "The fully qualified type name of the knowledge object to create.  The fully qualified type name follows the format solutionName:typeName (e.g. extensibility:solution)")
 	_ = objStoreInsertCmd.MarkPersistentFlagRequired("type")
 
 	objStoreInsertCmd.Flags().

--- a/cmd/knowledge/delete.go
+++ b/cmd/knowledge/delete.go
@@ -44,7 +44,7 @@ Usage:
 
 func getDeleteObjectCmd() *cobra.Command {
 	objStoreDeleteCmd.Flags().
-		String("type", "", "The fully qualified type name of the knowledge object to delete")
+		String("type", "", "The fully qualified type name of the knowledge object to delete.  The fully qualified type name follows the format solutionName:typeName (e.g. extensibility:solution)")
 	_ = objStoreDeleteCmd.MarkPersistentFlagRequired("type")
 
 	objStoreDeleteCmd.Flags().

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -56,7 +56,7 @@ func newGetObjectCmd() *cobra.Command {
 	// get object
 
 	getCmd.PersistentFlags().
-		String("type", "", "Fully qualified type name of knowledge object. It will be formed by combining the solution which defined the type and the type name")
+		String("type", "", "Fully qualified type name of knowledge object.  The fully qualified type name follows the format solutionName:typeName (e.g. extensibility:solution)")
 
 	getCmd.PersistentFlags().String("object-id", "", "Object ID of the knowledge object to fetch")
 	getCmd.PersistentFlags().String("layer-id", "", "Layer ID of the related knowledge object to fetch")

--- a/cmd/knowledge/update.go
+++ b/cmd/knowledge/update.go
@@ -53,7 +53,7 @@ var objStoreUpdateCmd = &cobra.Command{
 
 func getUpdateObjectCmd() *cobra.Command {
 	objStoreUpdateCmd.Flags().
-		String("type", "", "The fully qualified type name of the related knowledge object to update")
+		String("type", "", "The fully qualified type name of the related knowledge object to update.  The fully qualified type name follows the format solutionName:typeName (e.g. extensibility:solution)")
 	_ = objStoreUpdateCmd.MarkPersistentFlagRequired("type")
 
 	objStoreUpdateCmd.Flags().


### PR DESCRIPTION
## Description

In this PR, we are adding some more informative text related to the --type flag used in the knowledge commands.  Specifically, we are outlining what the format of the fully qualified type name is (this was missing earlier but we were mentioning it).

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
