### PR TITLE
fixed missing nil check in fetch-and-print options; restore `ks get-t…

### DIFF
--- a/cmdkit/fetch_and_print.go
+++ b/cmdkit/fetch_and_print.go
@@ -64,7 +64,7 @@ func FetchAndPrint(cmd *cobra.Command, path string, options *FetchAndPrintOption
 	// fetch data
 	var err error
 
-	if options.Filters != nil {
+	if options != nil && options.Filters != nil {
 		// If there are filters, apply them to query path
 		numberOfFilters := len(strings.Split(path, "?"))
 		if numberOfFilters != 1 && numberOfFilters != 0 {


### PR DESCRIPTION
…ype` to work

## Description

Fixed a but introduced in v0.46.0, in the fetch-and-print filter options check. This fix resolves a panic/crash on the `ks get-type` command (which does not use the option at all).

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
