### PR TITLE
Fetch and Print options for queries. example shown with fsoc solution list

### DIFF
--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -71,13 +71,14 @@ func getSolutionList(cmd *cobra.Command, args []string) {
 
 	// get data and display
 	solutionBaseURL := getSolutionListUrl()
+	var filters []string
 	if subscribed {
-		solutionBaseURL += "?filter=" + url.QueryEscape("data.isSubscribed eq true")
+		filters = []string{"filter=" + url.QueryEscape("data.isSubscribed eq true")}
 	} else if unsubscribed {
-		solutionBaseURL += "?filter=" + url.QueryEscape("data.isSubscribed ne true")
+		filters = []string{"filter=" + url.QueryEscape("data.isSubscribed ne true")}
 	}
 	println(solutionBaseURL)
-	cmdkit.FetchAndPrint(cmd, solutionBaseURL, &cmdkit.FetchAndPrintOptions{Headers: headers, IsCollection: true})
+	cmdkit.FetchAndPrint(cmd, solutionBaseURL, &cmdkit.FetchAndPrintOptions{Headers: headers, IsCollection: true, Filters: filters})
 }
 
 func getSolutionListUrl() string {

--- a/cmdkit/fetch_and_print.go
+++ b/cmdkit/fetch_and_print.go
@@ -16,6 +16,7 @@ package cmdkit
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ type FetchAndPrintOptions struct {
 	Body         any               // body to send with the request (nil for no body)
 	ResponseType *reflect.Type     // structure type to parse response into (for schema validation & fields) (nil for none)
 	IsCollection bool              // set to true for GET to request a collection that may be paginated (see platform/api/collection.go)
+	Filters      []string
 }
 
 // FetchAndPrint consolidates the common sequence of fetching from the server and
@@ -61,6 +63,19 @@ func FetchAndPrint(cmd *cobra.Command, path string, options *FetchAndPrintOption
 
 	// fetch data
 	var err error
+
+	if options.Filters != nil {
+		// If there are filters, apply them to query path
+		numberOfFilters := len(strings.Split(path, "?"))
+		if numberOfFilters != 1 && numberOfFilters != 0 {
+			// Case 1: There is already a query in path append to the path
+			path += "&" + strings.Join(options.Filters, "&")
+		} else {
+			// Case 2: There is no query in path
+			path += "?" + strings.Join(options.Filters, "&")
+		}
+	}
+
 	if options != nil && options.IsCollection {
 		if method != "GET" {
 			log.Fatalf("bug: cannot request %q for a collection at %q, only GET is supported for collections", method, path)


### PR DESCRIPTION
## Description

Fetch and Print options now include a filters field. If there are strings in that field, it will append them as queries to the path. An examples of this is shown in fsoc solution list

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
