### PR TITLE
Add nil checks on uql response mainDataSet

### DIFF
--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -142,7 +142,11 @@ func listReports(cmd *cobra.Command, args []string) error {
 }
 
 func extractReportData(response *uql.Response) ([]reportRow, error) {
-	resp_data := &response.Main().Data
+	mainDataSet := response.Main()
+	if mainDataSet == nil {
+		return []reportRow{}, nil
+	}
+	resp_data := &mainDataSet.Data
 	results := make([]reportRow, 0, len(*resp_data))
 	for index, row := range *resp_data {
 		if len(row) < 3 {

--- a/cmd/optimize/server_report.go
+++ b/cmd/optimize/server_report.go
@@ -89,7 +89,11 @@ func getWorkloadId(workloadName string) (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-	workloadIds := columnValues(response.Main(), 0)
+	mainDataSet := response.Main()
+	if mainDataSet == nil {
+		return nil, fmt.Errorf("nil main data set when querying for workloads with name %q", workloadName)
+	}
+	workloadIds := columnValues(mainDataSet, 0)
 
 	// Check if either none or multiple workload IDs found
 	if len(workloadIds) < 1 {


### PR DESCRIPTION
## Description

As noted by @pavel-georgiev , there was a case encountered recently where an error during the UQL query request (noted in the response) caused a panic during the `optimize report` command. After reviewing the log I determined its most probably caused by the mainDataSet of the uql response being nil resulting in the noted "nil pointer dereference" error when we try to access the fields of the underlying struct. I've added a nil check on mainDataSet in all applicable optimize commands.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
