### PR TITLE
Add nil check on events dataset pagination

### DIFF
--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -217,7 +217,10 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 		}
 
 		// handle pagination
-		_, next_ok := data_set.Links["next"]
+		next_ok := false
+		if data_set != nil {
+			_, next_ok = data_set.Links["next"]
+		}
 		if flags.count != -1 {
 			// skip pagination if limits provided. Otherwise, we return the full result list (chunked into count per response)
 			// instead of constraining to count
@@ -413,7 +416,10 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 		}
 
 		// handle pagination
-		_, next_ok := data_set.Links["next"]
+		next_ok := false
+		if data_set != nil {
+			_, next_ok = data_set.Links["next"]
+		}
 		if flags.count != -1 {
 			// skip pagination if limits provided. Otherwise, we return the full result list (chunked into count per response)
 			// instead of constraining to count


### PR DESCRIPTION
## Description

Adds nil check to `fsoc optimize` events related datasets during pagination logic. Prevents following stack trace:

```
✓ Platform API call (POST /monitoring/v1/query/execute)
   ⨯ Execution of events query encountered errors. Returned data may not be complete!
   ⨯ General Error: Event data error (logged with TraceId: [3063c1ccd79d60f5d55db6b8006b196c])
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x38 pc=0x102e96b34]

goroutine 1 [running]:
github.com/cisco-open/fsoc/cmd/optimize.listEvents.func1(0x140001ec300?, {0x1400032b030?, 0x0?, 0x7?})
	github.com/cisco-open/fsoc/cmd/optimize/events.go:220 +0x8e4
github.com/spf13/cobra.(*Command).execute(0x140001ec300, {0x140000b2030, 0x7, 0x7})
	github.com/spf13/cobra@v1.7.0/command.go:940 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x1036ef4c0)
	github.com/spf13/cobra@v1.7.0/command.go:1068 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.7.0/command.go:992
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	github.com/spf13/cobra@v1.7.0/command.go:985
github.com/cisco-open/fsoc/cmd.Execute(...)
	github.com/cisco-open/fsoc/cmd/root.go:87
main.realMain()
	github.com/cisco-open/fsoc/main.go:36 +0x114
main.main()
	github.com/cisco-open/fsoc/main.go:28 +0x1c
```

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
