### PR TITLE
deprecate --include flags in solution init

### DIFF
--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -29,7 +29,7 @@ import (
 )
 
 var solutionExtendCmd = &cobra.Command{
-	Use:              "extend",
+	Use:              "extend [flags]",
 	Args:             cobra.ExactArgs(0),
 	Short:            "Extends your solution by adding new components",
 	Long:             `This command allows you to easily add new components to your solution.`,

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -34,21 +34,13 @@ var solutionInitCmd = &cobra.Command{
 	Long: `This command creates a skeleton of a solution in the current directory.
 
 It creates a subdirectory named <solution-name> in the current directory and populates
-it with a solution manifest and objects for it. The optional --include-... flags
-define what objects are added to the solution. Once the solution is created,
-the "solution extend" command can be used to add more objects.`,
-	Example:          `  fsoc solution init --name=testSolution --include-service --include-knowledge`,
+it with a solution manifest and objects for it. Once the solution is created,
+the "solution extend" command can be used to add objects to it.`,
+	Example:          `  fsoc solution init mysolution`,
 	Run:              generateSolutionPackage,
 	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
 	TraverseChildren: true,
 }
-
-// Planned options:
-//    include-service - Flag to include sample service component
-//    include-metric - Flag to include sample metric type component
-//    include-knowledge - Flag to include sample knowledge type component
-//    include-meltworkflow - Flag to include sample melt workflow
-//    include-dash-ui - Flag to include sample dash-ui template
 
 func getInitSolutionCmd() *cobra.Command {
 	solutionInitCmd.Flags().
@@ -57,8 +49,10 @@ func getInitSolutionCmd() *cobra.Command {
 
 	solutionInitCmd.Flags().
 		Bool("include-service", true, "Add a service component definition to this solution")
+	_ = solutionInitCmd.Flags().MarkDeprecated("include-service", `please use the "solution extend" command instead.`)
 	solutionInitCmd.Flags().
 		Bool("include-knowledge", true, "Add a knowledge type definition to this solution")
+	_ = solutionInitCmd.Flags().MarkDeprecated("include-knowledge", `please use the "solution extend" command instead.`)
 
 	return solutionInitCmd
 }


### PR DESCRIPTION
## Description

Deprecated the limited `--include-<object>` flags in `solution init` in favor of using the more robust `solution extend` command.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
