### PR TITLE
Refactor collection API calls to use generics

### DIFF
--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -77,7 +77,7 @@ func editObject(cmd *cobra.Command, args []string) {
 	httpOptions := &api.Options{Headers: headers}
 	url := getObjectUrl(fqtn, objID)
 
-	var res api.KSObject
+	var res KSObject
 	err = api.JSONGet(url, &res, httpOptions)
 	if err != nil {
 		log.Fatalf("Failed to fetch object: %v", err)

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -77,7 +77,7 @@ func editObject(cmd *cobra.Command, args []string) {
 	httpOptions := &api.Options{Headers: headers}
 	url := getObjectUrl(fqtn, objID)
 
-	var res Object
+	var res api.KSObject
 	err = api.JSONGet(url, &res, httpOptions)
 	if err != nil {
 		log.Fatalf("Failed to fetch object: %v", err)

--- a/cmd/knowledge/knowledge.go
+++ b/cmd/knowledge/knowledge.go
@@ -99,12 +99,13 @@ func getObjectsForType(typeName string, lType string, layerID string, prefix str
 
 	httpOptions := &api.Options{Headers: headers}
 
-	items, err := api.JSONGetCollection[api.KSObject](getObjectListUrl(typeName), httpOptions)
+	var result api.CollectionResult[KSObject]
+	err := api.JSONGetCollection[KSObject](getObjectListUrl(typeName), &result, httpOptions)
 	if err != nil {
 		return objects
 	}
 
-	for _, s := range items {
+	for _, s := range result.Items {
 		if strings.HasPrefix(s.ID, prefix) {
 			objects = append(objects, s.ID)
 		}
@@ -115,12 +116,13 @@ func getObjectsForType(typeName string, lType string, layerID string, prefix str
 
 func getTypes(prefix string) (types []string) {
 
-	items, err := api.JSONGetCollection[api.KSType](getTypeUrl(""), nil)
+	var result api.CollectionResult[KSType]
+	err := api.JSONGetCollection[KSType](getTypeUrl(""), &result, nil)
 	if err != nil {
 		return types
 	}
 
-	for _, s := range items {
+	for _, s := range result.Items {
 		t := fmt.Sprintf("%s:%s", s.Solution, s.Name)
 		if strings.HasPrefix(t, prefix) {
 			types = append(types, t)

--- a/cmd/knowledge/knowledge.go
+++ b/cmd/knowledge/knowledge.go
@@ -53,24 +53,6 @@ for more information on the Knowledge Store. `,
 	return knowledgeStoreCmd
 }
 
-type Type struct {
-	Name     string `json:"name"`
-	Solution string `json:"solution"`
-}
-
-type TypeList struct {
-	Items []Type `json:"items"`
-}
-
-type Object struct {
-	ID   string                 `json:"id"`
-	Data map[string]interface{} `json:"data"`
-}
-
-type ObjectList struct {
-	Items []Object `json:"items"`
-}
-
 // completion functions
 var typeCompletionFunc = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return getTypes(toComplete), cobra.ShellCompDirectiveNoFileComp
@@ -117,14 +99,12 @@ func getObjectsForType(typeName string, lType string, layerID string, prefix str
 
 	httpOptions := &api.Options{Headers: headers}
 
-	var res ObjectList
-	url := fmt.Sprintf("%s?max=%d", getObjectListUrl(typeName), api.MAX_COMPLETION_RESULTS)
-	err := api.JSONGet(url, &res, httpOptions)
+	items, err := api.JSONGetCollection[api.KSObject](getObjectListUrl(typeName), httpOptions)
 	if err != nil {
 		return objects
 	}
 
-	for _, s := range res.Items {
+	for _, s := range items {
 		if strings.HasPrefix(s.ID, prefix) {
 			objects = append(objects, s.ID)
 		}
@@ -135,14 +115,12 @@ func getObjectsForType(typeName string, lType string, layerID string, prefix str
 
 func getTypes(prefix string) (types []string) {
 
-	var res TypeList
-	url := fmt.Sprintf("%s?max=%d", getTypeUrl(""), api.MAX_COMPLETION_RESULTS)
-	err := api.JSONGet(url, &res, nil)
+	items, err := api.JSONGetCollection[api.KSType](getTypeUrl(""), nil)
 	if err != nil {
 		return types
 	}
 
-	for _, s := range res.Items {
+	for _, s := range items {
 		t := fmt.Sprintf("%s:%s", s.Solution, s.Name)
 		if strings.HasPrefix(t, prefix) {
 			types = append(types, t)

--- a/cmd/knowledge/types.go
+++ b/cmd/knowledge/types.go
@@ -1,0 +1,11 @@
+package knowledge
+
+type KSType struct {
+	Name     string `json:"name"`
+	Solution string `json:"solution"`
+}
+
+type KSObject struct {
+	ID   string                 `json:"id"`
+	Data map[string]interface{} `json:"data"`
+}

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -44,7 +44,7 @@ func solutionDescribe(cmd *cobra.Command, args []string) {
 	}
 
 	log.WithField("solution", solution).Info("Getting solution details")
-	var res api.KSSolution
+	var res Solution
 	err := api.JSONGet(getSolutionDescribeUrl(url.PathEscape(solution)), &res, &api.Options{Headers: headers})
 	if err != nil {
 		log.Fatalf("Cannot get solution details: %v", err)

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -44,7 +44,7 @@ func solutionDescribe(cmd *cobra.Command, args []string) {
 	}
 
 	log.WithField("solution", solution).Info("Getting solution details")
-	var res Solution
+	var res api.KSSolution
 	err := api.JSONGet(getSolutionDescribeUrl(url.PathEscape(solution)), &res, &api.Options{Headers: headers})
 	if err != nil {
 		log.Fatalf("Cannot get solution details: %v", err)

--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -15,7 +15,6 @@
 package solution
 
 import (
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -92,14 +91,12 @@ func getSolutionNames(prefix string) (names []string) {
 	}
 	httpOptions := &api.Options{Headers: headers}
 
-	var res SolutionList
-	url := fmt.Sprintf("%s?max=%d", getSolutionListUrl(), api.MAX_COMPLETION_RESULTS)
-	err := api.JSONGet(url, &res, httpOptions)
+	items, err := api.JSONGetCollection[api.KSObject](getSolutionListUrl(), httpOptions)
 	if err != nil {
 		return names
 	}
 
-	for _, s := range res.Items {
+	for _, s := range items {
 		if strings.HasPrefix(s.ID, prefix) {
 			names = append(names, s.ID)
 		}

--- a/cmd/solution/list.go
+++ b/cmd/solution/list.go
@@ -91,12 +91,13 @@ func getSolutionNames(prefix string) (names []string) {
 	}
 	httpOptions := &api.Options{Headers: headers}
 
-	items, err := api.JSONGetCollection[api.KSObject](getSolutionListUrl(), httpOptions)
+	var result api.CollectionResult[Solution]
+	err := api.JSONGetCollection[Solution](getSolutionListUrl(), &result, httpOptions)
 	if err != nil {
 		return names
 	}
 
-	for _, s := range items {
+	for _, s := range result.Items {
 		if strings.HasPrefix(s.ID, prefix) {
 			names = append(names, s.ID)
 		}

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -71,21 +71,6 @@ type SolutionDef struct {
 	Name         string   `json:"name,omitempty"`
 }
 
-type Solution struct {
-	ID             string `json:"id"`
-	LayerID        string `json:"layerId"`
-	LayerType      string `json:"layerType"`
-	ObjectMimeType string `json:"objectMimeType"`
-	TargetObjectId string `json:"targetObjectId"`
-	CreatedAt      string `json:"createdAt"`
-	UpdatedAt      string `json:"updatedAt"`
-	DisplayName    string `json:"displayName"`
-}
-
-type SolutionList struct {
-	Items []Solution `json:"items"`
-}
-
 func (manifest *Manifest) GetNamespaceName() string {
 	namespaceName := manifest.Name
 	if manifest.HasIsolation() {

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -71,6 +71,17 @@ type SolutionDef struct {
 	Name         string   `json:"name,omitempty"`
 }
 
+type Solution struct {
+	ID             string `json:"id"`
+	LayerID        string `json:"layerId"`
+	LayerType      string `json:"layerType"`
+	ObjectMimeType string `json:"objectMimeType"`
+	TargetObjectId string `json:"targetObjectId"`
+	CreatedAt      string `json:"createdAt"`
+	UpdatedAt      string `json:"updatedAt"`
+	DisplayName    string `json:"displayName"`
+}
+
 func (manifest *Manifest) GetNamespaceName() string {
 	namespaceName := manifest.Name
 	if manifest.HasIsolation() {

--- a/cmdkit/fetch_and_print.go
+++ b/cmdkit/fetch_and_print.go
@@ -80,15 +80,12 @@ func FetchAndPrint(cmd *cobra.Command, path string, options *FetchAndPrintOption
 		if method != "GET" {
 			log.Fatalf("bug: cannot request %q for a collection at %q, only GET is supported for collections", method, path)
 		}
-		items, err := api.JSONGetCollection[any](path, httpOptions)
+		var result api.CollectionResult[any]
+		err := api.JSONGetCollection[any](path, &result, httpOptions)
 		if err != nil {
 			log.Fatalf("Platform API call failed: %v", err)
 		}
-		res = struct {
-			Items []any `json:"items"`
-		}{
-			Items: items,
-		}
+		res = result
 
 	} else {
 		err = api.JSONRequest(method, path, body, &res, httpOptions)

--- a/cmdkit/fetch_and_print.go
+++ b/cmdkit/fetch_and_print.go
@@ -80,7 +80,16 @@ func FetchAndPrint(cmd *cobra.Command, path string, options *FetchAndPrintOption
 		if method != "GET" {
 			log.Fatalf("bug: cannot request %q for a collection at %q, only GET is supported for collections", method, path)
 		}
-		err = api.JSONGetCollection(path, &res, httpOptions)
+		items, err := api.JSONGetCollection[any](path, httpOptions)
+		if err != nil {
+			log.Fatalf("Platform API call failed: %v", err)
+		}
+		res = struct {
+			Items []any `json:"items"`
+		}{
+			Items: items,
+		}
+
 	} else {
 		err = api.JSONRequest(method, path, body, &res, httpOptions)
 	}

--- a/platform/api/collection.go
+++ b/platform/api/collection.go
@@ -30,51 +30,30 @@ const (
 	nextRelName    = "next"
 )
 
-const MAX_COMPLETION_RESULTS = 500
-
-type dataPage struct {
-	Items []any `json:"items"`
-	Total int   `json:"total"`
-}
-
 // JSONGetCollection performs a GET request and parses the response as JSON,
 // handling pagination per https://www.rfc-editor.org/rfc/rfc5988,
 // https://developer.cisco.com/api-guidelines/#rest-style/API.REST.STYLE.25 and
 // https://developer.cisco.com/api-guidelines/#rest-style/API.REST.STYLE.24
-func JSONGetCollection(path string, out any, options *Options) error {
-
-	// ensure we can return the data
-	outPtr, ok := out.(*any)
-	if !ok {
-		return fmt.Errorf("bug: request for collection at %q does not provide buffer for data (type %T found instead of *any)", path, out)
-	}
+func JSONGetCollection[T KSItem](path string, options *Options) (items []T, err error) {
 
 	subOptions := Options{}
 	if options != nil {
 		subOptions = *options // shallow copy
 	}
 
-	var result dataPage
-
-	var page dataPage
+	var page KSCollectionResponse[T]
 	var pageNo int
 	for pageNo = 0; true; pageNo += 1 {
 		// request collection
 		err := httpRequest("GET", path, nil, &page, &subOptions)
 		if err != nil {
 			if pageNo > 0 {
-				return fmt.Errorf("Error retrieving non-first page #%v in collection at %q: %v. All data discarded", pageNo+1, path, err)
+				return nil, fmt.Errorf("Error retrieving non-first page #%v in collection at %q: %v. All data discarded", pageNo+1, path, err)
 			}
-			return err
+			return nil, err
 		}
 
-		// transfer received items
-		//log.Infof("Collection page #%v returned %v items, with total of %v", pageNo+1, len(page.Items), page.Total)
-		if result.Items == nil {
-			// initialize slice for the full result size
-			result.Items = make([]any, 0, page.Total)
-		}
-		result.Items = append(result.Items, page.Items...)
+		items = append(items, page.Items...)
 
 		// break if no more pages (no response headers, no links or no next link)
 		if subOptions.ResponseHeaders == nil {
@@ -94,23 +73,21 @@ func JSONGetCollection(path string, out any, options *Options) error {
 		log.Infof("Collection page #%v at %q returned %v items and indicated that more are available at %q for a total of %v", pageNo+1, path, len(page.Items), next, page.Total)
 		nextUrl, err := url.Parse(next.String())
 		if err != nil {
-			return fmt.Errorf("Failed to parse collection iterator link(s) %v: %v ", links, err)
+			return nil, fmt.Errorf("failed to parse collection iterator link(s) %v: %v ", links, err)
 		}
 		nextQuery := nextUrl.RawQuery
 		nextUrl, err = url.Parse(path)
 		if err != nil {
-			return fmt.Errorf("Failed to parse path %q: %v", path, err)
+			return nil, fmt.Errorf("failed to parse path %q: %v", path, err)
 		}
 		nextUrl.RawQuery = nextQuery
 		path = nextUrl.String()
 	}
 	log.Infof("Collection page #%v at %q returned %v items (last page)", pageNo+1, path, len(page.Items))
 
-	result.Total = len(result.Items)
-	if result.Total != page.Total {
-		log.Warnf("Collection at %q returned %v items vs. expected %v items", path, result.Total, page.Total)
+	if len(items) != page.Total {
+		log.Warnf("Collection at %q returned %v items vs. expected %v items", path, len(items), page.Total)
 	}
-	*outPtr = &result
 
-	return nil
+	return items, nil
 }

--- a/platform/api/types.go
+++ b/platform/api/types.go
@@ -1,0 +1,31 @@
+package api
+
+type KSType struct {
+	Name     string `json:"name"`
+	Solution string `json:"solution"`
+}
+
+type KSObject struct {
+	ID   string                 `json:"id"`
+	Data map[string]interface{} `json:"data"`
+}
+
+type KSSolution struct {
+	ID             string `json:"id"`
+	LayerID        string `json:"layerId"`
+	LayerType      string `json:"layerType"`
+	ObjectMimeType string `json:"objectMimeType"`
+	TargetObjectId string `json:"targetObjectId"`
+	CreatedAt      string `json:"createdAt"`
+	UpdatedAt      string `json:"updatedAt"`
+	DisplayName    string `json:"displayName"`
+}
+
+type KSItem interface {
+	any | KSType | KSObject | KSSolution
+}
+
+type KSCollectionResponse[T KSItem] struct {
+	Items []T `json:"items"`
+	Total int `json:"total"`
+}

--- a/platform/api/types.go
+++ b/platform/api/types.go
@@ -1,31 +1,6 @@
 package api
 
-type KSType struct {
-	Name     string `json:"name"`
-	Solution string `json:"solution"`
-}
-
-type KSObject struct {
-	ID   string                 `json:"id"`
-	Data map[string]interface{} `json:"data"`
-}
-
-type KSSolution struct {
-	ID             string `json:"id"`
-	LayerID        string `json:"layerId"`
-	LayerType      string `json:"layerType"`
-	ObjectMimeType string `json:"objectMimeType"`
-	TargetObjectId string `json:"targetObjectId"`
-	CreatedAt      string `json:"createdAt"`
-	UpdatedAt      string `json:"updatedAt"`
-	DisplayName    string `json:"displayName"`
-}
-
-type KSItem interface {
-	any | KSType | KSObject | KSSolution
-}
-
-type KSCollectionResponse[T KSItem] struct {
+type CollectionResult[T any] struct {
 	Items []T `json:"items"`
 	Total int `json:"total"`
 }


### PR DESCRIPTION
This change allows api.JSONGetCollection() to be used for fetching a paginated collection of KnowledgeStore objects, which is used in multiple places. It should have no effect on existing users of api.JSONGetCollection(), with a slight interface change, but it allows other component to use it. Completion functions use that to fetch multi-page results.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

