### PR TITLE
Update usage help in `config set`

### DIFF
--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -54,7 +54,7 @@ if on context name is specified, the current context is created/updated.`
 func newCmdConfigSet() *cobra.Command {
 
 	var cmd = &cobra.Command{
-		Use:         "set [--profile CONTEXT] --auth=AUTH [flags]",
+		Use:         "set [--profile CONTEXT] auth=AUTH [flags]",
 		Short:       "Create or modify a context entry in an fsoc config file",
 		Long:        setContextLong,
 		Args:        cobra.MaximumNArgs(9),


### PR DESCRIPTION
## Description

Fix the usage help in `config set` with the new style attribute names (`auth=XYZ` rather than `--auth=XYZ`)

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
