### PR TITLE
Feature/handling typed attributes in melt

### DIFF
--- a/cmd/melt/geometry-test.go
+++ b/cmd/melt/geometry-test.go
@@ -205,7 +205,7 @@ func exportSpans() error {
 				TraceID:    traceID1.String(),
 				SpanID:     spanID1.String(),
 				TraceState: "state",
-				Attributes: map[string]string{
+				Attributes: map[string]interface{}{
 					"span-link-attrbute1": "value",
 				},
 			},

--- a/platform/melt/exporter.go
+++ b/platform/melt/exporter.go
@@ -432,6 +432,10 @@ func toKeyValueList(a map[string]interface{}) []*common.KeyValue {
 				StringValue: vt.String(),
 			}
 		default:
+			if v == nil {
+				log.Warnf("Value not set for attribute: %s", k)
+				continue
+			}
 			otVal.Value = &common.AnyValue_StringValue{
 				StringValue: fmt.Sprintf("%v", vt.Interface()),
 			}

--- a/platform/melt/exporter.go
+++ b/platform/melt/exporter.go
@@ -3,7 +3,7 @@ package melt
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
+	"reflect"
 
 	"github.com/apex/log"
 	colllogs "go.opentelemetry.io/proto/otlp/collector/logs/v1"
@@ -405,58 +405,44 @@ func (exp *Exporter) exportHTTP(path string, m protoreflect.ProtoMessage) error 
 	return nil
 }
 
-func toKeyValueList(a map[string]string) []*common.KeyValue {
+func toKeyValueList(a map[string]interface{}) []*common.KeyValue {
 	attribs := []*common.KeyValue{}
-
 	for k, v := range a {
-		key := k
-		var value *common.KeyValue
-
-		if intValue, err := strconv.Atoi(v); err == nil {
-			value = &common.KeyValue{
-				Key: key,
-				Value: &common.AnyValue{
-					Value: &common.AnyValue_IntValue{
-						IntValue: int64(intValue),
-					},
-				},
+		otVal := &common.AnyValue{}
+		vt := reflect.ValueOf(v)
+		switch vt.Kind() {
+		case reflect.Bool:
+			otVal.Value = &common.AnyValue_BoolValue{
+				BoolValue: vt.Bool(),
 			}
-		} else if doubleValue, err := strconv.ParseFloat(v, 64); err == nil {
-			value = &common.KeyValue{
-				Key: key,
-				Value: &common.AnyValue{
-					Value: &common.AnyValue_DoubleValue{
-						DoubleValue: doubleValue,
-					},
-				},
+		case reflect.Int, reflect.Int8, reflect.Int32, reflect.Int64:
+			otVal.Value = &common.AnyValue_IntValue{
+				IntValue: vt.Int(),
 			}
-		} else if boolValue, err := strconv.ParseBool(v); err == nil {
-			value = &common.KeyValue{
-				Key: key,
-				Value: &common.AnyValue{
-					Value: &common.AnyValue_BoolValue{
-						BoolValue: boolValue,
-					},
-				},
+		case reflect.Uint, reflect.Uint8, reflect.Uint32, reflect.Uint64:
+			otVal.Value = &common.AnyValue_IntValue{
+				IntValue: int64(vt.Uint()),
 			}
-
-		} else {
-			value = &common.KeyValue{
-				Key: key,
-				Value: &common.AnyValue{
-					Value: &common.AnyValue_StringValue{
-						StringValue: v,
-					},
-				},
+		case reflect.Float32, reflect.Float64:
+			otVal.Value = &common.AnyValue_DoubleValue{
+				DoubleValue: float64(vt.Float()),
 			}
+		case reflect.String:
+			otVal.Value = &common.AnyValue_StringValue{
+				StringValue: vt.String(),
+			}
+		default:
+			otVal.Value = &common.AnyValue_StringValue{
+				StringValue: fmt.Sprintf("%v", vt.Interface()),
+			}
+		}
+		value := &common.KeyValue{
+			Key:   k,
+			Value: otVal,
 		}
 
 		attribs = append(attribs, value)
 
-		// attribs = append(attribs, &common.KeyValue{
-		// 	Key:   key,
-		// 	Value: atrValue,
-		// })
 	}
 	return attribs
 }

--- a/platform/melt/types.go
+++ b/platform/melt/types.go
@@ -48,7 +48,7 @@ type FsocData struct {
 type Entity struct {
 	TypeName      string
 	ID            string `yaml:"id,omitempty"`
-	Attributes    map[string]string
+	Attributes    map[string]interface{}
 	Metrics       []*Metric
 	Logs          []*Log
 	Relationships []*Relationship
@@ -62,7 +62,7 @@ type Metric struct {
 	Unit                   string
 	Type                   string
 	Resource               Resource `yaml:"resource,omitempty"`
-	Attributes             map[string]string
+	Attributes             map[string]interface{}
 	DataPoints             []*DataPoint           `yaml:"datapoints,omitempty"`
 	Min                    string                 `yaml:"min,omitempty"`
 	Max                    string                 `yaml:"max,omitempty"`
@@ -76,7 +76,7 @@ type Log struct {
 	Body       string
 	Severity   string // use for log
 	Timestamp  int64  `yaml:"timestamp,omitempty"`
-	Attributes map[string]string
+	Attributes map[string]interface{}
 	IsEvent    bool   `yaml:"isevent,omitempty"`
 	TypeName   string `yaml:"typename,omitempty"`
 }
@@ -84,7 +84,7 @@ type Log struct {
 // Resource - structs for data point
 type Resource struct {
 	TypeName   string
-	Attributes map[string]string
+	Attributes map[string]interface{}
 }
 
 // Span - structs for a span
@@ -97,7 +97,7 @@ type Span struct {
 	Kind         SpanKind
 	StartTime    int64
 	EndTime      int64
-	Attributes   map[string]string
+	Attributes   map[string]interface{}
 	Events       []*SpanEvent
 	Links        []*SpanLink
 	Status       *SpanStatus
@@ -107,7 +107,7 @@ type Span struct {
 type SpanEvent struct {
 	Name       string
 	Timestamp  int64
-	Attributes map[string]string
+	Attributes map[string]interface{}
 }
 
 // SpanLink - link for span
@@ -115,7 +115,7 @@ type SpanLink struct {
 	TraceID    string
 	SpanID     string
 	TraceState string
-	Attributes map[string]string
+	Attributes map[string]interface{}
 }
 
 // SpanStatus - status for span
@@ -133,7 +133,7 @@ type DataPoint struct {
 
 // Relationship - structs for holding relationship info
 type Relationship struct {
-	Attributes map[string]string
+	Attributes map[string]interface{}
 }
 
 // NewEntity - Returns a new entity
@@ -141,7 +141,7 @@ func NewEntity(typeName string) *Entity {
 	return &Entity{
 		TypeName:      typeName,
 		Metrics:       []*Metric{},
-		Attributes:    map[string]string{},
+		Attributes:    map[string]interface{}{},
 		Relationships: []*Relationship{},
 		Spans:         []*Span{},
 	}
@@ -190,7 +190,7 @@ func NewMetric(typeName string, unit string, contentType string, metricType stri
 		Unit:                   unit,
 		ContentType:            contentType,
 		Type:                   metricType,
-		Attributes:             map[string]string{},
+		Attributes:             map[string]interface{}{},
 		DataPoints:             []*DataPoint{},
 		AggregationTemporality: AggregationTemporalityUnspecified,
 	}
@@ -199,7 +199,7 @@ func NewMetric(typeName string, unit string, contentType string, metricType stri
 // NewLog - Returns a new log
 func NewLog() *Log {
 	return &Log{
-		Attributes: map[string]string{},
+		Attributes: map[string]interface{}{},
 		IsEvent:    false,
 	}
 }
@@ -207,7 +207,7 @@ func NewLog() *Log {
 // NewEvent - Returns a new event
 func NewEvent(typeName string) *Log {
 	return &Log{
-		Attributes: map[string]string{},
+		Attributes: map[string]interface{}{},
 		TypeName:   typeName,
 		IsEvent:    true,
 	}
@@ -216,7 +216,7 @@ func NewEvent(typeName string) *Log {
 // NewRelationship - Returns a new Relationship
 func NewRelationship() *Relationship {
 	return &Relationship{
-		Attributes: map[string]string{},
+		Attributes: map[string]interface{}{},
 	}
 }
 
@@ -225,37 +225,37 @@ func NewSpan(traceID, spanID, name string) *Span {
 	return &Span{
 		SpanID:     spanID,
 		TraceID:    traceID,
-		Attributes: map[string]string{},
+		Attributes: map[string]interface{}{},
 		Name:       name,
 	}
 }
 
 // SetAttribute - Set an attribute
-func (e *Entity) SetAttribute(key, value string) *Entity {
+func (e *Entity) SetAttribute(key string, value interface{}) *Entity {
 	e.Attributes[key] = value
 	return e
 }
 
 // SetAttribute - Set an attribute on metric
-func (m *Metric) SetAttribute(key, value string) *Metric {
+func (m *Metric) SetAttribute(key string, value interface{}) *Metric {
 	m.Attributes[key] = value
 	return m
 }
 
 // SetAttribute - Set an attribute on log
-func (l *Log) SetAttribute(key, value string) *Log {
+func (l *Log) SetAttribute(key string, value interface{}) *Log {
 	l.Attributes[key] = value
 	return l
 }
 
 // SetAttribute - Set an attribute on log
-func (r *Relationship) SetAttribute(key, value string) *Relationship {
+func (r *Relationship) SetAttribute(key string, value interface{}) *Relationship {
 	r.Attributes[key] = value
 	return r
 }
 
 // SetAttribute - Set an attribute on log
-func (s *Span) SetAttribute(key, value string) *Span {
+func (s *Span) SetAttribute(key string, value interface{}) *Span {
 	s.Attributes[key] = value
 	return s
 }
@@ -265,14 +265,14 @@ func (s *Span) NewEvent(name string, timeStamp int64) *SpanEvent {
 	e := &SpanEvent{
 		Name:       name,
 		Timestamp:  timeStamp,
-		Attributes: map[string]string{},
+		Attributes: map[string]interface{}{},
 	}
 	s.Events = append(s.Events, e)
 	return e
 }
 
 // SetAttribute - Set an attribute on span event
-func (s *SpanEvent) SetAttribute(key, value string) *SpanEvent {
+func (s *SpanEvent) SetAttribute(key string, value interface{}) *SpanEvent {
 	s.Attributes[key] = value
 	return s
 }
@@ -283,14 +283,14 @@ func (s *Span) NewLink(traceID, spanID, traceState string) *SpanLink {
 		TraceID:    traceID,
 		SpanID:     spanID,
 		TraceState: traceState,
-		Attributes: map[string]string{},
+		Attributes: map[string]interface{}{},
 	}
 	s.Links = append(s.Links, l)
 	return l
 }
 
 // SetAttribute - Set an attribute on span link
-func (s *SpanLink) SetAttribute(key, value string) *SpanLink {
+func (s *SpanLink) SetAttribute(key string, value interface{}) *SpanLink {
 	s.Attributes[key] = value
 	return s
 }


### PR DESCRIPTION
## Description

This addresses the handling of attribute types in the fsoc melt subcommands. This includes changes in

* platform/types.go to support Attributes of any value not just string.
* platform.exporter.go to map to correct OTEL type based on the Attribute value type
* "fsoc melt model" to generate the yaml values with proper types based on attribute type in entity definition .



## Type of Change

- [X ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ X] Existing issues have been referenced (where applicable)
- [X ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ X] All code style checks pass
- [ X] New code contribution is covered by automated tests
- [ X] All new and existing tests pass
