### PR TITLE
Add nil check on optimize configure report dataset

### DIFF
--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -443,6 +443,9 @@ func getProfilerReport(workloadId string) (map[string]any, error) {
 	if !ok {
 		return nil, fmt.Errorf("Unexpected type %T for event data set", mainDataSetData[0][0])
 	}
+	if eventDataSet == nil {
+		return nil, errors.New("No events found, event data set was nil")
+	}
 	if len(eventDataSet.Data) < 1 {
 		return nil, errors.New("No events found, event data set had no rows")
 	}


### PR DESCRIPTION
## Description

Add nil check on optimize configure report dataset (fixes OPTSERV-786)

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
