### PR TITLE
FSOC-168: fix issue with fsoc ks get not automatically paginating result set

### DIFF
--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -144,7 +144,7 @@ func getObject(cmd *cobra.Command, args []string, ltFlag layerType) error {
 		objStoreUrl = getObjectListUrl(fqtn)
 	}
 
-	cmdkit.FetchAndPrint(cmd, objStoreUrl, &cmdkit.FetchAndPrintOptions{Headers: headers})
+	cmdkit.FetchAndPrint(cmd, objStoreUrl, &cmdkit.FetchAndPrintOptions{Headers: headers, IsCollection: true})
 	return nil
 }
 


### PR DESCRIPTION
## Description

Noticed that the fsoc ks get command was not passing IsCollection: true when calling cmdkit.FetchAndPrint and this was causing issues with some users who were trying to get all of the objects in the get all output.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
