### PR TITLE
ORION-2198: switch over from idGeneration to identifyingProperties when generating knowledge types with fsoc commands

### DIFF
--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -412,18 +412,13 @@ func getKnowledgeComponent(name string) *KnowledgeDef {
 		},
 		"required": []string{"name"},
 	}
-	idGen := &IdGenerationDef{
-		EnforceGlobalUniqueness: true,
-		GenerateRandomId:        true,
-		IdGenerationMechanism:   "{{layer.id}}",
-	}
 
 	knowledgeComponent := &KnowledgeDef{
-		Name:             name,
-		AllowedLayers:    []string{"TENANT"},
-		IdGeneration:     idGen,
-		SecureProperties: []string{"$.secret"},
-		JsonSchema:       jsonSchema,
+		Name:                  name,
+		AllowedLayers:         []string{"TENANT"},
+		IdentifyingProperties: []string{"/name"},
+		SecureProperties:      []string{"$.secret"},
+		JsonSchema:            jsonSchema,
 	}
 
 	return knowledgeComponent

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -161,21 +161,20 @@ func createKnowledgeComponent(manifest *Manifest) *KnowledgeDef {
 				"type":        "string",
 				"description": "The apiKey used to secure the REST endpoint and added to calls by the poller function",
 			},
+			"name": map[string]interface{}{
+				"type":        "string",
+				"description": "Name for the data collector configuration that will be used to generate the ID for this knowledge object",
+			},
 		},
-		"required": []string{"cloudCollectorTargetURL", "cloudCollectorTargetApiKey"},
-	}
-	idGen := &IdGenerationDef{
-		EnforceGlobalUniqueness: true,
-		GenerateRandomId:        true,
-		IdGenerationMechanism:   "{{layer.id}}",
+		"required": []string{"cloudCollectorTargetURL", "cloudCollectorTargetApiKey", "name"},
 	}
 
 	knowledgeComponent := &KnowledgeDef{
-		Name:             "dataCollectorConfiguration",
-		AllowedLayers:    []string{"TENANT"},
-		IdGeneration:     idGen,
-		SecureProperties: []string{"$.collectorTargetApiKey"},
-		JsonSchema:       jsonSchema,
+		Name:                  "dataCollectorConfiguration",
+		AllowedLayers:         []string{"TENANT"},
+		IdentifyingProperties: []string{"/name"},
+		SecureProperties:      []string{"$.collectorTargetApiKey"},
+		JsonSchema:            jsonSchema,
 	}
 
 	return knowledgeComponent

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -50,18 +50,12 @@ type ServiceDef struct {
 	Image string `json:"image,omitempty"`
 }
 
-type IdGenerationDef struct {
-	GenerateRandomId        bool   `json:"generateRandomId"`
-	EnforceGlobalUniqueness bool   `json:"enforceGlobalUniqueness"`
-	IdGenerationMechanism   string `json:"idGenerationMechanism,omitempty"`
-}
-
 type KnowledgeDef struct {
-	Name             string                 `json:"name,omitempty"`
-	AllowedLayers    []string               `json:"allowedLayers,omitempty"`
-	IdGeneration     *IdGenerationDef       `json:"idGeneration,omitempty"`
-	SecureProperties []string               `json:"secureProperties,omitempty"`
-	JsonSchema       map[string]interface{} `json:"jsonSchema,omitempty"`
+	Name                  string                 `json:"name,omitempty"`
+	AllowedLayers         []string               `json:"allowedLayers,omitempty"`
+	IdentifyingProperties []string               `json:"identifyingProperties,omitempty"`
+	SecureProperties      []string               `json:"secureProperties,omitempty"`
+	JsonSchema            map[string]interface{} `json:"jsonSchema,omitempty"`
 }
 
 type SolutionDef struct {


### PR DESCRIPTION
## Description

Orion is now using the identifyingProperties field to determine the IDs for knowledge objects generated of a given knowledge type.  As such, all clients need to switch over to start using this field.  This PR removes support for generating types with idGeneration and uses the new identifyingProperties field instead.

## Type of Change

- [ ] Bug Fix
- [] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
