### PR TITLE
Update optimize configure to set deployment UID on optimizer Orion config object

### DIFF
--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -236,6 +236,7 @@ FROM entities(k8s:deployment)[attributes("k8s.cluster.name") = "{{.Cluster}}" &&
 		}
 		// Target
 		newOptimizerConfig.Target.K8SDeployment.ClusterID = profilerReport["resource_metadata.cluster_id"].(string)
+		newOptimizerConfig.Target.K8SDeployment.DeploymentUID = profilerReport["k8s.deployment.uid"].(string)
 		newOptimizerConfig.Target.K8SDeployment.ClusterName = profilerReport["resource_metadata.cluster_name"].(string)
 		newOptimizerConfig.Target.K8SDeployment.ContainerName = profilerReport["report_contents.main_container_name"].(string)
 		newOptimizerConfig.Target.K8SDeployment.NamespaceName = profilerReport["resource_metadata.namespace_name"].(string)

--- a/cmd/optimize/types.go
+++ b/cmd/optimize/types.go
@@ -59,6 +59,7 @@ type Suspension struct {
 }
 type K8SDeployment struct {
 	ClusterID     string `json:"clusterId"`
+	DeploymentUID string `json:"deploymentUid"`
 	ClusterName   string `json:"clusterName"`
 	ContainerName string `json:"containerName"`
 	NamespaceName string `json:"namespaceName"`


### PR DESCRIPTION
## Description

In order to create FMM entities associated with the deployment under optimization, the ARO backend needs to have the UID of the relevant deployment. This update writes deployment UID to a new field within the optimizer configuration object so that it can be used by the backed in its entity creation.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [x] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
