### PR TITLE
version check now recognizes local build versions

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -30,9 +30,12 @@ import (
 	"github.com/spf13/viper"
 )
 
-const FSOC_PROFILE_ENVVAR = "FSOC_PROFILE"
+const (
+	FSOC_PROFILE_ENVVAR = "FSOC_PROFILE"
+	FSOC_CONFIG_ENVVAR  = "FSOC_CONFIG"
+)
 
-var selectedProfile string
+var activeProfile string
 
 // Package registration function for the config root command
 func NewSubCmd() *cobra.Command {
@@ -247,9 +250,9 @@ func ReplaceCurrentContext(ctx *Context) {
 	updateContext(ctx)
 }
 
-// SetCurrentProfile sets the name of the profile that should be used instead of the
+// SetActiveProfile sets the name of the profile that should be used instead of the
 // config file's current profile value.
-func SetCurrentProfile(cmd *cobra.Command, args []string, emptyOK bool) {
+func SetActiveProfile(cmd *cobra.Command, args []string, emptyOK bool) {
 	var profile string // used only in this block
 
 	if cmd.Flags().Changed("profile") {
@@ -264,10 +267,10 @@ func SetCurrentProfile(cmd *cobra.Command, args []string, emptyOK bool) {
 	if !emptyOK && getContext(profile) == nil {
 		log.Fatalf("Could not find profile %q", profile)
 	}
-	if selectedProfile != "" {
-		log.Warnf("The selected profile is being overridden: old=%q, new=%q", selectedProfile, profile)
+	if activeProfile != "" {
+		log.Warnf("The selected profile is being overridden: old=%q, new=%q", activeProfile, profile)
 	}
-	selectedProfile = profile
+	activeProfile = profile
 }
 
 // GetCurrentProfileName returns the profile name that is used to select the context.
@@ -278,8 +281,8 @@ func GetCurrentProfileName() string {
 	profile := DefaultContext
 
 	// use the profile from command line or the config file's current
-	if selectedProfile != "" {
-		profile = selectedProfile
+	if activeProfile != "" {
+		profile = activeProfile
 	} else {
 		// get profile that is current for the config file
 		cfg := getConfig()

--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/exp/maps"
 	"gopkg.in/yaml.v2"
 
-	"github.com/cisco-open/fsoc/cmd/solution"
 	sol "github.com/cisco-open/fsoc/cmd/solution"
 	"github.com/cisco-open/fsoc/output"
 	"github.com/cisco-open/fsoc/platform/melt"
@@ -240,7 +239,7 @@ func writeDataFile(fsoData *melt.FsocData, fileName string) {
 	fsoDataYamlFile.Close()
 }
 
-func getDefaultValue(td *solution.FmmAttributeTypeDef) interface{} {
+func getDefaultValue(td *sol.FmmAttributeTypeDef) interface{} {
 	switch td.Type {
 	case "boolean":
 		return false

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,10 +40,7 @@ var cfgFile string
 var cfgProfile string
 var outputFormat string
 
-const (
-	FSOC_CONFIG_ENVVAR    = "FSOC_CONFIG"
-	FSOC_NO_VERSION_CHECK = "FSOC_NO_VERSION_CHECK"
-)
+const FSOC_NO_VERSION_CHECK = "FSOC_NO_VERSION_CHECK"
 
 const (
 	secondsInDay      = 24 * 60 * 60
@@ -122,7 +119,7 @@ func init() {
 func initConfig() {
 	// use config file from env var
 	if cfgFile == "" { // only if not set from command line (command line has priority)
-		cfgFile = os.Getenv(FSOC_CONFIG_ENVVAR) // remains empty if not found
+		cfgFile = os.Getenv(config.FSOC_CONFIG_ENVVAR) // remains empty if not found
 	}
 
 	// finalize config file
@@ -209,7 +206,7 @@ func preExecHook(cmd *cobra.Command, args []string) {
 	}
 
 	// override the config file's current profile from cmd line or env var
-	config.SetCurrentProfile(cmd, args, bypass)
+	config.SetActiveProfile(cmd, args, bypass)
 	if err != nil { // bypass == true
 		log.Infof("Unable to read config file (%v), proceeding without a config", err)
 	} else { // err == nil

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -19,7 +19,7 @@ var solutionDescribeCmd = &cobra.Command{
 	Example: `  fsoc solution describe spacefleet`,
 	Run:     solutionDescribe,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		config.SetCurrentProfile(cmd, args, false)
+		config.SetActiveProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -33,7 +33,7 @@ var solutionDownloadCmd = &cobra.Command{
 	Run:              downloadSolution,
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		config.SetCurrentProfile(cmd, args, false)
+		config.SetActiveProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -43,7 +43,7 @@ var solutionForkCmd = &cobra.Command{
 		if len(args) >= 1 {
 			return nil, cobra.ShellCompDirectiveDefault
 		} else {
-			config.SetCurrentProfile(cmd, args, false)
+			config.SetActiveProfile(cmd, args, false)
 			return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 		}
 	},

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -69,7 +69,7 @@ var solutionStatusCmd = &cobra.Command{
 	},
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		config.SetCurrentProfile(cmd, args, false)
+		config.SetActiveProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/subscribe.go
+++ b/cmd/solution/subscribe.go
@@ -38,7 +38,7 @@ var solutionSubscribeCmd = &cobra.Command{
 	Run:              subscribeToSolution,
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		config.SetCurrentProfile(cmd, args, false)
+		config.SetActiveProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/solution/unsubscribe.go
+++ b/cmd/solution/unsubscribe.go
@@ -33,7 +33,7 @@ var solutionUnsubscribeCmd = &cobra.Command{
 	Run:              unsubscribeFromSolution,
 	TraverseChildren: true,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		config.SetCurrentProfile(cmd, args, false)
+		config.SetActiveProfile(cmd, args, false)
 		return getSolutionNames(toComplete), cobra.ShellCompDirectiveDefault
 	},
 }

--- a/cmd/version/version_check.go
+++ b/cmd/version/version_check.go
@@ -53,7 +53,9 @@ func CompareAndLogVersions(newestVersionSemVar *semver.Version) {
 	newerVersionAvailable := currentVersionSemVer.Compare(newestVersionSemVar) < 0
 	var debugFields = log.Fields{"current_version": currentVersionSemVer.String(), "latest_version": newestVersionSemVar.String()}
 
-	if newerVersionAvailable {
+	if IsDev() {
+		log.WithFields(debugFields).Warnf("Running a local build of fsoc that may not have the latest improvements")
+	} else if newerVersionAvailable {
 		log.WithFields(debugFields).Warnf("There is a newer version of fsoc available, please upgrade")
 	} else {
 		debugFields["version_cmp"] = newerVersionAvailable


### PR DESCRIPTION
## Description

Improved the fsoc version check to recognize when it's running a locally built version and use a different message to avoid confusion.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
