### PR TITLE
fixing --add-resourceMapping semantic convention support

### DIFF
--- a/cmd/solution/extend-fmm.go
+++ b/cmd/solution/extend-fmm.go
@@ -43,14 +43,26 @@ func getResourceMap(cmd *cobra.Command, entityName string, manifest *Manifest) *
 		Name:        name,
 		DisplayName: displayName,
 	}
+	var scopeForField string
+	semanticConvention := fmt.Sprintf("%s.%s", namespaceName, entityName)
 
 	for _, requiredField := range entity.AttributeDefinitions.Required {
-		scopeForField := fmt.Sprintf("%s.%s.%s", namespaceName, entityName, requiredField)
+
+		if strings.Contains(requiredField, semanticConvention) {
+			scopeForField = requiredField
+		} else {
+			scopeForField = fmt.Sprintf("%s.%s", semanticConvention, requiredField)
+		}
+
 		scopeFilterFields = append(scopeFilterFields, scopeForField)
 	}
 
 	for k := range entity.AttributeDefinitions.Attributes {
-		scopeForField := fmt.Sprintf("%s.%s.%s", namespaceName, entityName, k)
+		if strings.Contains(k, semanticConvention) {
+			scopeForField = k
+		} else {
+			scopeForField = fmt.Sprintf("%s.%s", semanticConvention, k)
+		}
 		attributeMaps[k] = scopeForField
 	}
 


### PR DESCRIPTION
## Description

--add-resourceMapping was not generating proper semantic conventions based attributes causing namespace.name to be duplicated

## Type of Change

- [X] Bug Fix
