### PR TITLE
Fsoc gendocs header changes

### DIFF
--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -223,6 +223,12 @@ func processFile(file *os.File) error {
 				fileLines[i] = line[2:]
 			}
 		}
+		if fileLines[i] == "# SEE ALSO" {
+			fileLines[i] = "# See Also"
+		}
+		if fileLines[i] == "# Options inherited from parent commands" {
+			fileLines[i] = "# Options Inherited From Parent Commands"
+		}
 	}
 
 	if err := os.Truncate(file.Name(), 0); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ For more information, see https://github.com/cisco-open/fsoc
 
 NOTE: fsoc is in alpha; breaking changes may occur`,
 	PersistentPreRun:  preExecHook,
+	PersistentPostRun: postExecHook,
 	TraverseChildren:  true,
 	DisableAutoGenTag: true,
 }
@@ -220,6 +221,14 @@ func preExecHook(cmd *cobra.Command, args []string) {
 			log.Infof("Unable to read config file (%v), proceeding without a config", err)
 		} else {
 			log.Fatalf("fsoc is not configured, please use \"fsoc config set\" to configure an initial context")
+		}
+	}
+}
+
+func postExecHook(cmd *cobra.Command, args []string) {
+	if cmd.Name() == "cmd" {
+		if err := api.Login(); err != nil {
+			log.Fatalf(err.Error())
 		}
 	}
 }

--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -71,13 +71,14 @@ func getSolutionList(cmd *cobra.Command, args []string) {
 
 	// get data and display
 	solutionBaseURL := getSolutionListUrl()
+	var filters []string
 	if subscribed {
-		solutionBaseURL += "?filter=" + url.QueryEscape("data.isSubscribed eq true")
+		filters = []string{"filter=" + url.QueryEscape("data.isSubscribed eq true")}
 	} else if unsubscribed {
-		solutionBaseURL += "?filter=" + url.QueryEscape("data.isSubscribed ne true")
+		filters = []string{"filter=" + url.QueryEscape("data.isSubscribed ne true")}
 	}
 	println(solutionBaseURL)
-	cmdkit.FetchAndPrint(cmd, solutionBaseURL, &cmdkit.FetchAndPrintOptions{Headers: headers, IsCollection: true})
+	cmdkit.FetchAndPrint(cmd, solutionBaseURL, &cmdkit.FetchAndPrintOptions{Headers: headers, IsCollection: true, Filters: filters})
 }
 
 func getSolutionListUrl() string {

--- a/cmdkit/fetch_and_print.go
+++ b/cmdkit/fetch_and_print.go
@@ -16,6 +16,7 @@ package cmdkit
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
@@ -30,6 +31,7 @@ type FetchAndPrintOptions struct {
 	Body         any               // body to send with the request (nil for no body)
 	ResponseType *reflect.Type     // structure type to parse response into (for schema validation & fields) (nil for none)
 	IsCollection bool              // set to true for GET to request a collection that may be paginated (see platform/api/collection.go)
+	Filters      []string
 }
 
 // FetchAndPrint consolidates the common sequence of fetching from the server and
@@ -61,6 +63,19 @@ func FetchAndPrint(cmd *cobra.Command, path string, options *FetchAndPrintOption
 
 	// fetch data
 	var err error
+
+	if options.Filters != nil {
+		// If there are filters, apply them to query path
+		numberOfFilters := len(strings.Split(path, "?"))
+		if numberOfFilters != 1 && numberOfFilters != 0 {
+			// Case 1: There is already a query in path append to the path
+			path += "&" + strings.Join(options.Filters, "&")
+		} else {
+			// Case 2: There is no query in path
+			path += "?" + strings.Join(options.Filters, "&")
+		}
+	}
+
 	if options != nil && options.IsCollection {
 		if method != "GET" {
 			log.Fatalf("bug: cannot request %q for a collection at %q, only GET is supported for collections", method, path)


### PR DESCRIPTION
## Description

When the gendocs command was used before, the documentation generated would start at a third level header. This was inconsistent with other fsoc documentation, this fix makes the gendocs command consistent with other fsoc documentation.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
