### PR TITLE
Generate OT data from a Stated template using Meltini REST APIs

### DIFF
--- a/cmd/melt/meltini.go
+++ b/cmd/melt/meltini.go
@@ -21,18 +21,13 @@ var meltMelitiniCmd = &cobra.Command{
 func init() {
 	meltMelitiniCmd.Flags().String("template-file", "", "path to the stated template file")
 	meltMelitiniCmd.Flags().String("meltini-url", "http://localhost:3000/", "meltini REST APIs URL")
+	meltMelitiniCmd.MarkFlagRequired("template-file")
 	meltCmd.AddCommand(meltMelitiniCmd) // Assuming meltCmd is defined elsewhere
 }
 
 func meltMeltini(cmd *cobra.Command, args []string) {
 	templateFile, _ := cmd.Flags().GetString("template-file")
 	meltiniURL, _ := cmd.Flags().GetString("meltini-url")
-
-	// Check if template file is provided
-	if templateFile == "" {
-		fmt.Println("Please provide a path to the stated template file")
-		return
-	}
 
 	// Read the JSON file
 	jsonData, err := os.ReadFile(templateFile)

--- a/cmd/melt/meltini.go
+++ b/cmd/melt/meltini.go
@@ -15,6 +15,7 @@ var meltMelitiniCmd = &cobra.Command{
 	Short:            "uses meltini APIs to generate metrics from a template",
 	Long:             `Uses meltini APIs to generate OT data from provided stated template file.`,
 	TraverseChildren: true,
+	Hidden:           true,
 	Run:              meltMeltini,
 }
 

--- a/cmd/melt/meltini.go
+++ b/cmd/melt/meltini.go
@@ -3,10 +3,11 @@ package melt
 import (
 	"bytes"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io"
 	"net/http"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 var meltMelitiniCmd = &cobra.Command{

--- a/cmd/melt/meltini.go
+++ b/cmd/melt/meltini.go
@@ -21,7 +21,7 @@ var meltMelitiniCmd = &cobra.Command{
 func init() {
 	meltMelitiniCmd.Flags().String("template-file", "", "path to the stated template file")
 	meltMelitiniCmd.Flags().String("meltini-url", "http://localhost:3000/", "meltini REST APIs URL")
-	meltMelitiniCmd.MarkFlagRequired("template-file")
+	_ = meltMelitiniCmd.MarkFlagRequired("template-file")
 	meltCmd.AddCommand(meltMelitiniCmd) // Assuming meltCmd is defined elsewhere
 }
 

--- a/cmd/melt/meltini.go
+++ b/cmd/melt/meltini.go
@@ -1,0 +1,60 @@
+package melt
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io"
+	"net/http"
+	"os"
+)
+
+var meltMelitiniCmd = &cobra.Command{
+	Use:              "meltini",
+	Short:            "uses meltini APIs to generate metrics from a template",
+	Long:             `Uses meltini APIs to generate OT data from provided stated template file.`,
+	TraverseChildren: true,
+	Run:              meltMeltini,
+}
+
+func init() {
+	meltMelitiniCmd.Flags().String("template-file", "", "path to the stated template file")
+	meltMelitiniCmd.Flags().String("meltini-url", "http://localhost:3000/", "meltini REST APIs URL")
+	meltCmd.AddCommand(meltMelitiniCmd) // Assuming meltCmd is defined elsewhere
+}
+
+func meltMeltini(cmd *cobra.Command, args []string) {
+	templateFile, _ := cmd.Flags().GetString("template-file")
+	meltiniURL, _ := cmd.Flags().GetString("meltini-url")
+
+	// Check if template file is provided
+	if templateFile == "" {
+		fmt.Println("Please provide a path to the stated template file")
+		return
+	}
+
+	// Read the JSON file
+	jsonData, err := os.ReadFile(templateFile)
+	if err != nil {
+		fmt.Println("Error reading template file:", err)
+		return
+	}
+
+	// Send a POST request with the JSON data
+	response, err := http.Post(meltiniURL, "application/json", bytes.NewBuffer(jsonData))
+	if err != nil {
+		fmt.Println("Error sending request to meltini:", err)
+		return
+	}
+	defer response.Body.Close()
+
+	// Read the response
+	respData, err := io.ReadAll(response.Body)
+	if err != nil {
+		fmt.Println("Error reading response from meltini:", err)
+		return
+	}
+
+	// Print the response
+	fmt.Println("Response from meltini:", string(respData))
+}


### PR DESCRIPTION
## Description

Generate OT data from a Stated template using Meltini REST APIs

## Type of Change
- [ X] New Feature

## Example usage
Start meltini process
```
node src/MELTini.js
```

use fsoc to generate OT data
```
./fsoc melt meltini --template-file ~/projects/sandbox/meltini/templates/spacefleet_basic.json
Response from meltini: [
  {
    "resource": {
      "attributes": [
        {
          "key": "spacecraft.name",
          "value": {
            "string_value": "LaSirena"
          }
        },
        {
          "key": "spacecraft.registry",
          "value": {
            "string_value": "NCC-2312"
          }
        }
      ]
    },
    "scope_metrics": {
      "scope": {
        "name": "@opentelemetry/appdynamics-simulator",
        "version": "0.0.1"
      },
      "metrics": [
        {
          "sum": {
            "data_points": [
              {
                "time_unix_nano": 1691602873106000000,
                "start_time_unix_nano": 1691602933106000000,
                "as_double": 30617187.069894012
              }
            ],
            "aggregation_temporality": "AGGREGATION_TEMPORALITY_DELTA"
          },
          "name": "spacefleet:speed"
        }
      ]
    }
  },
  {
    "resource": {
      "attributes": [
        {
          "key": "spacecraft.name",
          "value": {
            "string_value": "Phoenix"
          }
        },
        {
          "key": "spacecraft.registry",
          "value": {
            "string_value": "NCC-6522"
          }
        }
      ]
    },
    "scope_metrics": {
      "scope": {
        "name": "@opentelemetry/appdynamics-simulator",
        "version": "0.0.1"
      },
      "metrics": [
        {
          "sum": {
            "data_points": [
              {
                "time_unix_nano": 1691602873106000000,
                "start_time_unix_nano": 1691602933106000000,
                "as_double": 30617187.069894012
              }
            ],
            "aggregation_temporality": "AGGREGATION_TEMPORALITY_DELTA"
          },
          "name": "spacefleet:speed"
        }
      ]
    }
  },
  {
    "resource": {
      "attributes": [
        {
          "key": "spacecraft.name",
          "value": {
            "string_value": "Sarcophagus"
          }
        },
        {
          "key": "spacecraft.registry",
          "value": {
            "string_value": "NCC-3264"
          }
        }
      ]
    },
    "scope_metrics": {
      "scope": {
        "name": "@opentelemetry/appdynamics-simulator",
        "version": "0.0.1"
      },
      "metrics": [
        {
          "sum": {
            "data_points": [
              {
                "time_unix_nano": 1691602873106000000,
                "start_time_unix_nano": 1691602933106000000,
                "as_double": 30617187.069894012
              }
            ],
            "aggregation_temporality": "AGGREGATION_TEMPORALITY_DELTA"
          },
          "name": "spacefleet:speed"
        }
      ]
    }
  },
  {
    "resource": {
      "attributes": [
        {
          "key": "spacecraft.name",
          "value": {
            "string_value": "Scimitar"
          }
        },
        {
          "key": "spacecraft.registry",
          "value": {
            "string_value": "NCC-1653"
          }
        }
      ]
    },
    "scope_metrics": {
      "scope": {
        "name": "@opentelemetry/appdynamics-simulator",
        "version": "0.0.1"
      },
      "metrics": [
        {
          "sum": {
            "data_points": [
              {
                "time_unix_nano": 1691602873106000000,
                "start_time_unix_nano": 1691602933106000000,
                "as_double": 30617187.069894012
              }
            ],
            "aggregation_temporality": "AGGREGATION_TEMPORALITY_DELTA"
          },
          "name": "spacefleet:speed"
        }
      ]
    }
  },
  {
    "resource": {
      "attributes": [
        {
          "key": "spacecraft.name",
          "value": {
            "string_value": "USSPrometheus"
          }
        },
        {
          "key": "spacecraft.registry",
          "value": {
            "string_value": "NCC-4363"
          }
        }
      ]
    },
    "scope_metrics": {
      "scope": {
        "name": "@opentelemetry/appdynamics-simulator",
        "version": "0.0.1"
      },
      "metrics": [
        {
          "sum": {
            "data_points": [
              {
                "time_unix_nano": 1691602873106000000,
                "start_time_unix_nano": 1691602933106000000,
                "as_double": 30617187.069894012
              }
            ],
            "aggregation_temporality": "AGGREGATION_TEMPORALITY_DELTA"
          },
          "name": "spacefleet:speed"
        }
      ]
    }
  }
]
```
