### PR TITLE
FSOC-37 Added argument support to `fsoc config set`

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -37,18 +37,18 @@ if on context name is specified, the current context is created/updated.`
 
 	setContextExample = `
   # Set oauth credentials (recommended for interactive use)
-  fsoc config set --auth=oauth --url=https://mytenant.observe.appdynamics.com
+  fsoc config set auth=oauth url=https://mytenant.observe.appdynamics.com
 
   # Set service or agent principal credentials (secret file must remain accessible)
-  fsoc config set --auth=service-principal --secret-file=my-service-principal.json
-  fsoc config set --auth=agent-principal --secret-file=agent-helm-values.yaml
-  fsoc config set --auth=agent-principal --secret-file=client-values.json --tenant=123456 --url=https://mytenant.observe.appdynamics.com
+  fsoc config set auth=service-principal secret-file=my-service-principal.json
+  fsoc config set auth=agent-principal secret-file=agent-helm-values.yaml
+  fsoc config set auth=agent-principal secret-file=client-values.json tenant=123456 url=https://mytenant.observe.appdynamics.com
 
   # Set local access
-  fsoc config set --auth=local url=http://localhost --appd-pid=PID --appd-tid=TID --appd-pty=PTY
+  fsoc config set auth=local url=http://localhost appd-pid=PID appd-tid=TID appd-pty=PTY
 
   # Set the token field on the "prod" context entry without touching other values
-  fsoc config set --profile prod --token=top-secret`
+  fsoc config set profile prod token=top-secret`
 )
 
 func newCmdConfigSet() *cobra.Command {
@@ -63,17 +63,23 @@ func newCmdConfigSet() *cobra.Command {
 		Run:         configSetContext,
 	}
 	cmd.Flags().String(AppdPid, "", "pid to use (local auth type only, provide raw value to be encoded)")
+	_ = cmd.Flags().MarkDeprecated(AppdPid, "the --"+AppdPid+" flag is deprecated, please use arguments supplied as "+AppdPid+"="+strings.ToUpper(AppdPid))
 	cmd.Flags().String(AppdTid, "", "tid to use (local auth type only, provide raw value to be encoded)")
+	_ = cmd.Flags().MarkDeprecated(AppdTid, "the --"+AppdTid+" flag is deprecated, please use arguments supplied as "+AppdTid+"="+strings.ToUpper(AppdTid))
 	cmd.Flags().String(AppdPty, "", "pty to use (local auth type only, provide raw value to be encoded)")
+	_ = cmd.Flags().MarkDeprecated(AppdPty, "the --"+AppdPty+" flag is deprecated, please use arguments supplied as "+AppdPty+"="+strings.ToUpper(AppdPty))
 	cmd.Flags().String("auth", "", fmt.Sprintf(`Select authentication method, one of {"%v"}`, strings.Join(GetAuthMethodsStringList(), `", "`)))
-	_ = cmd.Flags().MarkDeprecated("url", "TODO") // TODO: Change Deprecation Message
+	_ = cmd.Flags().MarkDeprecated("auth", "the --auth flag is deprecated, please use arguments supplied as auth=AUTH")
 	cmd.Flags().String("server", "", "Set server host name")
-	_ = cmd.Flags().MarkDeprecated("server", "The --server flag is deprecated, please use --url instead.")
+	_ = cmd.Flags().MarkDeprecated("server", "the --server flag is deprecated, please use arguments supplied as url=URL")
 	cmd.Flags().String("url", "", "Set server URL (with http or https schema)")
-	_ = cmd.Flags().MarkDeprecated("url", "The --server flag is deprecated, please use --url instead.") // TODO: Change Deprecation Message
+	_ = cmd.Flags().MarkDeprecated("url", "the --url flag is deprecated, please use arguments supplied as url=URL")
 	cmd.Flags().String("tenant", "", "Set tenant ID")
+	_ = cmd.Flags().MarkDeprecated("tenant", "the --tenant flag is deprecated, please use arguments supplied as tenant=TENANT")
 	cmd.Flags().String("token", "", "Set token value (use --token=- to get from stdin)")
+	_ = cmd.Flags().MarkDeprecated("token", "the --token flag is deprecated, please use arguments supplied as token=TOKEN")
 	cmd.Flags().String("secret-file", "", "Set a credentials file to use for service principal (.json or .csv) or agent principal (.yaml)")
+	_ = cmd.Flags().MarkDeprecated("secret-file", "the --secret-file flag is deprecated, please use arguments supplied as secret-file=SECRET-TOKEN")
 	return cmd
 }
 


### PR DESCRIPTION
## Description

Addressing FSOC-37

Before you were only able to provide values for the config file through flags (i.e. "--auth oauth"). Now you can provide values for the config file through arguments (i.e. "auth=oauth")

This is closer to `git config` style

This is done with little refactoring to the existent code and all changes still support the old way of supplying values (which can be mixed and matched i.e. "auth=oauth --url URL")


## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
