### PR TITLE
Adjust flags for solution push and list commands

### DIFF
--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -49,6 +49,8 @@ func getSolutionListCmd() *cobra.Command {
 	solutionListCmd.Flags().
 		Bool("unsubscribed", false, "Use this to only see solutions that you are unsubscribed to")
 
+	solutionListCmd.MarkFlagsMutuallyExclusive("subscribed", "unsubscribed")
+
 	return solutionListCmd
 
 }
@@ -58,10 +60,6 @@ func getSolutionList(cmd *cobra.Command, args []string) {
 	// get subscribe and unsubscribe flags
 	subscribed := cmd.Flags().Lookup("subscribed").Changed
 	unsubscribed := cmd.Flags().Lookup("unsubscribed").Changed
-
-	if subscribed && unsubscribed {
-		log.Fatalf("You cannot use both the subscribed flag and the unsubscribed flag")
-	}
 
 	cfg := config.GetCurrentContext()
 	layerID := cfg.Tenant

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -68,7 +68,7 @@ func getSolutionPushCmd() *cobra.Command {
 
 	solutionPushCmd.Flags().
 		Bool("subscribe", false, "Subscribe to the solution that you are pushing")
-	solutionPushCmd.Flags().MarkHidden("subscribe") // TODO: unify with isolation before showing
+	_ = solutionPushCmd.Flags().MarkHidden("subscribe") // TODO: unify with isolation before showing
 
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "directory") // either solution dir or prepackaged zip
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")      // cannot modify prepackaged zip

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -68,6 +68,7 @@ func getSolutionPushCmd() *cobra.Command {
 
 	solutionPushCmd.Flags().
 		Bool("subscribe", false, "Subscribe to the solution that you are pushing")
+	solutionPushCmd.Flags().MarkHidden("subscribe") // TODO: unify with isolation before showing
 
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "directory") // either solution dir or prepackaged zip
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")      // cannot modify prepackaged zip


### PR DESCRIPTION
## Description

* mark the new --subscribe flag for `solution push` as hidden before it is adjusted to support isolation
* change the way --subscribed/--unsubscribed flags for `solution list` are made mutually exclusive

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
