### PR TITLE
ORION-1455: fix issue with fsoc solution download passing tag incorrectly

### DIFF
--- a/cmd/solution/name.go
+++ b/cmd/solution/name.go
@@ -28,6 +28,7 @@ func getSolutionNameFromArgs(cmd *cobra.Command, args []string, flagName string)
 	// get solution name from a flag, if provided (deprecated but kept for backward compatibility)
 	var nameFromFlag string
 	solutionTag, _ := cmd.Flags().GetString("tag")
+	commandName, _ := cmd.Name()
 	if flagName != "" {
 		var err error
 		nameFromFlag, err = cmd.Flags().GetString(flagName)
@@ -46,7 +47,8 @@ func getSolutionNameFromArgs(cmd *cobra.Command, args []string, flagName string)
 		if nameFromFlag != "" {
 			log.Fatal("Solution name must be specified either as a positional argument or with a flag but not both")
 		}
-		if solutionTag != "" && solutionTag != "stable" {
+		// We only want to append .dev for subscribing/unsubscribing commands
+		if solutionTag != "" && solutionTag != "stable" && (commandName == "subscribe" || commandName == "unsubscribe") {
 			name = fmt.Sprintf("%s.%s", name, solutionTag)
 		}
 		return name

--- a/cmd/solution/name.go
+++ b/cmd/solution/name.go
@@ -28,7 +28,7 @@ func getSolutionNameFromArgs(cmd *cobra.Command, args []string, flagName string)
 	// get solution name from a flag, if provided (deprecated but kept for backward compatibility)
 	var nameFromFlag string
 	solutionTag, _ := cmd.Flags().GetString("tag")
-	commandName, _ := cmd.Name()
+	commandName := cmd.Name()
 	if flagName != "" {
 		var err error
 		nameFromFlag, err = cmd.Flags().GetString(flagName)


### PR DESCRIPTION
## Description

Renato caught a bug related to fsoc solution download when trying to download a solution with a dev tag.  This is the fix for that.  I have validated it on my machine.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
