### PR TITLE
Fix fsoc extend incorrect number of arguments

### DIFF
--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -30,7 +30,7 @@ import (
 
 var solutionExtendCmd = &cobra.Command{
 	Use:              "extend",
-	Args:             cobra.ExactArgs(0),
+	Args:             cobra.ExactArgs(1),
 	Short:            "Extends your solution by adding new components",
 	Long:             `This command allows you to easily add new components to your solution.`,
 	Example:          `  fsoc solution extend --add-knowledge=<knowldgetypename>`,


### PR DESCRIPTION
Currently
```
fsoc solution extend –-add-entity=openaiapp
Error: accepts 0 arg(s), received 1
```

this tiny change fixed the issue

## Description

Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to
related issues, other PRs, or technical references.

Note that by _not_ including a description, you are asking reviewers to do extra work to understand the context of this
change, which may lead to your PR taking much longer to review, or result in it not being reviewed at all.

## Type of Change

- [ x] Bug Fix

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
