### PR TITLE
fix config set errors and context log

### DIFF
--- a/cmd/config/set-fields.go
+++ b/cmd/config/set-fields.go
@@ -65,7 +65,7 @@ func getAuthFieldWritePermissions() map[string]AuthFieldConfigRow {
 			"client-ID":     ClearField,
 			"secret-file":   AllowField,
 			"token":         ClearField,
-			"tenant":        ClearField,
+			"tenant":        AllowField,
 			"url":           AllowField,
 			"refresh-token": ClearField,
 			"user":          ClearField,
@@ -77,7 +77,7 @@ func getAuthFieldWritePermissions() map[string]AuthFieldConfigRow {
 			"client-ID":     ClearField,
 			"secret-file":   AllowField,
 			"token":         ClearField,
-			"tenant":        ClearField,
+			"tenant":        AllowField,
 			"url":           AllowField,
 			"refresh-token": ClearField,
 			"user":          ClearField,
@@ -122,7 +122,7 @@ func getAuthFieldClearConfig() map[string]authClearFields {
 			"secret-file":   {}, //NA
 			"token":         {}, //NA
 			"tenant":        {}, //NA
-			"url":           {"tenant", "user", "token", "refresh_token", "secret-file"},
+			"url":           {"tenant", "user", "token", "refresh-token", "secret-file"},
 			"refresh-token": {}, //NA
 			"user":          {}, //NA
 			AppdTid:         {}, //NA
@@ -143,10 +143,10 @@ func getAuthFieldClearConfig() map[string]authClearFields {
 		},
 		AuthMethodServicePrincipal: {
 			"client-ID":     {},
-			"secret-file":   {"url", "server", "tenant", "user", "token", "refresh_token"},
+			"secret-file":   {"url", "tenant", "user", "token", "refresh-token"},
 			"token":         {},
 			"tenant":        {},
-			"url":           {"tenant", "user", "token", "refresh_token"},
+			"url":           {"tenant", "user", "token", "refresh-token"},
 			"refresh-token": {},
 			"user":          {},
 			AppdTid:         {},
@@ -155,10 +155,10 @@ func getAuthFieldClearConfig() map[string]authClearFields {
 		},
 		AuthMethodAgentPrincipal: {
 			"client-ID":     {},
-			"secret-file":   {"url", "server", "tenant", "user", "token", "refresh_token"},
+			"secret-file":   {"url", "tenant", "user", "token", "refresh-token"},
 			"token":         {},
 			"tenant":        {},
-			"url":           {"tenant", "user", "token", "refresh_token"},
+			"url":           {"tenant", "user", "token", "refresh-token"},
 			"refresh-token": {},
 			"user":          {},
 			AppdTid:         {},

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -117,7 +117,7 @@ func validateWriteReq(cmd *cobra.Command, authService string, field string) erro
 	if authProvider == "" {
 		return fmt.Errorf("must provide an authentication type before or while writing to other context fields")
 	}
-	if getAuthFieldConfigRow(authProvider)[field] == 0 {
+	if getAuthFieldConfigRow(authProvider)[field] == ClearField {
 		return fmt.Errorf("cannot write to field %s because it is not allowed for authentication method %s", field, authProvider)
 	}
 	return nil
@@ -129,9 +129,7 @@ func clearFields(fields []string, ctxPtr *Context) {
 	}
 	if slices.Contains(fields, "url") {
 		ctxPtr.URL = ""
-	}
-	if slices.Contains(fields, "server") {
-		ctxPtr.Server = ""
+		ctxPtr.Server = "" // server is just the old name of url
 	}
 	if slices.Contains(fields, "tenant") {
 		ctxPtr.Tenant = ""
@@ -142,7 +140,7 @@ func clearFields(fields []string, ctxPtr *Context) {
 	if slices.Contains(fields, "token") {
 		ctxPtr.Token = ""
 	}
-	if slices.Contains(fields, "refresh_token") {
+	if slices.Contains(fields, "refresh-token") {
 		ctxPtr.RefreshToken = ""
 	}
 	if slices.Contains(fields, "secret-file") {

--- a/platform/api/context.go
+++ b/platform/api/context.go
@@ -45,7 +45,7 @@ func newCallContext() *callContext {
 		log.Fatal("Missing context; use 'fsoc config set' to configure your context")
 		panic("unreachable") // keep golintci happy (until it recognizes apex/log fatals)
 	}
-	log.WithFields(log.Fields{"context": cfg.Name, "server": cfg.Server, "tenant": cfg.Tenant}).Info("Using context")
+	log.WithFields(log.Fields{"context": cfg.Name, "url": cfg.URL, "tenant": cfg.Tenant}).Info("Using context")
 
 	// prepare call context
 	callCtx := callContext{


### PR DESCRIPTION
## Description

* Fixed inability to explicitly set tenant on `config set` when using json-based service or agent principal. 
* Corrected some of the config set checks (wrong string values were being compared)
* Fixed log entry to correctly include the URL for the API 

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
