### PR TITLE
Add support for go 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3
@@ -61,7 +61,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        go-version: ['1.20']
+        go-version: ['1.20', '1.21']
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -103,7 +103,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.20'
+          go-version: '1.21'
           check-latest: true
 
       - name: Install tools

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ print-version-info:
 
 .PHONY: install-tools
 install-tools:
-	${GO} install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+	${GO} install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2
 	${GO} install github.com/goreleaser/goreleaser@v1.19.2
 	${GO} install golang.org/x/tools/cmd/goimports@v0.6.0
 	${GO} install github.com/pavius/impi/cmd/impi@v0.0.3


### PR DESCRIPTION
## Description

* Use go 1.21 for builds and release
* Run unit tests on go 1.20 & 1.21
* Update golangci-lint to latest.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
