### PR TITLE
Only set RestartTimestamp when restarting started optimizer

### DIFF
--- a/cmd/optimize/management.go
+++ b/cmd/optimize/management.go
@@ -143,8 +143,10 @@ func startOptimizer(flags *startFlags) func(cmd *cobra.Command, args []string) e
 			}
 		}
 
+		if flags.restart && config.DesiredState != "stopped" {
+			config.RestartTimestamp = time.Now().UTC().String()
+		}
 		config.DesiredState = "started"
-		config.RestartTimestamp = time.Now().UTC().String()
 
 		if err := flags.updateOptimizerConfiguration(config); err != nil {
 			return fmt.Errorf("flags.updateOptimizerConfiguration: %w", err)


### PR DESCRIPTION
## Description

In initial implementation I was treating the RestartTimestamp as an informational StartedAt field. Thanks to clarifications from  @kekssw (Vlad), it was pointed out that updating this field on a stopped optimization creates non-sensical directive for the optimizer to restart an optimization that is already stopped. This change ensures updates to an existing optimizer only sets the RestartTimestamp when that optimizer is in a "started" state.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
