### PR TITLE
Mofidy version check to be best effort and notify on each run

### DIFF
--- a/cmd/version/version_check.go
+++ b/cmd/version/version_check.go
@@ -48,6 +48,10 @@ func CheckForUpdate(versionChannel chan *semver.Version) {
 }
 
 func CompareAndLogVersions(newestVersionSemVar *semver.Version) {
+	if newestVersionSemVar == nil {
+		log.Error("failed to get latest version")
+		return
+	}
 	currentVersion := GetVersion()
 	currentVersionSemVer := ConvertVerToSemVar(currentVersion)
 	newerVersionAvailable := currentVersionSemVer.Compare(newestVersionSemVar) < 0


### PR DESCRIPTION
## Description

* Fix null pointer dereference when version check fails
* Do not wait on the version check to complete. If it does not complete in time, we will try again next time. This makes it a no-cost operation for local commands, while allows it to still succeedes when fsoc is doing network commands (which take longer than the version check)
* When a version check completes successfully, store the version in a file
* If there is a newer version (as indicated by the version file), notify the user on each fsoc command. This is a change from the previous behavior, which only notified the user when the latest version is fetched. The logic for skipping version checks is preserved, if specified the latest version will not be checked _and_ no notifications will be printed even if we previusly detected a newer version.

