### PR TITLE
ORION-1797: transition orion urls to v1, add support for dev tags in fsoc solution status, handle 303 response for PUT/PATCH requests

### DIFF
--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -110,7 +110,7 @@ func insertObject(cmd *cobra.Command, args []string) {
 }
 
 func getObjStoreObjectUrl() string {
-	return "objstore/v1beta/objects"
+	return "knowledge-store/v1/objects"
 }
 
 var objStoreInsertPatchedObjectCmd = &cobra.Command{

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -149,15 +149,15 @@ func getObject(cmd *cobra.Command, args []string, ltFlag layerType) error {
 }
 
 func getTypeUrl(fqtn string) string {
-	return fmt.Sprintf("objstore/v1beta/types/%s", fqtn)
+	return fmt.Sprintf("knowledge-store/v1/types/%s", fqtn)
 }
 
 func getObjectUrl(fqtn, objId string) string {
-	return fmt.Sprintf("objstore/v1beta/objects/%s/%s", fqtn, objId)
+	return fmt.Sprintf("knowledge-store/v1/objects/%s/%s", fqtn, objId)
 }
 
 func getObjectListUrl(fqtn string) string {
-	return fmt.Sprintf("objstore/v1beta/objects/%s", fqtn)
+	return fmt.Sprintf("knowledge-store/v1/objects/%s", fqtn)
 }
 
 type layerType string

--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -319,12 +319,12 @@ FROM entities(k8s:deployment)[attributes("k8s.cluster.name") = "{{.Cluster}}" &&
 		var res any
 
 		if flags.create {
-			urlStr := fmt.Sprintf("objstore/v1beta/objects/%v:optimizer", flags.solutionName)
+			urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer", flags.solutionName)
 			if err = api.JSONPost(urlStr, newOptimizerConfig, &res, &api.Options{Headers: headers}); err != nil {
 				return fmt.Errorf("Failed to create knowledge object for optimizer configuration: %w", err)
 			}
 		} else {
-			urlStr := fmt.Sprintf("objstore/v1beta/objects/%v:optimizer/%v", flags.solutionName, newOptimizerConfig.OptimizerID)
+			urlStr := fmt.Sprintf("knowledge-store/v1a/objects/%v:optimizer/%v", flags.solutionName, newOptimizerConfig.OptimizerID)
 			if err = api.JSONPut(urlStr, newOptimizerConfig, &res, &api.Options{Headers: headers}); err != nil {
 				return fmt.Errorf("Failed to update knowledge object with new optimizer configuration: %w", err)
 			}
@@ -362,7 +362,7 @@ func getOptimizerConfig(optimizerId string, workloadId string, solutionName stri
 	if optimizerId != "" {
 		var response configJsonStoreItem
 
-		urlStr := fmt.Sprintf("objstore/v1beta/objects/%v:optimizer/%v", solutionName, optimizerId)
+		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer/%v", solutionName, optimizerId)
 		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers})
 		if err != nil {
 			if problem, ok := err.(api.Problem); ok && problem.Status == 404 {
@@ -381,7 +381,7 @@ func getOptimizerConfig(optimizerId string, workloadId string, solutionName stri
 		} else {
 			return optimizerConfig, fmt.Errorf("Optimizer object does not support workloads type for given ID %q", workloadId)
 		}
-		urlStr := fmt.Sprintf("objstore/v1beta/objects/%v:optimizer?filter=%v", solutionName, queryStr)
+		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer?filter=%v", solutionName, queryStr)
 
 		err := api.JSONGet(urlStr, &configPage, &api.Options{Headers: headers})
 		if err != nil {

--- a/cmd/optimize/management.go
+++ b/cmd/optimize/management.go
@@ -60,7 +60,7 @@ func (flags *managementFlags) getOptimizerConfig() (OptimizerConfiguration, erro
 	if flags.optimizerId != "" {
 		var response configJsonStoreItem
 
-		urlStr := fmt.Sprintf("objstore/v1beta/objects/%v:optimizer/%v", flags.solutionName, flags.optimizerId)
+		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer/%v", flags.solutionName, flags.optimizerId)
 		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers})
 		if err != nil {
 			return optimizerConfig, fmt.Errorf("Unable to fetch config by optimizer ID. api.JSONGet: %w", err)
@@ -75,7 +75,7 @@ func (flags *managementFlags) getOptimizerConfig() (OptimizerConfiguration, erro
 				" and data.target.k8sDeployment.namespaceName eq %q"+
 				" and data.target.k8sDeployment.workloadName eq %q",
 			flags.cluster, flags.namespace, flags.workloadName))
-		urlStr := fmt.Sprintf("objstore/v1beta/objects/%v:optimizer?filter=%v", flags.solutionName, queryStr)
+		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer?filter=%v", flags.solutionName, queryStr)
 
 		err := api.JSONGet(urlStr, &configPage, &api.Options{Headers: headers})
 		if err != nil {
@@ -95,7 +95,7 @@ func (flags *managementFlags) getOptimizerConfig() (OptimizerConfiguration, erro
 
 func (flags *managementFlags) updateOptimizerConfiguration(config OptimizerConfiguration) error {
 	var res any
-	urlStr := fmt.Sprintf("objstore/v1beta/objects/%v:optimizer/%v", flags.solutionName, config.OptimizerID)
+	urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer/%v", flags.solutionName, config.OptimizerID)
 	if err := api.JSONPut(urlStr, config, &res, &api.Options{Headers: getOrionTenantHeaders()}); err != nil {
 		return fmt.Errorf("Failed to update knowledge object with new optimizer configuration. api.JSONPut: %w", err)
 	}

--- a/cmd/optimize/status.go
+++ b/cmd/optimize/status.go
@@ -73,7 +73,7 @@ You may also specify a particular optimizer ID to fetch details for a single opt
 
 func listStatus(flags *statusFlags) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		objStoreUrl := "objstore/v1beta/objects/optimize:status"
+		objStoreUrl := "knowledge-store/v1/objects/optimize:status"
 		headers := map[string]string{
 			"layer-type": "TENANT",
 			"layer-id":   config.GetCurrentContext().Tenant,

--- a/cmd/solution/check.go
+++ b/cmd/solution/check.go
@@ -96,7 +96,7 @@ func checkSolution(cmd *cobra.Command, args []string) {
 }
 
 func getTypeUrl(fqtn string) string {
-	return fmt.Sprintf("objstore/v1beta/types/%s", fqtn)
+	return fmt.Sprintf("knowledge-store/v1/types/%s", fqtn)
 }
 
 func Fetch(path string, httpOptions *api.Options) map[string]interface{} {

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -52,5 +52,5 @@ func solutionDescribe(cmd *cobra.Command, args []string) {
 }
 
 func getSolutionDescribeUrl(id string) string {
-	return "objstore/v1beta/objects/extensibility:solution/" + id
+	return "knowledge-store/v1/objects/extensibility:solution/" + id
 }

--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -65,7 +65,7 @@ func downloadSolution(cmd *cobra.Command, args []string) {
 }
 
 func getSolutionDownloadUrl(solutionName string) string {
-	return fmt.Sprintf("solnmgmt/v1beta/solutions/%s", solutionName)
+	return fmt.Sprintf("solution-manager/v1/solutions/%s", solutionName)
 }
 
 func getSolutionNameWithZip(solutionName string) string {

--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -82,7 +82,7 @@ func getSolutionList(cmd *cobra.Command, args []string) {
 }
 
 func getSolutionListUrl() string {
-	return "objstore/v1beta/objects/extensibility:solution"
+	return "knowledge-store/v1/objects/extensibility:solution"
 }
 
 func getSolutionNames(prefix string) (names []string) {

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -83,6 +83,9 @@ func getSolutionStatusCmd() *cobra.Command {
 	solutionStatusCmd.Flags().
 		String("status-type", "", "The status type that you want to see.  This can be one of [upload, install, all] and will default to all if not specified")
 
+	solutionStatusCmd.Flags().
+		String("tag", "stable", "The tag associated with the solution for which you would like to view the status for.  Defaults to 'stable' unless otherwise specified")
+
 	return solutionStatusCmd
 }
 
@@ -117,9 +120,17 @@ func getExtensibilitySolutionObject(url string, headers map[string]string) Exten
 }
 
 func fetchValuesAndPrint(operation string, solutionNameAndVersionQuery string, subscriptionStatusQuery string, solutionName string, requestHeaders map[string]string, cmd *cobra.Command) {
+	var solutionNameWithTag string
+	solutionTag, _ := cmd.Flags().GetString("tag")
+
+	if solutionTag != "stable" {
+		solutionNameWithTag = fmt.Sprintf(`%s.%s`, solutionName, solutionTag)
+	} else {
+		solutionNameWithTag = solutionName
+	}
 	uploadStatusItem := getObjects(fmt.Sprintf(getSolutionReleaseUrl(), solutionNameAndVersionQuery), requestHeaders)
 	installStatusItem := getObjects(fmt.Sprintf(getSolutionInstallUrl(), solutionNameAndVersionQuery), requestHeaders)
-	solutionStatusItem := getExtensibilitySolutionObject(fmt.Sprintf(getExtensibilitySolutionUrl(), solutionName), requestHeaders)
+	solutionStatusItem := getExtensibilitySolutionObject(fmt.Sprintf(getExtensibilitySolutionUrl(), solutionNameWithTag), requestHeaders)
 
 	installStatusData := installStatusItem.StatusData
 	uploadStatusData := uploadStatusItem.StatusData
@@ -175,6 +186,7 @@ func fetchValuesAndPrint(operation string, solutionNameAndVersionQuery string, s
 func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	var solutionVersionFilter string
 	var solutionNameFilter string
+	var solutionTagFilter string
 	var solutionNameAndVersionFilter string
 	var solutionNameAndTenantIdFilter string
 	cfg := config.GetCurrentContext()
@@ -188,18 +200,24 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	}
 	solutionVersion, _ := cmd.Flags().GetString("solution-version")
 	statusTypeToFetch, _ := cmd.Flags().GetString("status-type")
+	solutionTag, _ := cmd.Flags().GetString("tag")
 	solutionVersionFilter = fmt.Sprintf(`data.solutionVersion eq "%s"`, solutionVersion)
 	solutionNameFilter = fmt.Sprintf(`data.solutionName eq "%s"`, solutionName)
+	solutionTagFilter = fmt.Sprintf(`data.tag eq "%s"`, solutionTag)
+	log.Infof(`value of solution tag filter: %s`, solutionTagFilter)
 
 	if solutionVersion != "" {
-		solutionNameAndVersionFilter = fmt.Sprintf(`%s and %s`, solutionNameFilter, solutionVersionFilter)
+		solutionNameAndVersionFilter = fmt.Sprintf(`%s and %s and %s`, solutionNameFilter, solutionVersionFilter, solutionTagFilter)
 	} else {
-		solutionNameAndVersionFilter = solutionNameFilter
+		solutionNameAndVersionFilter = fmt.Sprintf(`%s and %s`, solutionNameFilter, solutionTagFilter)
 	}
-	solutionNameAndTenantIdFilter = fmt.Sprintf(`%s and data.tenantId eq "%s"`, solutionNameFilter, cfg.Tenant)
+	solutionNameAndTenantIdFilter = fmt.Sprintf(`%s and data.tenantId eq "%s" and %s`, solutionNameFilter, cfg.Tenant, solutionTagFilter)
 
 	solutionNameAndVersionQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(solutionNameAndVersionFilter))
 	solutionNameAndTenantIdQuery := fmt.Sprintf("?order=%s&filter=%s", url.QueryEscape("desc"), url.QueryEscape(solutionNameAndTenantIdFilter))
+
+	log.Infof(`solution name and version query: %s`, solutionNameAndVersionQuery)
+	log.Infof(`solution name and tenant id query: %s`, solutionNameAndTenantIdQuery)
 
 	fetchValuesAndPrint(statusTypeToFetch, solutionNameAndVersionQuery, solutionNameAndTenantIdQuery, solutionName, headers, cmd)
 

--- a/cmd/solution/subscribe.go
+++ b/cmd/solution/subscribe.go
@@ -94,5 +94,5 @@ func subscribeToSolution(cmd *cobra.Command, args []string) {
 }
 
 func getSolutionSubscribeUrl() string {
-	return "objstore/v1beta/objects/extensibility:solution"
+	return "knowledge-store/v1/objects/extensibility:solution"
 }

--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -283,5 +283,5 @@ func getSolutionValidationErrorsString(total int, errors Errors) string {
 }
 
 func getSolutionPushUrl() string {
-	return "solnmgmt/v1beta/solutions"
+	return "solution-manager/v1/solutions"
 }

--- a/platform/api/call.go
+++ b/platform/api/call.go
@@ -198,7 +198,11 @@ func httpRequest(method string, path string, body any, out any, options *Options
 	}
 
 	// create http client for the request
-	client := &http.Client{}
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 
 	// build HTTP request
 	req, err := prepareHTTPRequest(cfg, client, method, path, body, options.Headers)
@@ -254,7 +258,8 @@ func httpRequest(method string, path string, body any, out any, options *Options
 	}
 
 	// return if API call response indicates error
-	if resp.StatusCode/100 != 2 {
+	// handle 303 in case of updating object that changes the ID
+	if resp.StatusCode/100 != 2 && resp.StatusCode != 303 {
 		callCtx.stopSpinner(false) // if still running
 		log.WithFields(log.Fields{"status": resp.StatusCode}).Error("Platform API call failed")
 		return parseIntoError(resp, respBytes)
@@ -278,7 +283,8 @@ func httpRequest(method string, path string, body any, out any, options *Options
 			if err != nil {
 				return fmt.Errorf("Failed to save the solution archive file as %q: %w", solutionFileName, err)
 			}
-		} else if len(respBytes) > 0 {
+		// if response code is 303 then it won't be valid json
+		} else if len(respBytes) > 0 && resp.StatusCode != 303 {
 			// unmarshal response from JSON (assuming JSON data, even if the content-type is not set)
 			if err := json.Unmarshal(respBytes, out); err != nil {
 				return fmt.Errorf("Failed to JSON-parse the response: %w (%q)", err, respBytes)

--- a/platform/api/call.go
+++ b/platform/api/call.go
@@ -283,7 +283,7 @@ func httpRequest(method string, path string, body any, out any, options *Options
 			if err != nil {
 				return fmt.Errorf("Failed to save the solution archive file as %q: %w", solutionFileName, err)
 			}
-		// if response code is 303 then it won't be valid json
+			// if response code is 303 then it won't be valid json
 		} else if len(respBytes) > 0 && resp.StatusCode != 303 {
 			// unmarshal response from JSON (assuming JSON data, even if the content-type is not set)
 			if err := json.Unmarshal(respBytes, out); err != nil {


### PR DESCRIPTION
## Description

Transition all of the calls to orion services (SM and KS) to use v1 urls instead of v1beta.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
