### PR TITLE
Moved zip files created as part of solution commands to temp folder

### DIFF
--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -131,7 +131,6 @@ func manifestExists(fileSystem afero.Fs, forkName string) bool {
 }
 
 func extractZip(rootFileSystem afero.Fs, fileSystem afero.Fs, solutionName string) error {
-	println("./" + solutionName + ".zip")
 	zipFile, err := rootFileSystem.OpenFile("./"+solutionName+".zip", os.O_RDONLY, os.FileMode(0644))
 	if err != nil {
 		log.Fatalf("Error opening zip file: %v", err)

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -45,7 +45,8 @@ func generateZip(cmd *cobra.Command, sltnPackagePath string) *os.File {
 	archiveFileTemplate := fmt.Sprintf("%s*.zip", solutionName)
 
 	archive, err := os.CreateTemp("", archiveFileTemplate)
-	output.PrintCmdStatus(cmd, fmt.Sprintf("Creating archive zip at %s \n", archive.Name()))
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Creating archive zip (%q)\n", archive.Name()))
+	log.WithField("path", archive.Name()).Info("Creating solution bundle file")
 	if err != nil {
 		log.Fatalf("failed to create file: %s", archive.Name())
 		panic(err)
@@ -85,7 +86,8 @@ func generateZip(cmd *cobra.Command, sltnPackagePath string) *os.File {
 		log.Fatalf("Error traversing the folder: %v", err)
 	}
 	zipWriter.Close()
-	log.Infof("Created a temporary zip file: %s", archive.Name())
+	log.WithField("path", archive.Name()).Info("Created a temporary solution bundle file")
+
 	return archive
 }
 

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -42,10 +42,12 @@ func getSolutionPackageCmd() *cobra.Command {
 
 func generateZip(cmd *cobra.Command, sltnPackagePath string) *os.File {
 	solutionName := filepath.Base(sltnPackagePath)
-	archiveFileName := fmt.Sprintf("%s.zip", solutionName)
-	output.PrintCmdStatus(cmd, fmt.Sprintf("Creating %s archive... \n", archiveFileName))
-	archive, err := os.Create(archiveFileName)
+	archiveFileTemplate := fmt.Sprintf("%s*.zip", solutionName)
+
+	archive, err := os.CreateTemp("", archiveFileTemplate)
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Creating archive zip at %s \n", archive.Name()))
 	if err != nil {
+		log.Fatalf("failed to create file: %s", archive.Name())
 		panic(err)
 	}
 	defer archive.Close()
@@ -83,7 +85,7 @@ func generateZip(cmd *cobra.Command, sltnPackagePath string) *os.File {
 		log.Fatalf("Error traversing the folder: %v", err)
 	}
 	zipWriter.Close()
-
+	log.Infof("Created a temporary zip file: %s", archive.Name())
 	return archive
 }
 

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -124,9 +124,8 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	solutionVersion = manifest.SolutionVersion
 
 	// create a temporary solution archive
-	// solutionArchive := generateZipNoCmd(manifestPath)
 	solutionArchive := generateZip(cmd, manifestPath)
-	solutionArchivePath = (solutionArchive.Name())
+	solutionArchivePath = solutionArchive.Name()
 
 	message := fmt.Sprintf("Deploying solution %s version %s with tag %s", manifest.Name, manifest.SolutionVersion, solutionTagFlag)
 	log.WithFields(log.Fields{"solution": manifest.Name, "version": manifest.SolutionVersion}).Info("Deploying solution")

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -21,7 +21,6 @@ import (
 	"mime/multipart"
 	"net/url"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/apex/log"
@@ -127,7 +126,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	// create a temporary solution archive
 	// solutionArchive := generateZipNoCmd(manifestPath)
 	solutionArchive := generateZip(cmd, manifestPath)
-	solutionArchivePath = filepath.Base(solutionArchive.Name())
+	solutionArchivePath = (solutionArchive.Name())
 
 	message := fmt.Sprintf("Deploying solution %s version %s with tag %s", manifest.Name, manifest.SolutionVersion, solutionTagFlag)
 	log.WithFields(log.Fields{"solution": manifest.Name, "version": manifest.SolutionVersion}).Info("Deploying solution")

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -118,7 +118,6 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	}
 
 	// create a temporary solution archive
-	// solutionArchive := generateZipNoCmd(manifestPath)
 	solutionArchive := generateZip(cmd, manifestPath)
 	solutionArchivePath = solutionArchive.Name()
 
@@ -160,7 +159,6 @@ func validateSolution(cmd *cobra.Command, args []string) {
 
 	if res.Valid {
 		message = fmt.Sprintf("Solution %s version %s and tag %s was successfully validated.\n", manifest.Name, manifest.SolutionVersion, solutionTagFlag)
-		//message = fmt.Sprintf("Solution bundle %s validated successfully.\n", solutionArchivePath)
 	} else {
 		message = getSolutionValidationErrorsString(res.Errors.Total, res.Errors)
 	}

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"mime/multipart"
 	"os"
-	"path/filepath"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
@@ -121,10 +120,9 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	// create a temporary solution archive
 	// solutionArchive := generateZipNoCmd(manifestPath)
 	solutionArchive := generateZip(cmd, manifestPath)
-	solutionArchivePath = filepath.Base(solutionArchive.Name())
+	solutionArchivePath = solutionArchive.Name()
 
 	var message string
-
 	file, err := os.Open(solutionArchivePath)
 	if err != nil {
 		log.Fatalf("Failed to open file %q: %v", solutionArchivePath, err)


### PR DESCRIPTION
## Description

Many solution commands (e.g., `push`, `validate`) create temporary solution bundle files (zip archives). This PR moves these files to system's temp directory, so that they are not placed in the current working directory. The path to the file is displayed and logged.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass

Co-authored-by: GDW1 <guwilks@cisco.com>