### PR TITLE
Fix and enable "solution push --subscribe"

### DIFF
--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -68,11 +68,11 @@ func getSolutionPushCmd() *cobra.Command {
 
 	solutionPushCmd.Flags().
 		Bool("subscribe", false, "Subscribe to the solution that you are pushing")
-	_ = solutionPushCmd.Flags().MarkHidden("subscribe") // TODO: unify with isolation before showing
 
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "directory") // either solution dir or prepackaged zip
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")      // cannot modify prepackaged zip
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "wait")      // TODO: allow when extracting manifest data
+	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "subscribe") // TODO: allow when extracting manifest data
 	solutionPushCmd.MarkFlagsMutuallyExclusive("tag", "stable", "env-file")    // stable is an alias for --tag=stable
 
 	return solutionPushCmd


### PR DESCRIPTION
## Description

 * Unhide --subscribe flag
 * Fix issue when --subscribe is used with --wait
 * Do not allow --subscribe with --solution-bundle
 * Remove double print of messages upon subscribe
 * Make subscription retries more resiliant (up to 4 retries with backoff)


## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
