### PR TITLE
Added tag as a Flag option to fsoc solution fork

### DIFF
--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -48,10 +48,11 @@ var solutionForkCmd = &cobra.Command{
 }
 
 func GetSolutionForkCommand() *cobra.Command {
-	solutionForkCmd.Flags().String("source-name", "", "name of the solution that needs to be downloaded")
+	solutionForkCmd.Flags().String("source-name", "", "name of the solution that needs to be forked and downloaded")
 	_ = solutionForkCmd.Flags().MarkDeprecated("source-name", "please use argument instead.")
 	solutionForkCmd.Flags().String("name", "", "name of the solution to copy it to")
 	_ = solutionForkCmd.Flags().MarkDeprecated("name", "please use argument instead.")
+	solutionForkCmd.Flags().String("tag", "stable", "tag related to the solution to fork and download")
 	return solutionForkCmd
 }
 
@@ -177,11 +178,12 @@ func editManifest(fileSystem afero.Fs, forkName string) {
 
 func downloadSolutionZip(cmd *cobra.Command, solutionName string, forkName string) {
 	var solutionNameWithZipExtension = getSolutionNameWithZip(solutionName)
+	solutionTagFlag, _ := cmd.Flags().GetString("tag")
 	var message string
 
 	headers := map[string]string{
 		"stage":            "STABLE",
-		"tag":              "stable",
+		"tag":              solutionTagFlag,
 		"solutionFileName": solutionNameWithZipExtension,
 	}
 	httpOptions := api.Options{Headers: headers}


### PR DESCRIPTION
## Description

This change allows a tag to be passed as a flag when running `fsoc solution fork`.   Allowing a tagged version other than stable to be forked.

## Type of Change

- Bug Fix


## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ x] I have verified this change is not present in other open pull requests
- [ x] Functionality is documented
- [ x] All code style checks pass
- [x ] New code contribution is covered by automated tests
- [ x] All new and existing tests pass
