### PR TITLE
gendocs: make h1 default and fix header capitalization

### DIFF
--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -53,7 +53,7 @@ The directory should either be empty or not exist.`,
 
 func NewSubCmd() *cobra.Command {
 	gendocsCmd.Flags().
-		Bool("h1", false, "This flag will change all generated headers to start at an h1 level heading")
+		Bool("h1", true, "adjust generated headings to start from h1 rather than h2")
 	return gendocsCmd
 }
 
@@ -228,11 +228,11 @@ func processFile(file *os.File) error {
 				fileLines[i] = line[1:]
 			}
 		}
-		if fileLines[i] == "# SEE ALSO" {
-			fileLines[i] = "# See Also"
+		if fileLines[i] == "## SEE ALSO" {
+			fileLines[i] = "## See Also"
 		}
-		if fileLines[i] == "# Options inherited from parent commands" {
-			fileLines[i] = "# Options Inherited From Parent Commands"
+		if fileLines[i] == "## Options inherited from parent commands" {
+			fileLines[i] = "## Options Inherited From Parent Commands"
 		}
 	}
 


### PR DESCRIPTION
## Description

For the `gendocs` command, make the headings starting from h1 the default and fix the tweaks for heading capitalization.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
