### PR TITLE
Revise isolation tag logic

### DIFF
--- a/cmd/solution/isolate.go
+++ b/cmd/solution/isolate.go
@@ -106,7 +106,7 @@ func solutionIsolateCommand(cmd *cobra.Command, args []string) {
 		log.Fatal("Either <target-dir> or <target-file> must be specified.")
 	}
 
-	solutionName, err := isolateSolution(cmd, srcFolder, targetFolder, targetFile, tag, envVarsFile)
+	solutionName, _, err := isolateSolution(cmd, srcFolder, targetFolder, targetFile, tag, envVarsFile)
 	if err != nil {
 		log.Fatalf("Failed to isolate solution: %v", err)
 	}
@@ -115,21 +115,22 @@ func solutionIsolateCommand(cmd *cobra.Command, args []string) {
 	output.PrintCmdStatus(cmd, message)
 }
 
-func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, tag, envVarsFile string) (string, error) {
+// isolateSolution returns path to directory with isolated artifacts, the tag used and error
+func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, tag, envVarsFile string) (string, string, error) {
 	var err error
 	rgxp, err = regexp.Compile(regexPattern)
 	if err != nil {
-		return "", fmt.Errorf("(likely bug) Error compiling regex /%v/: %w", regexPattern, err)
+		return "", "", fmt.Errorf("(likely bug) Error compiling regex /%v/: %w", regexPattern, err)
 	}
 	srcPath, err := filepath.Abs(srcFolder)
 	if err != nil {
-		return "", fmt.Errorf("Error getting source directory %q: %w", srcFolder, err)
+		return "", "", fmt.Errorf("Error getting source directory %q: %w", srcFolder, err)
 	}
 
 	// parse env vars
 	envVars, err := loadEnvVars(cmd, tag, envVarsFile)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	log.WithField("env_vars", envVars).Info("Parsed env vars")
 
@@ -140,30 +141,30 @@ func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, ta
 		// e.g., for /home/joe/spacefleet4.zip create /tmp/fsocXXXXX/spacefleet4/
 		tempDirRoot, err := os.MkdirTemp("", "fsoc")
 		if err != nil {
-			return "", fmt.Errorf("Failed to create a temporary directory: %v", err)
+			return "", "", fmt.Errorf("Failed to create a temporary directory: %v", err)
 		}
 		defer os.RemoveAll(tempDirRoot)
 		zipFileName := filepath.Base(targetFile)
 		dirName := zipFileName[:len(zipFileName)-len(filepath.Ext(zipFileName))]
 		tempDir := filepath.Join(tempDirRoot, dirName)
 		if targetPath, err = filepath.Abs(tempDir); err != nil {
-			return "", fmt.Errorf("Error getting absolute directory path %v", err)
+			return "", "", fmt.Errorf("Error getting absolute directory path %v", err)
 		}
 		output.PrintCmdStatus(cmd, fmt.Sprintf("Assembling solution in temp target directory %q\n", targetPath))
 	} else {
 		targetPath, err = filepath.Abs(targetFolder)
 		if err != nil {
-			return "", fmt.Errorf("Error getting target directory %v", err)
+			return "", "", fmt.Errorf("Error getting target directory %v", err)
 		}
 	}
 
 	if err = prepareForIsolation(srcPath, targetPath, targetFile, envVars); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	mf, err := isolateManifest(cmd, srcPath, targetPath, envVars)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// merge some values from manifest into env vars
@@ -171,7 +172,7 @@ func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, ta
 
 	// isolate file
 	if err = isolateFiles(mf, srcPath, targetPath, targetFile, envVars); err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	// create zip if requested
@@ -179,13 +180,13 @@ func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, ta
 		zipFile := generateZip(cmd, targetPath, "")
 		err = os.Rename(zipFile.Name(), targetFile)
 		if err != nil {
-			return "", fmt.Errorf("Failed to rename temp file %q to final file %q: %w", zipFile.Name(), targetFile, err)
+			return "", "", fmt.Errorf("Failed to rename temp file %q to final file %q: %w", zipFile.Name(), targetFile, err)
 		}
 	}
 
 	log.Info("Pseudo-isolation successfully completed")
 
-	return mf.Name, nil
+	return mf.Name, getTag(envVars), nil
 }
 
 func prepareForIsolation(srcPath, targetPath, targetFile string, envVars interface{}) error {
@@ -314,6 +315,18 @@ func loadEnvVars(cmd *cobra.Command, tag, envVarsFile string) (interface{}, erro
 		return nil, fmt.Errorf("Failed to parse env vars file: %w", err)
 	}
 	return envVars, nil
+}
+
+func getTag(envVars interface{}) string {
+	if root, ok := envVars.(map[string]any); ok {
+		if env, ok := root["env"].(map[string]any); ok {
+			if tag, ok := env["tag"].(string); ok && tag != "" {
+				return tag
+			}
+		}
+	}
+	log.Fatalf(`Failed to extract tag from env vars. Minmum required is --tag flag or {"env":{"tag":"<tagvalue>""}} env.json file`)
+	return "" // can never get here, just keep compiler happy
 }
 
 func evalAndCopyFile(fileName, srcPath, targetPath string, envVars interface{}) error {

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -92,7 +92,7 @@ func packageSolution(cmd *cobra.Command, args []string) {
 	}
 
 	// isolate if needed
-	solutionDirectoryPath, err := embeddedConditionalIsolate(cmd, solutionDirectoryPath)
+	solutionDirectoryPath, tag, err := embeddedConditionalIsolate(cmd, solutionDirectoryPath)
 	if err != nil {
 		log.Fatalf("Failed to isolate solution with tag: %v", err)
 	}
@@ -104,7 +104,7 @@ func packageSolution(cmd *cobra.Command, args []string) {
 	}
 
 	var message string
-	message = fmt.Sprintf("Generating solution %s version %s\n", manifest.Name, manifest.SolutionVersion)
+	message = fmt.Sprintf("Packaging solution %s version %s with tag %s\n", manifest.Name, manifest.SolutionVersion, tag)
 	output.PrintCmdStatus(cmd, message)
 
 	// create archive

--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -56,14 +56,16 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 		waitFlag = -1
 	}
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
-	solutionTagFlag, _ := cmd.Flags().GetString("tag")
-	pushWithStableTag, _ := cmd.Flags().GetBool("stable")
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	solutionRootDirectory, _ := cmd.Flags().GetString("directory")
 
+	// prepare tag-related flags (note: these will be replaced if isolation is attempted)
+	solutionTagFlag, _ := cmd.Flags().GetString("tag")
+	pushWithStableTag, _ := cmd.Flags().GetBool("stable")
 	if pushWithStableTag {
 		solutionTagFlag = "stable"
 	}
+	requestedSolutionTag := solutionTagFlag // mostly for display, as solutionTagFlag may be changed to comply with supported API values
 
 	// prepare archive if needed
 	solutionAlreadyZipped = solutionBundlePath != ""
@@ -102,8 +104,10 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 			bumpSolutionVersionInManifest(cmd, manifest, solutionRootDirectory)
 		}
 
-		// isolate if needed
-		solutionIsolateDirectory, err := embeddedConditionalIsolate(cmd, solutionRootDirectory)
+		// isolate if needed (update tag values to reflect env var and/or env file settings)
+		solutionIsolateDirectory, tag, err := embeddedConditionalIsolate(cmd, solutionRootDirectory)
+		solutionTagFlag = tag
+		requestedSolutionTag = tag
 		if err != nil {
 			log.Fatalf("Failed to isolate solution with tag: %v", err)
 		}
@@ -118,7 +122,9 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 			}
 
 			// update tag to use supported values
-			solutionTagFlag = "stable" // TODO: get it from the env file
+			if solutionTagFlag != "stable" {
+				solutionTagFlag = "dev" // TODO: use tag value as-is once free-form values are supported by API
+			}
 		}
 
 		// create archive
@@ -136,7 +142,15 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 			"zip_prepackaged": false,
 		}
 	}
-	solutionDisplayText += " with tag " + solutionTagFlag
+	logFields["tag"] = requestedSolutionTag
+	logFields["isolation_tag"] = requestedSolutionTag
+	logFields["header_tag"] = solutionTagFlag
+	solutionDisplayText += " with tag "
+	if solutionTagFlag == requestedSolutionTag {
+		solutionDisplayText += solutionTagFlag
+	} else {
+		solutionDisplayText += fmt.Sprintf("%v (%v)", requestedSolutionTag, solutionTagFlag) // non-stable isolation tag uses "dev" in API header
+	}
 	if push {
 		output.PrintCmdStatus(cmd, fmt.Sprintf("Deploying %s\n", solutionDisplayText))
 	} else {


### PR DESCRIPTION
## Description

This PR revises the logic in choosing the tag value when validating/pushing a solution with isolation and non-stable tag. This resolves an issue with pushing solutions to production environments.

There are two key changes:
* adjust logic to fit current production style usage ("dev" tag when isolating)
* improve tag value displays to properly show and log the tag(s) used

Note that this change breaks backward compatibility of isolation on some dev environments that do not support the "dev" tag. If you see error indicating that the "dev" tag is not supported, the workaround is to package the solution into a zip file with the desired isolation (non-stable) tag and then push or validate with the "stable" flag:
1. `fsoc solution package --solution-bundle mysolution.zip --tag joe`
1. `fsoc solution push --solution-bundle mysolution.zip --tag stable`

The operation of push for "stable" and for non-isolated solutions is not affected.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [X] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
