### PR TITLE
ORION-1357: remove references to solution package and bundle in fsoc orion commands

### DIFF
--- a/cmd/solution/check.go
+++ b/cmd/solution/check.go
@@ -34,7 +34,7 @@ var solutionCheckCmd = &cobra.Command{
 	Use:              "check",
 	Args:             cobra.ExactArgs(0),
 	Short:            "Validate your solution component definitions",
-	Long:             `This command allows the current tenant specified in the profile to build and package a solution bundle to be deployed into the FSO Platform.`,
+	Long:             `This command allows the current tenant specified in the profile to check whether or not each FMM Knowledge Object inside their solution is valid.`,
 	Example:          `  fsoc solution check --entities --metrics`,
 	Run:              checkSolution,
 	TraverseChildren: true,
@@ -42,13 +42,13 @@ var solutionCheckCmd = &cobra.Command{
 
 func getSolutionCheckCmd() *cobra.Command {
 	solutionCheckCmd.Flags().
-		Bool("entities", false, "Validate all the entities and associations components defined in this solution package")
+		Bool("entities", false, "Validate all the entities and associations components defined in this solution")
 
 	solutionCheckCmd.Flags().
-		Bool("metrics", false, "Validate all the metrics, metricmappings and metricaggregations components defined in this solution package")
+		Bool("metrics", false, "Validate all the metrics, metricmappings and metricaggregations components defined in this solution")
 
 	solutionCheckCmd.Flags().
-		Bool("all", false, "Validate all the fmm components defined in this solution package")
+		Bool("all", false, "Validate all the fmm components defined in this solution")
 
 	return solutionCheckCmd
 }

--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -60,7 +60,7 @@ func downloadSolution(cmd *cobra.Command, args []string) {
 		log.Fatalf("Solution download command failed: %v", err)
 	}
 
-	message := fmt.Sprintf("Solution bundle %q with tag %s downloaded successfully.\n", solutionName, solutionTagFlag)
+	message := fmt.Sprintf("Solution %q with tag %s downloaded successfully.\n", solutionName, solutionTagFlag)
 	output.PrintCmdStatus(cmd, message)
 }
 

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -74,7 +74,7 @@ func extendSolution(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed("add-knowledge") {
 		componentName, _ := cmd.Flags().GetString("add-knowledge")
 		componentName = strings.ToLower(componentName)
-		output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %s knowledge component to %s's solution folder structure... \n", componentName, manifest.Name))
+		output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %s knowledge component to %s's solution directory structure... \n", componentName, manifest.Name))
 		folderName := "types"
 		fileName := fmt.Sprintf("%s.json", componentName)
 		output.PrintCmdStatus(cmd, fmt.Sprintf("Creating the %s file\n", fileName))

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -31,8 +31,8 @@ import (
 var solutionExtendCmd = &cobra.Command{
 	Use:              "extend",
 	Args:             cobra.ExactArgs(0),
-	Short:            "Extends your solution package by adding new components",
-	Long:             `This command allows you to easily add new components to your solution package.`,
+	Short:            "Extends your solution by adding new components",
+	Long:             `This command allows you to easily add new components to your solution.`,
 	Example:          `  fsoc solution extend --add-knowledge=<knowldgetypename>`,
 	Run:              extendSolution,
 	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
@@ -74,7 +74,7 @@ func extendSolution(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed("add-knowledge") {
 		componentName, _ := cmd.Flags().GetString("add-knowledge")
 		componentName = strings.ToLower(componentName)
-		output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %s knowledge component to %s's solution package folder structure... \n", componentName, manifest.Name))
+		output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %s knowledge component to %s's solution folder structure... \n", componentName, manifest.Name))
 		folderName := "types"
 		fileName := fmt.Sprintf("%s.json", componentName)
 		output.PrintCmdStatus(cmd, fmt.Sprintf("Creating the %s file\n", fileName))

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -34,7 +34,7 @@ import (
 var solutionForkCmd = &cobra.Command{
 	Use:     "fork <solution-name> <target-name>",
 	Args:    cobra.MaximumNArgs(2),
-	Short:   "Fork a solution into the specified folder",
+	Short:   "Fork a solution into the specified directory",
 	Long:    `This command downloads the specified solution into the current directory and changes its name to <target-name>`,
 	Example: `  fsoc solution fork spacefleet myfleet`,
 	Run:     solutionForkCommand,
@@ -77,13 +77,13 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 	fileSystemRoot := afero.NewBasePathFs(afero.NewOsFs(), currentDirectory)
 
 	if solutionNameFolderInvalid(fileSystemRoot, forkName) {
-		log.Fatalf(fmt.Sprintf("A non empty folder with the name %s already exists", forkName))
+		log.Fatalf(fmt.Sprintf("A non empty directory with the name %s already exists", forkName))
 	}
 
 	fileSystem := afero.NewBasePathFs(afero.NewOsFs(), currentDirectory+"/"+forkName)
 
 	if manifestExists(fileSystem, forkName) {
-		log.Fatalf("There is already a manifest file in this folder")
+		log.Fatalf("There is already a manifest file in this directory")
 	}
 
 	downloadSolutionZip(cmd, solutionName, forkName)
@@ -112,11 +112,11 @@ func solutionNameFolderInvalid(fileSystem afero.Fs, forkName string) bool {
 	} else {
 		err := fileSystem.Mkdir(forkName, os.ModeDir)
 		if err != nil {
-			log.Fatalf("Failed to create folder in this directory")
+			log.Fatalf("Failed to create directory in this directory")
 		}
 		err = os.Chmod(forkName, 0700)
 		if err != nil {
-			log.Fatalf("Failed to set permission on folder")
+			log.Fatalf("Failed to set permission on directory")
 		}
 	}
 	return false

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -190,7 +190,7 @@ func downloadSolutionZip(cmd *cobra.Command, solutionName string, forkName strin
 		log.Fatalf("Solution download failed: %v", err)
 	}
 
-	message = fmt.Sprintf("Solution bundle %s was successfully downloaded in the this directory.\r\n", solutionName)
+	message = fmt.Sprintf("Solution %s was successfully downloaded in the this directory.\r\n", solutionName)
 	output.PrintCmdStatus(cmd, message)
 
 	message = fmt.Sprintf("Changing solution name in manifest to %s.\r\n", forkName)

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -67,7 +67,7 @@ func generateSolutionPackage(cmd *cobra.Command, args []string) {
 	solutionName := getSolutionNameFromArgs(cmd, args, "name")
 	solutionName = strings.ToLower(solutionName)
 
-	output.PrintCmdStatus(cmd, fmt.Sprintf("Preparing the solution folder structure for %q... \n", solutionName))
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Preparing the solution directory structure for %q... \n", solutionName))
 
 	if err := os.Mkdir(solutionName, os.ModePerm); err != nil {
 		log.Fatal(err.Error())

--- a/cmd/solution/isolate.go
+++ b/cmd/solution/isolate.go
@@ -147,7 +147,7 @@ func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, ta
 		dirName := zipFileName[:len(zipFileName)-len(filepath.Ext(zipFileName))]
 		tempDir := filepath.Join(tempDirRoot, dirName)
 		if targetPath, err = filepath.Abs(tempDir); err != nil {
-			return "", fmt.Errorf("Error getting absolute folder path %v", err)
+			return "", fmt.Errorf("Error getting absolute directory path %v", err)
 		}
 		output.PrintCmdStatus(cmd, fmt.Sprintf("Assembling solution in temp target directory %q\n", targetPath))
 	} else {

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -57,7 +57,7 @@ on convenience and use cases. The following priority is available:
 func getSolutionPackageCmd() *cobra.Command {
 
 	solutionPackageCmd.Flags().
-		String("solution-bundle", "", "Path to output directory or file to package into (defaults to temp dir)")
+		String("solution-bundle", "", "Path to output directory or file to place solution zip into (defaults to temp dir)")
 
 	solutionPackageCmd.Flags().
 		StringP("directory", "d", "", "Path to the solution root directory (defaults to current dir)")
@@ -104,14 +104,14 @@ func packageSolution(cmd *cobra.Command, args []string) {
 	}
 
 	var message string
-	message = fmt.Sprintf("Generating solution %s version %s bundle archive\n", manifest.Name, manifest.SolutionVersion)
+	message = fmt.Sprintf("Generating solution %s version %s\n", manifest.Name, manifest.SolutionVersion)
 	output.PrintCmdStatus(cmd, message)
 
 	// create archive
 	solutionArchive := generateZip(cmd, solutionDirectoryPath, outputFilePath)
 	solutionArchive.Close()
 
-	message = fmt.Sprintf("Solution %s version %s bundle is ready in %s\n", manifest.Name, manifest.SolutionVersion, solutionArchive.Name())
+	message = fmt.Sprintf("Solution %s version %s is ready in %s\n", manifest.Name, manifest.SolutionVersion, solutionArchive.Name())
 	output.PrintCmdStatus(cmd, message)
 }
 
@@ -152,8 +152,8 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 		log.Fatalf("failed to create file %s: %v", outputPath, err)
 		panic(err)
 	}
-	output.PrintCmdStatus(cmd, fmt.Sprintf("Creating archive zip: %q\n", archive.Name()))
-	log.WithField("path", archive.Name()).Info("Creating solution bundle file")
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Creating solution zip: %q\n", archive.Name()))
+	log.WithField("path", archive.Name()).Info("Creating solution file")
 	defer archive.Close()
 	zipWriter := zip.NewWriter(archive)
 
@@ -192,7 +192,7 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 		log.Fatalf("Error traversing the folder: %v", err)
 	}
 	zipWriter.Close()
-	log.WithField("path", archive.Name()).Info("Created a solution bundle file")
+	log.WithField("path", archive.Name()).Info("Created a solution with path")
 
 	return archive
 }
@@ -251,7 +251,7 @@ func isSolutionPackageRoot(path string) bool {
 	manifestPath := fmt.Sprintf("%s/manifest.json", path)
 	manifestFile, err := os.Open(manifestPath)
 	if err != nil {
-		log.Errorf("The folder %s is not a solution package root folder", path)
+		log.Errorf("The folder %s is not a solution root folder", path)
 		return false
 	}
 	manifestFile.Close()
@@ -262,7 +262,7 @@ func getSolutionManifest(path string) (*Manifest, error) {
 	manifestPath := filepath.Join(path, "manifest.json")
 	manifestFile, err := os.Open(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("%q is not a solution package root folder", path)
+		return nil, fmt.Errorf("%q is not a solution root folder", path)
 	}
 	defer manifestFile.Close()
 

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -168,13 +168,13 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 	}
 	err = os.Chdir(solutionParentPath)
 	if err != nil {
-		log.Fatalf("Couldn't switch working folder to solution root's parent directory %q: %v", solutionParentPath, err)
+		log.Fatalf("Couldn't switch working directory to solution root's parent directory %q: %v", solutionParentPath, err)
 	}
 	defer func() {
 		// restore original working directory
 		err := os.Chdir(fsocWorkingDir)
 		if err != nil {
-			log.Fatalf("Couldn't switch working folder back to starting working folder: %v", err)
+			log.Fatalf("Couldn't switch working directory back to starting working directory: %v", err)
 		}
 	}()
 
@@ -189,7 +189,7 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 			return nil
 		})
 	if err != nil {
-		log.Fatalf("Error traversing the folder: %v", err)
+		log.Fatalf("Error traversing the directory: %v", err)
 	}
 	zipWriter.Close()
 	log.WithField("path", archive.Name()).Info("Created a solution with path")
@@ -251,7 +251,7 @@ func isSolutionPackageRoot(path string) bool {
 	manifestPath := fmt.Sprintf("%s/manifest.json", path)
 	manifestFile, err := os.Open(manifestPath)
 	if err != nil {
-		log.Errorf("The folder %s is not a solution root folder", path)
+		log.Errorf("The direcotry %s is not a solution root directory", path)
 		return false
 	}
 	manifestFile.Close()
@@ -262,7 +262,7 @@ func getSolutionManifest(path string) (*Manifest, error) {
 	manifestPath := filepath.Join(path, "manifest.json")
 	manifestFile, err := os.Open(manifestPath)
 	if err != nil {
-		return nil, fmt.Errorf("%q is not a solution root folder", path)
+		return nil, fmt.Errorf("%q is not a solution root directory", path)
 	}
 	defer manifestFile.Close()
 

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -52,13 +52,13 @@ func getSolutionPushCmd() *cobra.Command {
 	solutionPushCmd.Flag("wait").NoOptDefVal = "300"
 
 	solutionPushCmd.Flags().
-		BoolP("bump", "b", false, "Increment the patch version before deploying")
+		BoolP("bump", "b", false, "Increment the patch version before deploying solution")
 
 	solutionPushCmd.Flags().
 		StringP("directory", "d", "", "Path to the solution root directory (defaults to current dir)")
 
 	solutionPushCmd.Flags().
-		String("solution-bundle", "", "Path to a prepackaged solution zip bundle")
+		String("solution-bundle", "", "Path to a prepackaged solution zip")
 
 	solutionPushCmd.Flags().
 		String("env-file", "", "Path to the env vars json file with isolation tag and, optionally, dependency tags")

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -92,7 +92,7 @@ func testSolution(cmd *cobra.Command, args []string) {
 
 	// Read Test Objects JSON
 	if !isTestPackageRoot(testBundleDir) {
-		log.Fatalf("No test-objects file found in %q; please run this command in a folder with a test-objects file or use the --test-bundle flag", testBundleDir)
+		log.Fatalf("No test-objects file found in %q; please run this command in a directory with a test-objects file or use the --test-bundle flag", testBundleDir)
 	}
 	testObjects, err := getTestObjects(testBundleDir)
 	if err != nil {
@@ -211,7 +211,7 @@ func isTestPackageRoot(path string) bool {
 	testObjectsPath := fmt.Sprintf("%s/test-objects.json", path)
 	testObjectsFile, err := os.Open(testObjectsPath)
 	if err != nil {
-		log.Errorf("The folder %s is not a solution test root folder", path)
+		log.Errorf("The directory %s is not a solution test root directory", path)
 		return false
 	}
 	testObjectsFile.Close()
@@ -222,7 +222,7 @@ func getTestObjects(path string) (*SolutionTestObjects, error) {
 	testObjectsPath := fmt.Sprintf("%s/test-objects.json", path)
 	testObjectsFile, err := os.Open(testObjectsPath)
 	if err != nil {
-		return nil, fmt.Errorf("%q is not a solution test root folder", path)
+		return nil, fmt.Errorf("%q is not a solution test root directory", path)
 	}
 	defer testObjectsFile.Close()
 

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -106,7 +106,7 @@ func (manifest *Manifest) GetFmmEntities() []*FmmEntity {
 					return nil
 				})
 			if err != nil {
-				log.Fatalf("Error traversing the folder: %v", err)
+				log.Fatalf("Error traversing the directory: %v", err)
 			}
 		}
 
@@ -135,7 +135,7 @@ func (manifest *Manifest) GetFmmMetrics() []*FmmMetric {
 					return nil
 				})
 			if err != nil {
-				log.Fatalf("Error traversing the folder: %v", err)
+				log.Fatalf("Error traversing the directory: %v", err)
 			}
 		}
 
@@ -164,7 +164,7 @@ func (manifest *Manifest) GetFmmEvents() []*FmmEvent {
 					return nil
 				})
 			if err != nil {
-				log.Fatalf("Error traversing the folder: %v", err)
+				log.Fatalf("Error traversing the directory: %v", err)
 			}
 		}
 
@@ -231,7 +231,7 @@ func (manifest *Manifest) GetDashuiTemplates() []*DashuiTemplate {
 					return nil
 				})
 			if err != nil {
-				log.Fatalf("Error traversing the folder: %v", err)
+				log.Fatalf("Error traversing the directory: %v", err)
 			}
 		}
 

--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -232,7 +232,7 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 }
 
 func getSolutionValidationErrorsString(total int, errors Errors) string {
-	var message = fmt.Sprintf("\n%d errors detected while validating solution package\n", total)
+	var message = fmt.Sprintf("\n%d errors detected while validating solution\n", total)
 	for _, err := range errors.Items {
 		message += fmt.Sprintf("- Error Content: %+v\n", err)
 	}

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -37,7 +37,7 @@ var solutionValidateCmd = &cobra.Command{
 	Use:   "validate",
 	Args:  cobra.ExactArgs(0),
 	Short: "Validate solution",
-	Long:  `This command allows the current tenant specified in the profile to upload the solution in the current directory just to validate its contents.  The --stable flag provides a default value of 'stable' for the tag associated with the given solution bundle.  `,
+	Long:  `This command allows the current tenant specified in the profile to upload the solution in the current directory just to validate its contents.  The --stable flag provides a default value of 'stable' for the tag associated with the given solution.  `,
 	Example: `  fsoc solution validate
   fsoc solution validate --bump --tag preprod
   fsoc solution validate --tag dev
@@ -53,7 +53,7 @@ func getSolutionValidateCmd() *cobra.Command {
 		String("tag", "", "Tag to associate with provided solution.  Ensure tag used for validation & upload are same.")
 
 	solutionValidateCmd.Flags().
-		Bool("stable", false, "Automatically associate the 'stable' tag with solution bundle to be validate.  This should only be used for validating solutions uploaded with the 'stable' tag.")
+		Bool("stable", false, "Automatically associate the 'stable' tag with solution to validate.  This should only be used for validating solutions uploaded with the 'stable' tag.")
 
 	solutionValidateCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before validation")
@@ -62,7 +62,7 @@ func getSolutionValidateCmd() *cobra.Command {
 		StringP("directory", "d", "", "Path to the solution root directory (defaults to current dir)")
 
 	solutionValidateCmd.Flags().
-		String("solution-bundle", "", "Path to a prepackaged solution zip bundle")
+		String("solution-bundle", "", "Path to a prepackaged solution zip")
 
 	solutionValidateCmd.Flags().
 		String("env-file", "", "Path to the env vars json file with isolation tag and, optionally, dependency tags")


### PR DESCRIPTION
## Description

Since we no longer want to use the term "solution package" or "solution bundle", this PR cleans up any outstanding usage of those terms within orion fsoc commands.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
