### PR TITLE
Update publisher token name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,6 @@ jobs:
           args: release --clean --timeout 5m
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAP_GITHUB_TOKEN: ${{ secrets.PUBLISHER_CLASSIC_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLISHER_TOKEN }}
           GIT_BRANCH: ${{ github.ref_name }}
           BUILD_IS_DEV: 'false'


### PR DESCRIPTION
## Description

This PR updates the `release.yml` workflow to utilize a more descriptive token name, as secrets are now being stored at the GitHub organization level. 

## Changes

* `PUBLISHER_CLASSIC_TOKEN ` -> `HOMEBREW_GITHUB_PUBLISHER_TOKEN`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)