### PR TITLE
initial support for fsoc-supported solution isolation

### DIFF
--- a/cmd/solution/embed-isolate.go
+++ b/cmd/solution/embed-isolate.go
@@ -1,0 +1,119 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+// embeddedConditionalIsolate prepares a finalized version of a solution directory
+// in a way that's ready to pass to the platform. If the solution supports isolation
+// (i.e., uses templates in the manifest/objects), then this function ensures that
+// template vars are fully replaced. The function is specifically made to be convenient
+// to call from handlers of cobra commands and rely on common definition of flags.
+// To perform isolation without command dependencies, use isolateSolution()
+func embeddedConditionalIsolate(cmd *cobra.Command, sourceDir string) (string, error) {
+	// don't try to isolate if --no-isolate is specified (ignored if flag not defined)
+	noIsolate, _ := cmd.Flags().GetBool("no-isolate")
+	if noIsolate {
+		return sourceDir, nil
+	}
+
+	// return the solution folder as is if the manifest does not use isolation
+	manifest, err := getSolutionManifest(sourceDir)
+	if err != nil {
+		return "", err
+	}
+	if !strings.Contains(manifest.Name, "${") {
+		//TODO: consider failing if env vars file is specified/present
+		//      as this is doesn't make sense for solutions that don't support isolation
+		return sourceDir, nil
+	}
+
+	// finalize flags
+	tag, envVarsFile := determineTagEnvFile(cmd, sourceDir)
+
+	// prepare target directory
+	// TODO: instead of fsoc as prefix, use as much as we can extract from the solution name
+	//       in the manifest (assuming "<solution-name>${<something>}", the idea is to extract <solution-name>
+	//       and use that as a prefix). This will have only cosmetic advantages.
+	targetDir, err := os.MkdirTemp("", "fsoc")
+	if err != nil {
+		return "", fmt.Errorf("Failed to create a temporary directory: %v", err)
+	}
+	log.WithField("temp_solution_dir", targetDir).Info("Assembling solution in temp target directory")
+
+	// render templates to produce the final solution
+	name, err := isolateSolution(cmd, sourceDir, targetDir, "", tag, envVarsFile)
+	if err != nil {
+		os.RemoveAll(targetDir)
+		return "", nil
+	}
+
+	log.WithFields(log.Fields{
+		"isolated_solution_name": name,
+		"from_directory":         sourceDir,
+		"to_directory":           targetDir,
+	}).Info("Isolated solution")
+
+	return targetDir, nil
+}
+
+func determineTagEnvFile(cmd *cobra.Command, sourceDir string) (string, string) {
+	// if --tag flag is specified, this overrides everything
+	if cmd.Flags().Changed("tag") {
+		tag, _ := cmd.Flags().GetString("tag")
+		return tag, ""
+	}
+
+	// if --stable is specified, treat the same as tag
+	stable, _ := cmd.Flags().GetBool("stable")
+	if stable {
+		return "stable", ""
+	}
+
+	// if env var with tag is defined, it overrides env file
+	envTag, found := os.LookupEnv("FSOC_SOLUTION_TAG")
+	if found {
+		return envTag, ""
+	}
+
+	// try to determine env.json file path
+	fnameSpecified := cmd.Flags().Changed("env-file")
+	fname := ""
+	if fnameSpecified {
+		fname, _ = cmd.Flags().GetString("env-file")
+	} else {
+		fname = filepath.Join(sourceDir, "env.json")
+	}
+	if fname != "" {
+		_, err := os.Stat(fname)
+		if err == nil {
+			return "", fname
+		}
+	}
+	if fnameSpecified {
+		log.Fatalf("Env file %q not found", fname)
+	}
+
+	log.Fatalf("Tag must be specified (--tag, --stable, FSOC_SOLUTION_TAG env var or env.json file)")
+	return "", "" // should never happen, keep linters happy
+}

--- a/cmd/solution/isolate.go
+++ b/cmd/solution/isolate.go
@@ -180,6 +180,8 @@ func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, ta
 		}
 	}
 
+	log.Info("Pseudo-isolation successfully completed")
+
 	return mf.Name, nil
 }
 

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -55,15 +55,21 @@ func getSolutionPushCmd() *cobra.Command {
 		BoolP("bump", "b", false, "Increment the patch version before deploying")
 
 	solutionPushCmd.Flags().
-		StringP("directory", "d", "", "fully qualified path name for the solution root folder")
+		StringP("directory", "d", "", "Path to the solution root directory (defaults to current dir)")
 
 	solutionPushCmd.Flags().
-		String("solution-bundle", "", "fully qualified path name for solution bundle (this argument expects that the solution is already packaged into a zip file)")
+		String("solution-bundle", "", "Path to a prepackaged solution zip bundle")
+
+	solutionPushCmd.Flags().
+		String("env-file", "", "Path to the env vars json file with isolation tag and, optionally, dependency tags")
+
+	solutionPushCmd.Flags().
+		Bool("no-isolate", false, "Disable fsoc-supported solution isolation")
 
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "directory") // either solution dir or prepackaged zip
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")      // cannot modify prepackaged zip
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "wait")      // TODO: allow when extracting manifest data
-	solutionPushCmd.MarkFlagsMutuallyExclusive("tag", "stable")                // stable is an alias for --tag=stable
+	solutionPushCmd.MarkFlagsMutuallyExclusive("tag", "stable", "env-file")    // stable is an alias for --tag=stable
 
 	return solutionPushCmd
 }

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -59,15 +59,21 @@ func getSolutionValidateCmd() *cobra.Command {
 		BoolP("bump", "b", false, "Increment the patch version before validation")
 
 	solutionValidateCmd.Flags().
-		StringP("directory", "d", "", "fully qualified path name for the solution bundle that you want to validate (assumes that the solution folder has not been zipped yet)")
+		StringP("directory", "d", "", "Path to the solution root directory (defaults to current dir)")
 
 	solutionValidateCmd.Flags().
-		String("solution-bundle", "", "fully qualified path name for the solution bundle (assumes that the solution folder has already been zipped)")
+		String("solution-bundle", "", "Path to a prepackaged solution zip bundle")
 
-	solutionValidateCmd.MarkFlagsMutuallyExclusive("directory", "solution-bundle")
+	solutionValidateCmd.Flags().
+		String("env-file", "", "Path to the env vars json file with isolation tag and, optionally, dependency tags")
+
+	solutionValidateCmd.Flags().
+		Bool("no-isolate", false, "Disable fsoc-supported solution isolation")
+
+	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "directory")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")
 
-	solutionValidateCmd.MarkFlagsMutuallyExclusive("tag", "stable")
+	solutionValidateCmd.MarkFlagsMutuallyExclusive("tag", "stable", "env-file")
 
 	return solutionValidateCmd
 }


### PR DESCRIPTION
## Description

Added fsoc-supported (pseudo) solution isolation. The following `solution` commands now can created isolated solutions:
- `package`
- `push`
- `validate`

Only solutions with `${}` variables in their manifest are attempted to be isolated; a --no-isolate flag disables the automatic isolation.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
