### PR TITLE
Support env vars to set config file and/or profile

### DIFF
--- a/cmd/solution/bump.go
+++ b/cmd/solution/bump.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 )
 
@@ -32,6 +33,7 @@ it for validation or push.`,
 	Example:          `  fsoc solution bump`,
 	Args:             cobra.ExactArgs(0),
 	Run:              bumpSolutionVersion,
+	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
 	TraverseChildren: true,
 }
 

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 )
 
@@ -34,6 +35,7 @@ var solutionExtendCmd = &cobra.Command{
 	Long:             `This command allows you to easily add new components to your solution package.`,
 	Example:          `  fsoc solution extend --add-knowledge=<knowldgetypename>`,
 	Run:              extendSolution,
+	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
 	TraverseChildren: true,
 }
 

--- a/cmd/solution/isolate.go
+++ b/cmd/solution/isolate.go
@@ -65,7 +65,7 @@ Note that when the --tag flag is used, the env.json file is ignored and no depen
 
 The command takes the solution from current directory (or --source-dir) and produces the isolated version either in a directory (if --target-dir is specified) or in a solution zip file (if --target-file is specified).
 
-Note that this command is experimental at this time and it may change or be removed.
+Note that this command is experimental and will likely be removed. Please use "push", "validate" or "package" directly.
 
 See documentation for manifest syntax and examples (link to be added here).
 `,
@@ -76,6 +76,7 @@ See documentation for manifest syntax and examples (link to be added here).
 	`,
 	Run:         solutionIsolateCommand,
 	Annotations: map[string]string{config.AnnotationForConfigBypass: ""},
+	Deprecated:  "please use `push`, `validate` or `package` instead",
 }
 
 func getsolutionIsolateCmd() *cobra.Command {

--- a/cmd/solution/isolate.go
+++ b/cmd/solution/isolate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 )
 
@@ -73,7 +74,8 @@ See documentation for manifest syntax and examples (link to be added here).
   fsoc solution isolate --target-file=../mysolution-release.zip --tag=stable
   fsoc solution isolate --source-dir=mysolution --target-dir=mysolution-staging --env-file=staging-env.json
 	`,
-	Run: solutionIsolateCommand,
+	Run:         solutionIsolateCommand,
+	Annotations: map[string]string{config.AnnotationForConfigBypass: ""},
 }
 
 func getsolutionIsolateCmd() *cobra.Command {

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 )
 
@@ -49,7 +50,8 @@ on convenience and use cases. The following priority is available:
 `,
 	Example: `  fsoc solution package --solution-bundle=../mysolution.zip
   fsoc solution package -d mysolution --solution-bundle=/somepath/mysolution-1234.zip`,
-	Run: packageSolution,
+	Run:         packageSolution,
+	Annotations: map[string]string{config.AnnotationForConfigBypass: ""},
 }
 
 func getSolutionPackageCmd() *cobra.Command {


### PR DESCRIPTION
## Description

Added support for FSOC_CONFIG and FSOC_PROFILE environment variables to set the config file and profile to use, respectively. The command line flags, if specified, take precedence. (FSOC-151)

Also fixed solution `bump`, `extend`, `isolate` and `package' to not require config file/auth (as it is not needed for these commands)

## Type of Change

- [X] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
