### PR TITLE
Refactored UQL Client and added support for optimize events follow

### DIFF
--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -202,7 +202,7 @@ func followLogs(initialResponse *uql.Response, formatter rowFormatter, limit int
 }
 
 func queryLogs(query string) (*uql.Response, error) {
-	resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+	resp, err := uql.Client.ExecuteQuery(&uql.Query{Str: query})
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +215,7 @@ func queryLogs(query string) (*uql.Response, error) {
 }
 
 func followDataSet(dataSet *uql.DataSet) (*uql.Response, error) {
-	resp, err := uql.ContinueQuery(dataSet, "follow")
+	resp, err := uql.Client.ContinueQuery(dataSet, "follow")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -156,9 +156,9 @@ FROM entities(k8s:deployment)[attributes("k8s.cluster.name") = "{{.Cluster}}" &&
 			}
 			query = buff.String()
 
-			resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+			resp, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: query})
 			if err != nil {
-				return fmt.Errorf("uql.ExecuteQuery: %w", err)
+				return fmt.Errorf("uql.ClientV1.ExecuteQuery: %w", err)
 			}
 			if resp.HasErrors() {
 				log.Error("Execution of report query encountered errors. Returned data may not be complete!")
@@ -430,9 +430,9 @@ func getProfilerReport(workloadId string) (map[string]any, error) {
 	}
 	query = buff.String()
 
-	resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+	resp, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: query})
 	if err != nil {
-		return nil, fmt.Errorf("uql.ExecuteQuery: %w", err)
+		return nil, fmt.Errorf("uql.ClientV1.ExecuteQuery: %w", err)
 	}
 	if resp.HasErrors() {
 		log.Error("Execution of report query encountered errors. Returned data may not be complete!")

--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -4,8 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -47,14 +50,16 @@ func init() {
 }
 
 type eventsFlags struct {
-	clusterId    string
-	namespace    string
-	workloadName string
-	optimizerId  string
-	since        string
-	until        string
-	count        int
-	solutionName string
+	clusterId      string
+	namespace      string
+	workloadName   string
+	optimizerId    string
+	since          string
+	until          string
+	count          int
+	follow         bool
+	followInterval time.Duration
+	solutionName   string
 }
 
 type eventsCmdFlags struct {
@@ -101,8 +106,11 @@ func NewCmdEvents() *cobra.Command {
 
 	command.Flags().StringVarP(&flags.since, "since", "s", "", "Retrieve events contained in the time interval starting at a relative or exact time. (default: -1h)")
 	command.Flags().StringVarP(&flags.until, "until", "u", "", "Retrieve events contained in the time interval ending at a relative or exact time. (default: now)")
-
 	command.Flags().IntVarP(&flags.count, "count", "", -1, "Limit the number of events retrieved to the specified count")
+
+	command.Flags().BoolVarP(&flags.follow, "follow", "f", false, "Follow the events as they are produced")
+	command.Flags().DurationVarP(&flags.followInterval, "follow-interval", "t", time.Second*60, "Duration between requests to UQL when following events")
+	command.MarkFlagsMutuallyExclusive("follow", "count")
 
 	command.Flags().StringVarP(&flags.solutionName, "solution-name", "", "optimize", "Intended for developer usage, overrides the name of the solution defining the FMM types for reading")
 	if err := command.LocalFlags().MarkHidden("solution-name"); err != nil {
@@ -187,9 +195,9 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 		query := buff.String()
 
 		// execute query, process results
-		resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+		resp, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: query})
 		if err != nil {
-			return fmt.Errorf("uql.ExecuteQuery: %w", err)
+			return fmt.Errorf("uql.ClientV1.ExecuteQuery: %w", err)
 		}
 		if resp.HasErrors() {
 			log.Error("Execution of events query encountered errors. Returned data may not be complete!")
@@ -226,10 +234,14 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 			// instead of constraining to count
 			next_ok = false
 		}
+		if flags.follow {
+			// skip next cursor pagination on follow since the follow cursor contains the same data
+			next_ok = false
+		}
 		for page := 2; next_ok; page++ {
-			resp, err = uql.ContinueQuery(data_set, "next")
+			resp, err = uql.ClientV1.ContinueQuery(data_set, "next")
 			if err != nil {
-				return fmt.Errorf("page %v uql.ContinueQuery: %w", page, err)
+				return fmt.Errorf("page %v uql.ClientV1.ContinueQuery: %w", page, err)
 			}
 			if resp.HasErrors() {
 				log.Errorf("Continuation of events query (page %v) encountered errors. Returned data may not be complete!", page)
@@ -266,8 +278,92 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 			Total int         `json:"total"`
 		}{Items: eventRows, Total: len(eventRows)})
 
+		// handle follow
+		if flags.follow && data_set != nil {
+			// setup async channels
+			interrupt := make(chan os.Signal, 1)
+			signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)
+			followChan := make(chan *followEventResult, 1)
+			followChan <- &followEventResult{data_set: data_set}
+
+			for {
+				select {
+				case <-interrupt:
+					// exit requested
+					return nil
+				case followResult := <-followChan:
+					if followResult.err != nil {
+						return followResult.err
+					}
+					// queue up next follow interval sleep and print
+					// run in background to allow interrupts
+					go func() {
+						// Return immediately available results (additional pages) right away.
+						// Don't start waiting until follow cursor returns a response smaller than the max page size.
+						if followResult.cursorExhausted {
+							time.Sleep(flags.followInterval)
+						}
+						followChan <- followDatasetAndPrint(cmd, followResult.data_set)
+					}()
+				}
+			}
+		}
+
 		return nil
 	}
+}
+
+type followEventResult struct {
+	data_set        *uql.DataSet
+	err             error
+	cursorExhausted bool
+}
+
+func followDatasetAndPrint(cmd *cobra.Command, data_set *uql.DataSet) *followEventResult {
+	resp, err := uql.ClientV1.ContinueQuery(data_set, "follow")
+	if err != nil {
+		return &followEventResult{err: fmt.Errorf("follow uql.ClientV1.ContinueQuery: %w", err)}
+	}
+	if resp.HasErrors() {
+		log.Error("Following of events query encountered errors. Returned data may not be complete!")
+		for _, e := range resp.Errors() {
+			log.Errorf("%s: %s", e.Title, e.Detail)
+		}
+	}
+	main_data_set := resp.Main()
+	if main_data_set == nil {
+		log.Error("Following of events query has nil main data. Returned data may not be complete!")
+		return &followEventResult{data_set: data_set}
+	}
+	if len(main_data_set.Data) < 1 {
+		return &followEventResult{err: fmt.Errorf("follow main dataset %v has no rows", main_data_set.Name)}
+	}
+	if len(main_data_set.Data[0]) < 1 {
+		return &followEventResult{err: fmt.Errorf("follow main dataset %v first row has no columns", main_data_set.Name)}
+	}
+	var ok bool
+	data_set, ok = main_data_set.Data[0][0].(*uql.DataSet)
+	if !ok {
+		return &followEventResult{err: fmt.Errorf("follow main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])}
+	}
+
+	result := &followEventResult{data_set: data_set}
+	newRows, err := extractEventsData(data_set)
+	if err != nil {
+		result.err = fmt.Errorf("follow extractEventsData: %w", err)
+		return result
+	}
+
+	newRowsCount := len(newRows)
+	if newRowsCount > 0 {
+		output.PrintCmdOutputCustom(cmd, struct {
+			Items []eventsRow `json:"items"`
+			Total int         `json:"total"`
+		}{Items: newRows, Total: newRowsCount}, &output.Table{OmitHeaders: true})
+	} else {
+		result.cursorExhausted = true
+	}
+	return result
 }
 
 type recommendationsCmdFlags struct {
@@ -386,9 +482,9 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 		query := buff.String()
 
 		// execute query, process results
-		resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+		resp, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: query})
 		if err != nil {
-			return fmt.Errorf("uql.ExecuteQuery: %w", err)
+			return fmt.Errorf("uql.ClientV1.ExecuteQuery: %w", err)
 		}
 		if resp.HasErrors() {
 			log.Error("Execution of recommendations query encountered errors. Returned data may not be complete!")
@@ -426,9 +522,9 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 			next_ok = false
 		}
 		for page := 2; next_ok; page++ {
-			resp, err = uql.ContinueQuery(data_set, "next")
+			resp, err = uql.ClientV1.ContinueQuery(data_set, "next")
 			if err != nil {
-				return fmt.Errorf("page %v uql.ContinueQuery: %w", page, err)
+				return fmt.Errorf("page %v uql.ClientV1.ContinueQuery: %w", page, err)
 			}
 			if resp.HasErrors() {
 				log.Errorf("Continuation of recommendations query (page %v) encountered errors. Returned data may not be complete!", page)
@@ -532,9 +628,9 @@ func listOptimizations(flags *eventsFlags) ([]string, error) {
 	}
 	query := buff.String()
 
-	resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+	resp, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: query})
 	if err != nil {
-		return []string{}, fmt.Errorf("uql.ExecuteQuery: %w", err)
+		return []string{}, fmt.Errorf("uql.ClientV1.ExecuteQuery: %w", err)
 	}
 	if resp.HasErrors() {
 		log.Error("Execution of optimization query encountered errors. Returned data may not be complete!")
@@ -561,9 +657,9 @@ func listOptimizations(flags *eventsFlags) ([]string, error) {
 
 	_, next_ok := mainDataSet.Links["next"]
 	for page := 2; next_ok; page++ {
-		resp, err = uql.ContinueQuery(mainDataSet, "next")
+		resp, err = uql.ClientV1.ContinueQuery(mainDataSet, "next")
 		if err != nil {
-			return results, fmt.Errorf("page %v uql.ContinueQuery: %w", page, err)
+			return results, fmt.Errorf("page %v uql.ClientV1.ContinueQuery: %w", page, err)
 		}
 
 		if resp.HasErrors() {

--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -111,9 +111,9 @@ func listReports(cmd *cobra.Command, args []string) error {
 	}
 	query = buff.String()
 
-	resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+	resp, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: query})
 	if err != nil {
-		return fmt.Errorf("uql.ExecuteQuery: %w", err)
+		return fmt.Errorf("uql.ClientV1.ExecuteQuery: %w", err)
 	}
 
 	if resp.HasErrors() {
@@ -136,9 +136,9 @@ func listReports(cmd *cobra.Command, args []string) error {
 
 	_, next_ok := mainDataSet.Links["next"]
 	for page := 2; next_ok; page++ {
-		resp, err = uql.ContinueQuery(mainDataSet, "next")
+		resp, err = uql.ClientV1.ContinueQuery(mainDataSet, "next")
 		if err != nil {
-			return fmt.Errorf("page %v uql.ContinueQuery: %w", page, err)
+			return fmt.Errorf("page %v uql.ClientV1.ContinueQuery: %w", page, err)
 		}
 
 		if resp.HasErrors() {

--- a/cmd/optimize/server_report.go
+++ b/cmd/optimize/server_report.go
@@ -85,7 +85,7 @@ func getWorkloadId(workloadName string) (*string, error) {
 	// UQL query to retrieve ID via workload.name attribute
 	queryStr := fmt.Sprintf("SINCE -7d FETCH id FROM entities(k8s:workload)[isActive = true][attributes(k8s.workload.name) = '%s']", workloadName)
 
-	response, err := uql.ExecuteQuery(&uql.Query{Str: queryStr}, uql.ApiVersion1)
+	response, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: queryStr})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/optimize/servo.go
+++ b/cmd/optimize/servo.go
@@ -129,9 +129,9 @@ func getServoLogs(flags *servoLogsFlags) func(*cobra.Command, []string) error {
 		query := buff.String()
 
 		// execute query, process results
-		resp, err := uql.ExecuteQuery(&uql.Query{Str: query}, uql.ApiVersion1)
+		resp, err := uql.ClientV1.ExecuteQuery(&uql.Query{Str: query})
 		if err != nil {
-			return fmt.Errorf("uql.ExecuteQuery: %w", err)
+			return fmt.Errorf("uql.ClientV1.ExecuteQuery: %w", err)
 		}
 		if resp.HasErrors() {
 			log.Error("Execution of servo-logs query encountered errors. Returned data may not be complete!")
@@ -169,9 +169,9 @@ func getServoLogs(flags *servoLogsFlags) func(*cobra.Command, []string) error {
 			next_ok = false
 		}
 		for page := 2; next_ok; page++ {
-			resp, err = uql.ContinueQuery(data_set, "next")
+			resp, err = uql.ClientV1.ContinueQuery(data_set, "next")
 			if err != nil {
-				return fmt.Errorf("page %v uql.ContinueQuery: %w", page, err)
+				return fmt.Errorf("page %v uql.ClientV1.ContinueQuery: %w", page, err)
 			}
 			if resp.HasErrors() {
 				log.Errorf("Continuation of servo logs query (page %v) encountered errors. Returned data may not be complete!", page)

--- a/cmd/uql/api_version.go
+++ b/cmd/uql/api_version.go
@@ -30,7 +30,7 @@ type ApiVersion string
 // constants for direct use
 const (
 	ApiVersion1 ApiVersion = ApiVersion("v1")
-	//ApiVersion1Beta ApiVersion = ApiVersion("v1beta")
+	//ApiVersion2Beta ApiVersion = ApiVersion("v2beta")
 
 	ApiVersionDefault ApiVersion = ApiVersion1
 )
@@ -40,7 +40,7 @@ const (
 
 var supportedApiVersions = []string{
 	string(ApiVersion1),
-	//string(ApiVersion1Beta),
+	//string(ApiVersion2Beta),
 }
 
 func (a *ApiVersion) ValidateAndSet(v any) error {

--- a/cmd/uql/backend_default.go
+++ b/cmd/uql/backend_default.go
@@ -70,7 +70,11 @@ func (b defaultBackend) Continue(link *Link) (parsedResponse, error) {
 }
 
 func NewDefaultBackend(options ...BackendOption) defaultBackend {
-	return defaultBackend{}
+	b := defaultBackend{}
+	for _, option := range options {
+		option(&b)
+	}
+	return b
 }
 
 type BackendOption func(c *defaultBackend)

--- a/cmd/uql/backend_default.go
+++ b/cmd/uql/backend_default.go
@@ -1,0 +1,82 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uql
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/apex/log"
+	"github.com/pkg/errors"
+
+	"github.com/cisco-open/fsoc/platform/api"
+)
+
+type defaultBackend struct {
+	apiOptions *api.Options
+}
+
+func (b defaultBackend) Execute(query *Query, apiVersion ApiVersion) (parsedResponse, error) {
+	log.WithFields(log.Fields{"query": query.Str, "apiVersion": apiVersion}).Info("executing UQL query")
+
+	var rawJson json.RawMessage
+	err := api.JSONPost(GetAPIEndpoint(apiVersion), query, &rawJson, b.apiOptions)
+	if err != nil {
+		if problem, ok := err.(api.Problem); ok {
+			return parsedResponse{}, makeUqlProblem(problem)
+		}
+		return parsedResponse{}, errors.Wrap(err, fmt.Sprintf("failed to execute UQL Query: '%s'", query.Str))
+	}
+	var chunks []parsedChunk
+	err = json.Unmarshal(rawJson, &chunks)
+	if err != nil {
+		return parsedResponse{}, errors.Wrap(err, fmt.Sprintf("failed to parse response for UQL Query: '%s'", query.Str))
+	}
+	return parsedResponse{
+		chunks:  chunks,
+		rawJson: &rawJson,
+	}, nil
+}
+
+func (b defaultBackend) Continue(link *Link) (parsedResponse, error) {
+	log.WithFields(log.Fields{"query": link.Href}).Info("continuing UQL query")
+
+	var rawJson json.RawMessage
+	err := api.JSONGet(link.Href, &rawJson, b.apiOptions)
+	if err != nil {
+		return parsedResponse{}, errors.Wrap(err, fmt.Sprintf("failed follow link: '%s'", link.Href))
+	}
+	var chunks []parsedChunk
+	err = json.Unmarshal(rawJson, &chunks)
+	if err != nil {
+		return parsedResponse{}, errors.Wrap(err, fmt.Sprintf("failed to parse response for link: '%s'", link.Href))
+	}
+	return parsedResponse{
+		chunks:  chunks,
+		rawJson: &rawJson,
+	}, nil
+}
+
+func NewDefaultBackend(options ...BackendOption) defaultBackend {
+	return defaultBackend{}
+}
+
+type BackendOption func(c *defaultBackend)
+
+func WithBackendApiOptions(options *api.Options) BackendOption {
+	return func(b *defaultBackend) {
+		b.apiOptions = options
+	}
+}

--- a/cmd/uql/backend_local.go
+++ b/cmd/uql/backend_local.go
@@ -1,5 +1,19 @@
 //go:build uql_direct
 
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package uql
 
 import (
@@ -24,7 +38,7 @@ var localUqlTenantId string
 //
 //	go build -tags uql_direct -ldflags="-X 'github.com/cisco-open/fsoc/cmd/uql.localUqlUrl=http://localhost:8042' -X 'github.com/cisco-open/fsoc/cmd/uql.localUqlTenantId=00000000-0000-0000-0000-00000000'"
 func init() {
-	backend = &localBackend{baseUrl: localUqlUrl, tenantId: localUqlTenantId, client: &http.Client{}}
+	Client.backend = &localBackend{baseUrl: localUqlUrl, tenantId: localUqlTenantId, client: &http.Client{}}
 }
 
 type localBackend struct {

--- a/cmd/uql/client.go
+++ b/cmd/uql/client.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uql
+
+type UqlClient interface {
+	// ExecuteQuery sends an execute request to the UQL service
+	ExecuteQuery(query *Query) (*Response, error)
+
+	// ContinueQuery sends a continue request to the UQL service
+	ContinueQuery(dataSet *DataSet, rel string) (*Response, error)
+}
+
+type defaultClient struct {
+	backend    uqlService
+	apiVersion *ApiVersion
+}
+
+type UqlClientOption func(c *defaultClient)
+
+func NewClient(options ...UqlClientOption) UqlClient {
+	client := &defaultClient{backend: &defaultBackend{}}
+	for _, option := range options {
+		option(client)
+	}
+	return client
+}
+
+func WithClientApiVersion(version ApiVersion) UqlClientOption {
+	return func(c *defaultClient) {
+		c.apiVersion = &version
+	}
+}
+
+func (c defaultClient) ExecuteQuery(query *Query) (*Response, error) {
+	apiVersion := ApiVersion("")
+	if c.apiVersion != nil {
+		apiVersion = *c.apiVersion
+	}
+	return executeUqlQuery(query, apiVersion, c.backend)
+}
+
+func (c defaultClient) ContinueQuery(dataSet *DataSet, rel string) (*Response, error) {
+	return continueUqlQuery(dataSet, rel, c.backend)
+}

--- a/cmd/uql/error.go
+++ b/cmd/uql/error.go
@@ -1,0 +1,115 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package uql
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/cisco-open/fsoc/platform/api"
+)
+
+// uqlProblem represents parsed data from an object returned with content-type application/problem+json according to the RFC-7807
+// These parsed data are specific for the UQL service.
+type uqlProblem struct {
+	query        string
+	title        string
+	detail       string
+	errorDetails []errorDetail
+}
+
+func (p uqlProblem) Error() string {
+	return fmt.Sprintf("%s: %s", p.title, p.detail)
+}
+
+// errorDetail contains detailed information about user error in the query
+type errorDetail struct {
+	message          string
+	fixSuggestion    string
+	fixPossibilities []string
+	errorType        string
+	errorFrom        position
+	errorTo          position
+}
+
+// position is a place in a multi-line string. Numbering of lines starts with 1
+// Position before the first character has column value 0
+type position struct {
+	line   int
+	column int
+}
+
+func makeUqlProblem(original api.Problem) uqlProblem {
+	problem := uqlProblem{
+		query:        asStringOrNothing(original.Extensions["query"]),
+		title:        original.Title,
+		detail:       original.Detail,
+		errorDetails: make([]errorDetail, 0),
+	}
+	switch array := original.Extensions["errorDetails"].(type) {
+	case []any:
+		for _, values := range array {
+			switch asMap := values.(type) {
+			case map[string]any:
+				problem.errorDetails = append(problem.errorDetails, makeErrorDetail(asMap))
+			}
+		}
+	}
+	return problem
+}
+
+func makeErrorDetail(values map[string]any) errorDetail {
+	detail := errorDetail{
+		message:       asStringOrNothing(values["message"]),
+		fixSuggestion: asStringOrNothing(values["fixSuggestion"]),
+		errorType:     asStringOrNothing(values["errorType"]),
+		errorFrom:     asPositionOrNothing(asStringOrNothing(values["errorFrom"])),
+		errorTo:       asPositionOrNothing(asStringOrNothing(values["errorTo"])),
+	}
+	switch typed := values["fixPossibilities"].(type) {
+	case []any:
+		for _, val := range typed {
+			detail.fixPossibilities = append(detail.fixPossibilities, asStringOrNothing(val))
+		}
+	}
+	return detail
+}
+
+func asStringOrNothing(value any) string {
+	if str, ok := value.(string); ok {
+		return str
+	}
+	return ""
+}
+
+func asPositionOrNothing(value string) position {
+	if strings.Count(value, ":") != 1 {
+		return position{}
+	}
+	split := strings.Split(value, ":")
+	line, err := strconv.Atoi(split[0])
+	if err != nil {
+		return position{}
+	}
+	col, err := strconv.Atoi(split[1])
+	if err != nil {
+		return position{}
+	}
+	return position{
+		line:   line,
+		column: col,
+	}
+}

--- a/cmd/uql/execute_test.go
+++ b/cmd/uql/execute_test.go
@@ -27,7 +27,15 @@ import (
 )
 
 // Tests that a proper server response is correctly deserialized into a Response struct
-func TestExecuteUqlQuery_HappyDay(t *testing.T) {
+func TestExecuteUqlQuery_HappyDay_Version1(t *testing.T) {
+	testExecuteUqlQuery_HappyDay(t, ApiVersion1)
+}
+
+func TestExecuteUqlQuery_HappyDay_NoVersion(t *testing.T) {
+	testExecuteUqlQuery_HappyDay(t, ApiVersion(""))
+}
+
+func testExecuteUqlQuery_HappyDay(t *testing.T, apiVersion ApiVersion) {
 	// given
 	// language=json
 	serverResponse := `[
@@ -69,7 +77,7 @@ func TestExecuteUqlQuery_HappyDay(t *testing.T) {
 	]`
 
 	// when
-	response, err := executeUqlQuery(&Query{"fetch count, events(logs:generic_record) from entities"}, ApiVersion1, mockExecuteResponse(serverResponse))
+	response, err := executeUqlQuery(&Query{"fetch count, events(logs:generic_record) from entities"}, apiVersion, mockExecuteResponse(serverResponse))
 
 	// then
 	check := assert.New(t)
@@ -335,11 +343,6 @@ func TestExecuteUqlQuery_Validation(t *testing.T) {
 		response, err := executeUqlQuery(&Query{""}, ApiVersion1, emptyResponse())
 		assert.Nil(t, response)
 		assert.ErrorContains(t, err, "uql query missing", "no error thrown")
-	})
-	t.Run("missing api version", func(t *testing.T) {
-		response, err := executeUqlQuery(&Query{"fetch count from entities"}, "", emptyResponse())
-		assert.Nil(t, response)
-		assert.ErrorContains(t, err, "uql API version missing", "no error thrown")
 	})
 }
 

--- a/cmd/uql/uql.go
+++ b/cmd/uql/uql.go
@@ -146,7 +146,7 @@ func outputFormat(output string, useRaw bool) (format, error) {
 func runQuery(query string) (*Response, error) {
 	log.Info("fetch data")
 
-	resp, err := ExecuteQuery(&Query{Str: query}, ApiVersion1)
+	resp, err := Client.ExecuteQuery(&Query{Str: query})
 	if err != nil {
 		return nil, err
 	}

--- a/platform/api/abbrev_test.go
+++ b/platform/api/abbrev_test.go
@@ -1,0 +1,99 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+)
+
+func TestAbbreviateString(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		n    uint
+		want string
+	}{
+		// ------           1         2
+		// ------  12345678901234567890
+		{
+			name: "ASCII string, no trim required",
+			s:    "Hello",
+			n:    10,
+			want: "Hello",
+		},
+		{
+			name: "ASCII string, trim required",
+			s:    "Hello, world!",
+			n:    10,
+			want: "Hello, wo…",
+		},
+		{
+			name: "Unicode string, no trim required",
+			s:    "こんにちは、世界！",
+			n:    9,
+			want: "こんにちは、世界！",
+		},
+		{
+			name: "Unicode string, trim required",
+			s:    "こんにちは、世界！",
+			n:    5,
+			want: "こんにち…",
+		},
+		{
+			name: "n is 0",
+			s:    "Hello, world!",
+			n:    0,
+			want: "",
+		},
+		{
+			name: "n is 1",
+			s:    "Hello, world!",
+			n:    1,
+			want: "…",
+		},
+		{
+			name: "n is 1 with empty string",
+			s:    "",
+			n:    1,
+			want: "",
+		},
+		{
+			name: "n is 1 with short string",
+			s:    "a",
+			n:    1,
+			want: "a",
+		},
+		{
+			name: "n is 1 with short unicode string",
+			s:    "ᇂ",
+			n:    1,
+			want: "ᇂ",
+		},
+		{
+			name: "Unicode string, trim at the end",
+			s:    "こんにちは、世界！",
+			n:    8,
+			want: "こんにちは、世…",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := abbreviateString(tt.s, tt.n); got != tt.want {
+				t.Errorf("%v\n\tabbreviateString() returned %q instead of %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/platform/api/context.go
+++ b/platform/api/context.go
@@ -61,7 +61,8 @@ func (c *callContext) startSpinner(msg string) {
 	if c.spinner != nil {
 		if msg != "" {
 			c.spinner.Suffix = " " + msg + " in progress"
-			c.spinner.FinalMSG = statusChar[false] + " " + msg + "\n" // jic
+			//TODO: consider making leaving the message/status optional; or just drop it
+			//c.spinner.FinalMSG = statusChar[false] + " " + msg + "\n" // jic
 		} else {
 			c.spinner.Suffix = ""
 			c.spinner.FinalMSG = ""
@@ -72,6 +73,7 @@ func (c *callContext) startSpinner(msg string) {
 }
 
 func (c *callContext) stopSpinner(ok bool) {
+	c.stopSpinnerHide()
 	if c.spinner != nil {
 		_, msg, parsed := strings.Cut(c.spinner.FinalMSG, " ") // first blank after mark
 		if parsed {


### PR DESCRIPTION

## Description

* refactored UQL API to define a Client with options (`uql.Client`, `uql.ClientV1` and `uql.NewClient()`)
* added support for api version overrides in the uql subsystem
* added support for `--follow` flag in the `optimize events` command
* abbreviated API call progress messages to mostly keep them to single lines
* hide API progress messages when the API call completes
* added support for not printing table headers in the `output` package

This PR is intended to supersede PR #196, from which the majority of the changes are taken, as authored by linkous8.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
