### PR TITLE
updated help strings for `config set` to use non-flag arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For other shells, check out the completion help with `fsoc help completion`.
 Configure the default profile to your tenant of choice (replace MYTENANT with your tenant's name):
 
 ```
-fsoc config set --auth=oauth --server=MYTENANT.observe.appdynamics.com
+fsoc config set auth=oauth url=https://MYTENANT.observe.appdynamics.com
 fsoc login  # test access
 ```
 

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -63,23 +63,23 @@ func newCmdConfigSet() *cobra.Command {
 		Run:         configSetContext,
 	}
 	cmd.Flags().String(AppdPid, "", "pid to use (local auth type only, provide raw value to be encoded)")
-	_ = cmd.Flags().MarkDeprecated(AppdPid, "the --"+AppdPid+" flag is deprecated, please use arguments supplied as "+AppdPid+"="+strings.ToUpper(AppdPid))
+	_ = cmd.Flags().MarkDeprecated(AppdPid, "please use arguments supplied as "+AppdPid+"="+strings.ToUpper(AppdPid))
 	cmd.Flags().String(AppdTid, "", "tid to use (local auth type only, provide raw value to be encoded)")
-	_ = cmd.Flags().MarkDeprecated(AppdTid, "the --"+AppdTid+" flag is deprecated, please use arguments supplied as "+AppdTid+"="+strings.ToUpper(AppdTid))
+	_ = cmd.Flags().MarkDeprecated(AppdTid, "please use arguments supplied as "+AppdTid+"="+strings.ToUpper(AppdTid))
 	cmd.Flags().String(AppdPty, "", "pty to use (local auth type only, provide raw value to be encoded)")
-	_ = cmd.Flags().MarkDeprecated(AppdPty, "the --"+AppdPty+" flag is deprecated, please use arguments supplied as "+AppdPty+"="+strings.ToUpper(AppdPty))
+	_ = cmd.Flags().MarkDeprecated(AppdPty, "please use arguments supplied as "+AppdPty+"="+strings.ToUpper(AppdPty))
 	cmd.Flags().String("auth", "", fmt.Sprintf(`Select authentication method, one of {"%v"}`, strings.Join(GetAuthMethodsStringList(), `", "`)))
-	_ = cmd.Flags().MarkDeprecated("auth", "the --auth flag is deprecated, please use arguments supplied as auth=AUTH")
+	_ = cmd.Flags().MarkDeprecated("auth", `please use non-flag argument in the form "auth=AUTH"`)
 	cmd.Flags().String("server", "", "Set server host name")
-	_ = cmd.Flags().MarkDeprecated("server", "the --server flag is deprecated, please use arguments supplied as url=URL")
+	_ = cmd.Flags().MarkDeprecated("server", `please use the url argument instead, in the form "url=URL"`)
 	cmd.Flags().String("url", "", "Set server URL (with http or https schema)")
-	_ = cmd.Flags().MarkDeprecated("url", "the --url flag is deprecated, please use arguments supplied as url=URL")
+	_ = cmd.Flags().MarkDeprecated("url", `please use non-flag argument in the form "url=URL"`)
 	cmd.Flags().String("tenant", "", "Set tenant ID")
-	_ = cmd.Flags().MarkDeprecated("tenant", "the --tenant flag is deprecated, please use arguments supplied as tenant=TENANT")
+	_ = cmd.Flags().MarkDeprecated("tenant", `please use non-flag argument in the form "tenant=TENANT"`)
 	cmd.Flags().String("token", "", "Set token value (use --token=- to get from stdin)")
-	_ = cmd.Flags().MarkDeprecated("token", "the --token flag is deprecated, please use arguments supplied as token=TOKEN")
+	_ = cmd.Flags().MarkDeprecated("token", `please use non-flag argument in the form "token=TOKEN"`)
 	cmd.Flags().String("secret-file", "", "Set a credentials file to use for service principal (.json or .csv) or agent principal (.yaml)")
-	_ = cmd.Flags().MarkDeprecated("secret-file", "the --secret-file flag is deprecated, please use arguments supplied as secret-file=SECRET-TOKEN")
+	_ = cmd.Flags().MarkDeprecated("secret-file", `please use non-flag argument in the form "secret-file=SECRET-TOKEN"`)
 	return cmd
 }
 

--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -21,7 +21,7 @@ var meltPushCmd = &cobra.Command{
 	Long: `This command generates OTLP payload based on a fsoc telemetry data models and sends the data to the FSO Platform Ingestion services.
 	
 	To properly use the command you will need to create a fsoc profile using an agent principal yaml:
-	fsoc config set --profile <agent-principal-profile> --auth agent-principal --secret-file <agent-principal.yaml>
+	fsoc config set --profile=<agent-principal-profile> auth=agent-principal secret-file=<agent-principal.yaml>
 	
 	Then you will use the agent principal profile as part of the command:
 	fsoc melt push <fsocdatamodel>.yaml --profile <agent-principal-profile> `,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,7 @@ fsoc checks once a day if a newer version is available on github and warns if no
 You can use --no-version-check or the FSOC_NO_VERSION_CHECK=1 environment variable to suppress the check.
 
 Examples:
+  fsoc config set auth=oauth url=https://MYTENANT.observe.appdynamics.com
   fsoc login
   fsoc uql "FETCH id, type, attributes FROM entities(k8s:workload)"
   fsoc solution list

--- a/platform/api/login.go
+++ b/platform/api/login.go
@@ -37,7 +37,7 @@ var requiredSettings = map[string][]string{
 // fieldToFlag maps a config.Context field to CLI flag name, so that we can display better
 // help/error message for missing fields
 var fieldToFlag = map[string]string{
-	"Server":                   "server",
+	"Url":                      "url",
 	"Token":                    "token",
 	"SecretFile":               "secret-file",
 	"AuthMethod":               "auth",
@@ -144,7 +144,7 @@ func checkConfigForAuth(cfg *config.Context) error {
 		}
 		return fmt.Errorf(`Authentication method %q is not supported yet, please use one of {"%v"} 
 		Example:
-		fsoc config set --secret-file=~/secret.json --auth=service-principal`, cfg.AuthMethod, strings.Join(methods, `", "`))
+		fsoc config set auth=oauth url=https://MYTENANT.observe.appdynamics.com`, cfg.AuthMethod, strings.Join(methods, `", "`))
 	}
 
 	// fail if any of the required settings for this method are not set
@@ -166,7 +166,7 @@ func checkConfigForAuth(cfg *config.Context) error {
 		for _, field := range missing {
 			missList = append(missList, fieldToFlag[field])
 		}
-		usage := "Use `fsoc config set [--profile=PROFILE] --server=myhost.mydomain.com --tenant=TENANT --secret-file=CREDENTIALS`"
+		usage := `Use "fsoc config set [--config CONFIG_FILE] [--profile=PROFILE] auth=AUTH_METHOD ..."`
 		return fmt.Errorf("The current context is missing required configuration to perform a login: %v\n%v", strings.Join(missList, ","), usage)
 	}
 

--- a/platform/api/service_principal.go
+++ b/platform/api/service_principal.go
@@ -105,7 +105,7 @@ func agentOrServicePrincipalLogin(ctx *callContext, principalType string, creden
 	if ctx.cfg.Tenant == "" {
 		// some credentials formats include the tenant, use it if it's provided
 		if credentials.TenantID == "" {
-			return fmt.Errorf("Missing tenant ID, please specify using `fsoc config set --tenant=TENANTID`")
+			return fmt.Errorf(`Missing tenant ID, please specify using "fsoc config set tenant=TENANTID"`)
 		}
 		ctx.cfg.Tenant = credentials.TenantID
 		log.WithField("tenantID", ctx.cfg.Tenant).Info("Extracted tenant ID from the credentials file")
@@ -113,7 +113,7 @@ func agentOrServicePrincipalLogin(ctx *callContext, principalType string, creden
 	if ctx.cfg.URL == "" {
 		// some credentials formats provide the tokenURL from which we can get the server URL
 		if credentials.TokenURL == "" {
-			return fmt.Errorf("Missing server URL, please specify using `fsoc config set --url=SERVERURL`")
+			return fmt.Errorf(`Missing server URL, please specify using "fsoc config set url=https://MYTENANT.observe.appdynamics.com"`)
 		}
 		urlStruct, err := url.Parse(credentials.TokenURL)
 		if err != nil {

--- a/platform/api/tenant.go
+++ b/platform/api/tenant.go
@@ -93,7 +93,7 @@ func computeResolverEndpoint(ctx *config.Context) (string, error) {
 
 	elements := strings.Split(uri.Host, ".") // last element may have ":<port>"
 	if len(elements) != 4 {
-		return "", fmt.Errorf("Cannot determine tenant resolver URI for %q, please specify --tenant on `fsoc config set`", ctx.URL)
+		return "", fmt.Errorf("Cannot determine tenant resolver URI for %q, please specify tenant argument with `fsoc config set`", ctx.URL)
 	}
 
 	elements[0] = RESOLVER_HOST


### PR DESCRIPTION
## Description

Updated help strings with examples of `config set` commands to use non-flag arguments (i.e., `config set xyz=XYZ` instead of `config set --xyz=XYZ`).

This is needed for consistency with the new arguments, as the flag versions are now deprecated.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
