### PR TITLE
ORION-1761: correct source of truth for solution subscription status to pull from extensibility:solution object

### DIFF
--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -258,7 +258,7 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 					log.Fatalf("Failed to validate %s was installed: timed out", solutionDisplayText)
 				}
 			}
-			status := getObject(fmt.Sprintf(getSolutionInstallUrl(), query), headers)
+			status := getObjects(fmt.Sprintf(getSolutionInstallUrl(), query), headers)
 			statusData = status.StatusData
 			time.Sleep(3 * time.Second)
 		}


### PR DESCRIPTION
## Description

Since the environment:subscription object is now restricted from being accessed in prod (per security and privacy concerns), the fsoc solution status command is breaking.  This PR changes the source of truth regarding solution subscription from the environment:subscription object to the extensibility:solution object and also updates the urls in the solution status command to use the v1 url (not v1beta). 

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
