### PR TITLE
FSOC-160 Fatal when add-knowledge flag includes colon

### DIFF
--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -74,6 +74,9 @@ func extendSolution(cmd *cobra.Command, args []string) {
 	if cmd.Flags().Changed("add-knowledge") {
 		componentName, _ := cmd.Flags().GetString("add-knowledge")
 		componentName = strings.ToLower(componentName)
+		if strings.Contains(componentName, ":") {
+			log.Fatalf("\":\" is a disallowed character. Note that solution name is not required for the add-knowledge flag")
+		}
 		output.PrintCmdStatus(cmd, fmt.Sprintf("Adding %s knowledge component to %s's solution directory structure... \n", componentName, manifest.Name))
 		folderName := "types"
 		fileName := fmt.Sprintf("%s.json", componentName)


### PR DESCRIPTION
## Description

Check for ":" in extend add-knowledge command


## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
