### PR TITLE
Add "config delete NAME" command

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -47,6 +47,7 @@ func NewSubCmd() *cobra.Command {
 	cmd.AddCommand(newCmdConfigSet())
 	cmd.AddCommand(newCmdConfigUse())
 	cmd.AddCommand(newCmdConfigList())
+	cmd.AddCommand(newCmdConfigDelete())
 
 	return cmd
 }

--- a/cmd/config/delete.go
+++ b/cmd/config/delete.go
@@ -1,0 +1,76 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+func newCmdConfigDelete() *cobra.Command {
+
+	var cmd = &cobra.Command{
+		Use:   "delete CONTEXT_NAME",
+		Short: "Delete a context from the fsoc config file",
+		Long:  `Delete a context from the fsoc config file`,
+		Args:  cobra.ExactArgs(1),
+		Run:   configDeleteContext,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return ListContexts(toComplete), cobra.ShellCompDirectiveDefault
+		},
+	}
+
+	return cmd
+}
+
+func configDeleteContext(cmd *cobra.Command, args []string) {
+	profile := args[0]
+
+	// Make sure profile exists
+	ctx := getContext(profile)
+	if ctx == nil {
+		log.Fatalf("Could not find profile %q", profile)
+	}
+
+	cfg := getConfig()
+	profileIdx := -1
+	for idx, c := range cfg.Contexts {
+		if profile == c.Name {
+			profileIdx = idx
+			break
+		}
+	}
+
+	if profileIdx == -1 {
+		log.Fatalf("(possible bug) Could not find profile %q", profile)
+	}
+
+	// Delete context from config
+	newContexts := append(cfg.Contexts[:profileIdx], cfg.Contexts[profileIdx+1:]...)
+	update := map[string]interface{}{"contexts": newContexts}
+	if cfg.CurrentContext == profile {
+		var newCurrentContext string
+		if len(newContexts) > 0 {
+			newCurrentContext = newContexts[0].Name
+		} else {
+			newCurrentContext = DefaultContext
+		}
+		update["current_context"] = newCurrentContext
+		log.Infof("Setting current profile to %q", newCurrentContext)
+	}
+
+	updateConfigFile(update)
+	log.Infof("Deleted prfofile %q", profile)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,6 @@ var outputFormat string
 
 const (
 	FSOC_CONFIG_ENVVAR    = "FSOC_CONFIG"
-	FSOC_PROFILE_ENVVAR   = "FSOC_PROFILE"
 	FSOC_NO_VERSION_CHECK = "FSOC_NO_VERSION_CHECK"
 )
 
@@ -65,7 +64,7 @@ Full Stack Observability (FSO) Platform (https://developer.cisco.com/docs/fso/).
 It allows developers to interact with the product environments--developer, test and production--in a
 uniform way and to perform common tasks. fsoc primarily targets developers building solutions on the platform.
 
-You can use --config and --profile to select authentication credentials to use. You can also use 
+You can use --config and --profile to select authentication credentials to use. You can also use
 environment variables FSOC_CONFIG and FSOC_PROFILE, respectively. The command line flags take precedence.
 If a profile is not specified otherwise, the current profile from the config file is used.
 
@@ -203,24 +202,21 @@ func preExecHook(cmd *cobra.Command, args []string) {
 		"flags":     helperFlagFormatter(cmd.Flags())}).
 		Info("fsoc command line")
 
-	// override the config file's current profile from cmd line or env var
-	var profile string // used only in this block
-	if cmd.Flags().Changed("profile") {
-		profile, _ = cmd.Flags().GetString("profile")
-	} else {
-		profile = os.Getenv(FSOC_PROFILE_ENVVAR) // remains empty if not defined
-	}
-	if profile != "" { // allow empty string on cmd line to mean use current
-		config.SetSelectedProfile(profile)
-	}
-
 	// Determine if a configured profile is required for this command
 	// (bypassed only for commands that must work or can safely work without it)
 	bypass := bypassConfig(cmd) || cmd.Name() == "help" || isCompletionCommand(cmd)
 
 	// try to read the config file.and profile
 	err = viper.ReadInConfig()
-	if err == nil {
+	if err != nil && !bypass {
+		log.Fatalf("fsoc is not configured, please use \"fsoc config set\" to configure an initial context")
+	}
+
+	// override the config file's current profile from cmd line or env var
+	config.SetCurrentProfile(cmd, args, bypass)
+	if err != nil { // bypass == true
+		log.Infof("Unable to read config file (%v), proceeding without a config", err)
+	} else { // err == nil
 		profile := config.GetCurrentProfileName()
 		exists := config.GetCurrentContext() != nil
 		if !exists && !bypass {
@@ -232,12 +228,6 @@ func preExecHook(cmd *cobra.Command, args []string) {
 			"existing":    exists,
 		}).
 			Info("fsoc context")
-	} else {
-		if bypass {
-			log.Infof("Unable to read config file (%v), proceeding without a config", err)
-		} else {
-			log.Fatalf("fsoc is not configured, please use \"fsoc config set\" to configure an initial context")
-		}
 	}
 
 	// Do version checking

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -19,6 +19,7 @@ var solutionDescribeCmd = &cobra.Command{
 	Example: `  fsoc solution describe spacefleet`,
 	Run:     solutionDescribe,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config.SetCurrentProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -19,6 +19,7 @@ import (
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 	"github.com/cisco-open/fsoc/platform/api"
 )
@@ -32,6 +33,7 @@ var solutionDownloadCmd = &cobra.Command{
 	Run:              downloadSolution,
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config.SetCurrentProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -27,6 +27,7 @@ import (
 	"github.com/spf13/afero/zipfs"
 	"github.com/spf13/cobra"
 
+	"github.com/cisco-open/fsoc/cmd/config"
 	"github.com/cisco-open/fsoc/output"
 	"github.com/cisco-open/fsoc/platform/api"
 )
@@ -42,6 +43,7 @@ var solutionForkCmd = &cobra.Command{
 		if len(args) >= 1 {
 			return nil, cobra.ShellCompDirectiveDefault
 		} else {
+			config.SetCurrentProfile(cmd, args, false)
 			return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 		}
 	},

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -69,6 +69,7 @@ var solutionStatusCmd = &cobra.Command{
 	},
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config.SetCurrentProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/subscribe.go
+++ b/cmd/solution/subscribe.go
@@ -38,6 +38,7 @@ var solutionSubscribeCmd = &cobra.Command{
 	Run:              subscribeToSolution,
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config.SetCurrentProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/unsubscribe.go
+++ b/cmd/solution/unsubscribe.go
@@ -33,6 +33,7 @@ var solutionUnsubscribeCmd = &cobra.Command{
 	Run:              unsubscribeFromSolution,
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config.SetCurrentProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }


### PR DESCRIPTION
## Description

Deletes a context from the config file. If the context is the current context, the current context is set to the first context in the config file. If the config file is empty after the delete, the current context  is set to the default context.

Note: This should be merged after https://github.com/cisco-open/fsoc/pull/165, on which it is based.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
