### PR TITLE
Add timestamp to profiler report query

### DIFF
--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -51,7 +51,7 @@ var (
 
 var reportTemplate = template.Must(template.New("").Parse(`
 SINCE -1w
-FETCH id, attributes, events(k8sprofiler:report){{if .Eligible}}[attributes("report_contents.optimizable") = "true"]{{end}}{attributes}
+FETCH id, attributes, events(k8sprofiler:report){{if .Eligible}}[attributes("report_contents.optimizable") = "true"]{{end}}{attributes, timestamp}
 FROM entities(k8s:deployment{{with .WorkloadId}}:{{.}}{{end}}){{with .WorkloadFilters}}[{{.}}]{{end}}
 LIMITS events.count(1)
 `))
@@ -153,6 +153,7 @@ func extractReportData(response *uql.Response) ([]reportRow, error) {
 		if !ok {
 			return results, fmt.Errorf("entity id string type assertion failed on main dataset row %v: %+v", index, row)
 		}
+		log.WithField("workloadId", workloadId).Info("Processing workload report")
 		reportRow := reportRow{WorkloadId: workloadId}
 
 		workloadAttributeDataset, ok := row[1].(*uql.DataSet)


### PR DESCRIPTION
## Description

Resolves an issue where warnings were printed and profiler reports were not being included in output. This was caused by a change in UQL where the timestamp is no longer automatically included in results. The fix is to explicitly query for the timestamp where needed (note this does not apply to the `optimize configure` command as that was not checking for/using the timestamp column)

Also includes addition of `-v` logging of the workloadId corresponding to the report being processed

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
