### PR TITLE
ORION-2036: add flag for fetching last successful installation in solution status command

### DIFF
--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -224,7 +224,7 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	statusTypeToFetch, _ := cmd.Flags().GetString("status-type")
 	solutionTag, _ := cmd.Flags().GetString("tag")
 	fetchLastSuccessfulInstallation, _ := cmd.Flags().GetBool("last-successful-install")
-	solutionInstallSuccessfulFilter = fmt.Sprintf(`data.isSuccessful eq "true"`)
+	solutionInstallSuccessfulFilter = `data.isSuccessful eq "true"`
 	solutionVersionFilter = fmt.Sprintf(`data.solutionVersion eq "%s"`, solutionVersion)
 	solutionNameFilter = fmt.Sprintf(`data.solutionName eq "%s"`, solutionName)
 	solutionTagFilter = fmt.Sprintf(`data.tag eq "%s"`, solutionTag)

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -87,11 +87,6 @@ func getSolutionStatusCmd() *cobra.Command {
 	solutionStatusCmd.Flags().
 		String("tag", "stable", "The tag associated with the solution for which you would like to view the status for.  Defaults to 'stable' unless otherwise specified")
 
-	solutionStatusCmd.Flags().
-		Bool("last-successful-install", false, "Fetches the last successfully installed version of your solution.")
-
-	solutionStatusCmd.MarkFlagsMutuallyExclusive("solution-version", "last-successful-install")
-
 	return solutionStatusCmd
 }
 
@@ -125,10 +120,12 @@ func getExtensibilitySolutionObject(url string, headers map[string]string) Exten
 
 }
 
-func fetchValuesAndPrint(operation string, solutionInstallObjectQuery string, solutionReleaseObjectQuery string, solutionName string, requestHeaders map[string]string, cmd *cobra.Command) {
+func fetchValuesAndPrint(operation string, solutionInstallObjectQuery string, solutionReleaseObjectQuery string, successfulSolutionInstallObjectQuery string, solutionName string, requestHeaders map[string]string, cmd *cobra.Command) {
 	// finalize solution name (incl. the solution object name which includes the tag value)
 	var solutionNameWithTag string
+	var solutionInstallationMessagePrefix string
 	solutionTag, _ := cmd.Flags().GetString("tag")
+	solutionVersion, _ := cmd.Flags().GetString("solution-version")
 	if solutionTag != "stable" {
 		solutionNameWithTag = fmt.Sprintf(`%s.%s`, solutionName, solutionTag)
 	} else {
@@ -138,6 +135,7 @@ func fetchValuesAndPrint(operation string, solutionInstallObjectQuery string, so
 	uploadStatusChan := make(chan StatusItem)
 	installStatusChan := make(chan StatusItem)
 	solutionStatusChan := make(chan ExtensibilitySolutionObjectData)
+	successfulSolutionInstallStatusChan := make(chan StatusItem)
 
 	go func() {
 		uploadStatusChan <- getObjects(fmt.Sprintf(getSolutionReleaseUrl(), solutionReleaseObjectQuery), requestHeaders)
@@ -148,16 +146,26 @@ func fetchValuesAndPrint(operation string, solutionInstallObjectQuery string, so
 	go func() {
 		solutionStatusChan <- getExtensibilitySolutionObject(fmt.Sprintf(getExtensibilitySolutionUrl(), solutionNameWithTag), requestHeaders)
 	}()
+	go func() {
+		successfulSolutionInstallStatusChan <- getObjects(fmt.Sprintf(getSolutionInstallUrl(), successfulSolutionInstallObjectQuery), requestHeaders)
+	}()
 
 	uploadStatusItem := <-uploadStatusChan
 	installStatusItem := <-installStatusChan
 	solutionStatusItem := <-solutionStatusChan
+	successfulInstallStatusItem := <-successfulSolutionInstallStatusChan
 
 	installStatusData := installStatusItem.StatusData
+	successfulInstallStatusData := successfulInstallStatusItem.StatusData
 	uploadStatusData := uploadStatusItem.StatusData
 	uploadStatusTimestamp := uploadStatusItem.CreatedAt
 	isTenantSubscribedToSolution := (!solutionStatusItem.IsEmpty() && solutionStatusItem.IsSubscribed)
 
+	if solutionVersion != "" {
+		solutionInstallationMessagePrefix = "Viewing Solution"
+	} else {
+		solutionInstallationMessagePrefix = "Current Solution"
+	}
 	headers := []string{"Solution Name"}
 	values := []string{solutionName}
 
@@ -173,28 +181,30 @@ func fetchValuesAndPrint(operation string, solutionInstallObjectQuery string, so
 	}
 
 	if operation == "upload" {
-		appendValue("Solution Upload Version", uploadStatusData.SolutionVersion)
-		appendValue("Upload Timestamp", uploadStatusTimestamp)
+		appendValue(fmt.Sprintf("%s Upload Version", solutionInstallationMessagePrefix), uploadStatusData.SolutionVersion)
+		appendValue(fmt.Sprintf("%s Upload Timestamp", solutionInstallationMessagePrefix), uploadStatusTimestamp)
 	} else if operation == "install" {
-		appendValue("Solution Install Version", installStatusData.SolutionVersion)
+		appendValue("Last Successful Install Version", successfulInstallStatusData.SolutionVersion)
+		appendValue(fmt.Sprintf("%s Install Version", solutionInstallationMessagePrefix), installStatusData.SolutionVersion)
 		if isTenantSubscribedToSolution {
-			appendValue("Solution Install Successful?", fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
+			appendValue(fmt.Sprintf("%s Install Successful?", solutionInstallationMessagePrefix), fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
 		} else {
-			appendValue("Solution Install Successful?", "")
+			appendValue(fmt.Sprintf("%s Install Successful?", solutionInstallationMessagePrefix), "")
 		}
-		appendValue("Solution Install Time", installStatusData.InstallTime)
-		appendValue("Solution Install Message", installStatusData.InstallMessage)
+		appendValue(fmt.Sprintf("%s Install Time", solutionInstallationMessagePrefix), installStatusData.InstallTime)
+		appendValue(fmt.Sprintf("%s Install Message", solutionInstallationMessagePrefix), installStatusData.InstallMessage)
 	} else {
-		appendValue("Solution Upload Version", uploadStatusData.SolutionVersion)
-		appendValue("Upload Timestamp", uploadStatusTimestamp)
-		appendValue("Solution Install Version", installStatusData.SolutionVersion)
+		appendValue(fmt.Sprintf("%s Upload Version", solutionInstallationMessagePrefix), uploadStatusData.SolutionVersion)
+		appendValue(fmt.Sprintf("%s Upload Timestamp", solutionInstallationMessagePrefix), uploadStatusTimestamp)
+		appendValue("Last Successful Install Version", successfulInstallStatusData.SolutionVersion)
+		appendValue(fmt.Sprintf("%s Install Version", solutionInstallationMessagePrefix), installStatusData.SolutionVersion)
 		if isTenantSubscribedToSolution {
-			appendValue("Solution Install Successful?", fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
+			appendValue(fmt.Sprintf("%s Install Successful?", solutionInstallationMessagePrefix), fmt.Sprintf("%v", installStatusData.SuccessfulInstall))
 		} else {
-			appendValue("Solution Install Successful?", "")
+			appendValue(fmt.Sprintf("%s Install Successful?", solutionInstallationMessagePrefix), "")
 		}
-		appendValue("Solution Install Time", installStatusData.InstallTime)
-		appendValue("Solution Install Message", installStatusData.InstallMessage)
+		appendValue(fmt.Sprintf("%s Install Time", solutionInstallationMessagePrefix), installStatusData.InstallTime)
+		appendValue(fmt.Sprintf("%s Install Message", solutionInstallationMessagePrefix), installStatusData.InstallMessage)
 	}
 
 	output.PrintCmdOutputCustom(cmd, installStatusData, &output.Table{
@@ -211,6 +221,7 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	var solutionInstallSuccessfulFilter string
 	var solutionInstallObjectFilter string
 	var solutionReleaseObjectFilter string
+	var lastSuccesfulInstallFilter string
 	cfg := config.GetCurrentContext()
 
 	layerType := "TENANT"
@@ -223,7 +234,6 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	solutionVersion, _ := cmd.Flags().GetString("solution-version")
 	statusTypeToFetch, _ := cmd.Flags().GetString("status-type")
 	solutionTag, _ := cmd.Flags().GetString("tag")
-	fetchLastSuccessfulInstallation, _ := cmd.Flags().GetBool("last-successful-install")
 	solutionInstallSuccessfulFilter = `data.isSuccessful eq "true"`
 	solutionVersionFilter = fmt.Sprintf(`data.solutionVersion eq "%s"`, solutionVersion)
 	solutionNameFilter = fmt.Sprintf(`data.solutionName eq "%s"`, solutionName)
@@ -232,21 +242,20 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 
 	if solutionVersion != "" {
 		solutionInstallObjectFilter = fmt.Sprintf(`%s and %s and %s`, solutionNameFilter, solutionVersionFilter, solutionTagFilter)
-		solutionReleaseObjectFilter = solutionInstallObjectFilter
-	} else if fetchLastSuccessfulInstallation {
-		solutionInstallObjectFilter = fmt.Sprintf(`%s and %s and %s`, solutionNameFilter, solutionInstallSuccessfulFilter, solutionTagFilter)
-		solutionReleaseObjectFilter = fmt.Sprintf(`%s and %s`, solutionNameFilter, solutionTagFilter)
 	} else {
 		solutionInstallObjectFilter = fmt.Sprintf(`%s and %s`, solutionNameFilter, solutionTagFilter)
-		solutionReleaseObjectFilter = solutionInstallObjectFilter
 	}
 
+	lastSuccesfulInstallFilter = fmt.Sprintf(`%s and %s and %s`, solutionNameFilter, solutionTagFilter, solutionInstallSuccessfulFilter)
+	solutionReleaseObjectFilter = solutionInstallObjectFilter
+
 	solutionInstallObjectQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(solutionInstallObjectFilter))
+	successfulSolutionInstallObjectQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(lastSuccesfulInstallFilter))
 	solutionReleaseObjectQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(solutionReleaseObjectFilter))
 
 	log.Infof(`solution name and version query: %s`, solutionInstallObjectQuery)
 
-	fetchValuesAndPrint(statusTypeToFetch, solutionInstallObjectQuery, solutionReleaseObjectQuery, solutionName, headers, cmd)
+	fetchValuesAndPrint(statusTypeToFetch, solutionInstallObjectQuery, solutionReleaseObjectQuery, successfulSolutionInstallObjectQuery, solutionName, headers, cmd)
 
 	return nil
 }


### PR DESCRIPTION
## Description

Adding flag to solution status command to fetch the last successful installation version.  This is helpful for our users who want to debug differences across solution versions to identify the issues with installation.  
Cleaned up some no-longer-used variables in the status.go cmd

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
