### PR TITLE
ORION-1255: add --solution-path argument back to solution validate + push + package + add support for output directory

### DIFF
--- a/cmd/solution/isolate.go
+++ b/cmd/solution/isolate.go
@@ -173,7 +173,7 @@ func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, ta
 
 	// create zip if requested
 	if targetFile != "" {
-		zipFile := generateZip(cmd, targetPath)
+		zipFile := generateZip(cmd, targetPath, "")
 		err = os.Rename(zipFile.Name(), targetFile)
 		if err != nil {
 			return "", fmt.Errorf("Failed to rename temp file %q to final file %q: %w", zipFile.Name(), targetFile, err)

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -44,7 +44,7 @@ func getSolutionPackageCmd() *cobra.Command {
 		String("solution-bundle", "", "fully qualified path name to directory where you want the packaged solution to exist after creation.  If this isn't specified, the solution zip will be created and stored in a temp directory (the path to which will be specified in the output of the command)")
 
 	solutionPackageCmd.Flags().
-		String("directory", "", "fully qualified path name of the solution folder to be zipped")
+		StringP("directory", "d", "", "fully qualified path name of the solution folder to be zipped")
 
 	return solutionPackageCmd
 }

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -33,47 +33,48 @@ var solutionPackageCmd = &cobra.Command{
 	Use:   "package",
 	Short: "Package solution folder into .zip file",
 	Long:  `This command allows the user to turn their solution folder into a zip file from the command line directly`,
-	Example: `  fsoc solution package --bundle-path <path/to/solution/root/folder>
-  fsoc solution package --bundle-path <path/to/solution/root/folder> --output-directory <path/to/directory/where/zip/should/exist>`,
+	Example: `  fsoc solution package --directory <path/to/solution/root/folder>
+  fsoc solution package --directory <path/to/solution/root/folder> --solution-bundle <path/to/directory/where/zip/should/exist>`,
 	Run: packageSolution,
 }
 
 func getSolutionPackageCmd() *cobra.Command {
 
 	solutionPackageCmd.Flags().
-		String("bundle-path", "", "fully qualified path name for the solution root folder")
-
-	_ = solutionPackageCmd.MarkFlagRequired("bundle-path")
+		String("solution-bundle", "", "fully qualified path name to directory where you want the packaged solution to exist after creation.  If this isn't specified, the solution zip will be created and stored in a temp directory (the path to which will be specified in the output of the command)")
 
 	solutionPackageCmd.Flags().
-		String("output-directory", "", "fully qualified path name to directory where you want the packaged solution to exist after creation.  If this isn't specified, the solution zip will be created and stored in a temp directory (the path to which will be specified in the output of the command)")
+		String("directory", "", "fully qualified path name of the solution folder to be zipped")
 
 	return solutionPackageCmd
 }
 
 func packageSolution(cmd *cobra.Command, args []string) {
-	solutionPackagePath, _ := cmd.Flags().GetString("bundle-path")
-	outputDirectoryPath, _ := cmd.Flags().GetString("output-directory")
+	solutionDirectoryPath, _ := cmd.Flags().GetString("directory")
+	outputDirectoryPath, _ := cmd.Flags().GetString("solution-bundle")
 
-	if solutionPackagePath == "" {
-		log.Fatal("bundle-path cannot be empty, use --bundle-path=<solution-root-folder-file-path>")
+	if solutionDirectoryPath == "" {
+		currentDir, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		solutionDirectoryPath = currentDir
 	}
-	if !isSolutionPackageRoot(solutionPackagePath) {
-		log.Fatal("bundle-path path doesn't point to a solution root folder")
+	if !isSolutionPackageRoot(solutionDirectoryPath) {
+		log.Fatal("directory flag doesn't point to a solution root folder")
 	}
-	manifest, err := getSolutionManifest(solutionPackagePath)
+	manifest, err := getSolutionManifest(solutionDirectoryPath)
 	if err != nil {
 		log.Fatalf("Failed to read solution manifest: %v", err)
 	}
-
 	var message string
 	message = fmt.Sprintf("Generating solution %s - %s bundle archive \n", manifest.Name, manifest.SolutionVersion)
 	log.WithFields(log.Fields{
-		"bundle-path": solutionPackagePath,
+		"solution-bundle": solutionDirectoryPath,
 	}).Info(message)
 
 	output.PrintCmdStatus(cmd, message)
-	solutionArchive := generateZip(cmd, solutionPackagePath, outputDirectoryPath)
+	solutionArchive := generateZip(cmd, solutionDirectoryPath, outputDirectoryPath)
 	solutionArchive.Close()
 
 	message = fmt.Sprintf("Solution %s - %s bundle is ready. \n", manifest.Name, manifest.SolutionVersion)
@@ -81,16 +82,18 @@ func packageSolution(cmd *cobra.Command, args []string) {
 }
 
 // Helper functions for managing solution directory and zip bundle
-
 func generateZip(cmd *cobra.Command, sltnPackagePath string, outputDirectoryPath string) *os.File {
 	var archive *os.File
 	var err error
 	var archiveFileTemplate string
 	solutionName := filepath.Base(sltnPackagePath)
+	solutionNameWithZipSuffix := fmt.Sprintf("%s.zip", solutionName)
 
 	if outputDirectoryPath != "" {
-		archiveFileTemplate = fmt.Sprintf("%s.zip", solutionName)
-		archive, err = os.Create(archiveFileTemplate)
+		if filepath.Base(outputDirectoryPath) != solutionNameWithZipSuffix {
+			outputDirectoryPath = filepath.Join(filepath.Dir(outputDirectoryPath), solutionNameWithZipSuffix)
+		}
+		archive, err = os.Create(outputDirectoryPath)
 	} else {
 		archiveFileTemplate = fmt.Sprintf("%s*.zip", solutionName)
 		archive, err = os.CreateTemp("", archiveFileTemplate)

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -130,7 +130,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	solutionBundleAlreadyZipped = strings.HasSuffix(solutionArchivePath, ".zip")
 
 	if !solutionBundleAlreadyZipped {
-		solutionArchive := generateZip(cmd, manifestPath)
+		solutionArchive := generateZip(cmd, manifestPath, "")
 		solutionArchivePath = solutionArchive.Name()
 	} else {
 		message = fmt.Sprintf("Deploying already zipped solution with tag %s", solutionTagFlag)

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -21,7 +21,6 @@ import (
 	"mime/multipart"
 	"net/url"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -69,7 +68,7 @@ func getSolutionPushCmd() *cobra.Command {
 		BoolP("bump", "b", false, "Increment the patch version before deploying")
 
 	solutionPushCmd.Flags().
-		String("bundle-path", "", "fully qualified path name for the solution bundle .zip file")
+		String("bundle-path", "", "fully qualified path name for the solution bundle (can be .zip or a folder)")
 	solutionPushCmd.MarkFlagsMutuallyExclusive("bundle-path", "wait")
 	solutionPushCmd.MarkFlagsMutuallyExclusive("bundle-path", "bump")
 	solutionPushCmd.MarkFlagsMutuallyExclusive("tag", "stable")
@@ -125,14 +124,14 @@ func pushSolution(cmd *cobra.Command, args []string) {
 	} else {
 		manifestPath = solutionBundlePath
 		solutionArchivePath = manifestPath
-		message = fmt.Sprintf("Deploying solution specified with path %s with tag %s", solutionArchivePath, solutionTagFlag)
+		message = fmt.Sprintf("Zipping and deploying solution specified with path %s with tag %s", solutionArchivePath, solutionTagFlag)
 	}
 
 	solutionBundleAlreadyZipped = strings.HasSuffix(solutionArchivePath, ".zip")
 
 	if !solutionBundleAlreadyZipped {
 		solutionArchive := generateZip(cmd, manifestPath)
-		solutionArchivePath = filepath.Base(solutionArchive.Name())
+		solutionArchivePath = solutionArchive.Name()
 	} else {
 		message = fmt.Sprintf("Deploying already zipped solution with tag %s", solutionTagFlag)
 	}
@@ -212,7 +211,7 @@ func pushSolution(cmd *cobra.Command, args []string) {
 		}
 		fmt.Println(" Done")
 	}
-	message = fmt.Sprintf("Solution was successfully deployed.\n")
+	message = fmt.Sprintf("Solution with tag %s was successfully deployed.\n", solutionTagFlag)
 	output.PrintCmdStatus(cmd, message)
 }
 

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -131,7 +131,7 @@ func validateSolution(cmd *cobra.Command, args []string) {
 	solutionBundleAlreadyZipped = strings.HasSuffix(solutionArchivePath, ".zip")
 
 	if !solutionBundleAlreadyZipped {
-		solutionArchive := generateZip(cmd, manifestPath)
+		solutionArchive := generateZip(cmd, manifestPath, "")
 		solutionArchivePath = solutionArchive.Name()
 	} else {
 		message = fmt.Sprintf("Validating already zipped solution with tag %s", solutionTagFlag)


### PR DESCRIPTION
## Description

In this PR, we are adding support for a --bundle-path argument to the fsoc solution push/validate/package commands.  This will be very helpful for our users who want to automate their solution lifecycle in some ci/cd environment.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
