### PR TITLE
Configure soft/hard blocker bypassing, orion writing, and recommendat…

### DIFF
--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -487,6 +487,8 @@ func assignToBlocker(rawBlockers map[string]interface{}) (blockers Blockers) {
 			blocker.Description = "We didn't detect the Orchestration Client on your workload, which is responsible for provisioning and deprovisioning the Servo Agent"
 			blocker.Impact = "Optimization cannot be performed because the Servo Agent can't be provisioned on your cluster"
 			blockers.NoOrchestrationAgent = blocker
+		default:
+			log.Warnf("Unknown blocker %q encountered", key)
 		}
 		data := rawBlockers[key].(map[string]interface{})
 		if data["overridable"] == "true" {

--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -350,10 +350,10 @@ FROM entities(k8s:deployment)[attributes("k8s.cluster.name") = "{{.Cluster}}" &&
 			})
 
 			// Ascertain bypassability of blockers
-			if (flags.bypassSoftBlockers == true) || (flags.bypassHardBlockers == true) {
-				if flags.bypassHardBlockers == true {
+			if flags.bypassSoftBlockers || flags.bypassHardBlockers {
+				if flags.bypassHardBlockers {
 					log.Warn("Caution: bypassing hard blockers")
-				} else if flags.bypassSoftBlockers == true {
+				} else if flags.bypassSoftBlockers {
 					if checkHardBlockers(&blockers) {
 						return fmt.Errorf("Cannot soft bypass, hard blockers present. Resolve before onboarding the optimizer")
 					} else {
@@ -412,7 +412,7 @@ FROM entities(k8s:deployment)[attributes("k8s.cluster.name") = "{{.Cluster}}" &&
 }
 
 func assignToBlocker(rawBlockers map[string]interface{}) (blockers Blockers) {
-	for key, _ := range rawBlockers {
+	for key := range rawBlockers {
 		blocker := &Blocker{}
 		switch key {
 		case "stateful":

--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -317,7 +317,7 @@ FROM entities(k8s:deployment)[attributes("k8s.cluster.name") = "{{.Cluster}}" &&
 				setNestedMap(rawBlockers, segments, value)
 			}
 		}
-		if rawBlockers != nil {
+		if len(rawBlockers) != 0 {
 			var ignoredBlockers IgnoredBlockers
 			ignoredBlockers.Timestamp = time.Now().UTC().String()
 			ignoredBlockers.Principal = Principal{

--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -63,14 +63,14 @@ type eventsCmdFlags struct {
 	events          []string
 }
 
-type eventsRow struct {
+type EventsRow struct {
 	Timestamp       time.Time
 	EventAttributes map[string]any
 	Blockers        []string
 }
 
 type recommendationRow struct {
-	eventsRow
+	EventsRow
 	BlockersAttributes map[string]any
 	BlockersPresent    string
 	Blockers           []string
@@ -270,7 +270,7 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 		}
 
 		output.PrintCmdOutput(cmd, struct {
-			Items []eventsRow `json:"items"`
+			Items []EventsRow `json:"items"`
 			Total int         `json:"total"`
 		}{Items: eventRows, Total: len(eventRows)})
 
@@ -497,7 +497,7 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 			uniqueKey := fmt.Sprintf("%s-%s", optimizerId.(string), optimizationNum.(string))
 
 			recommendationWithBlockers := recommendationRow{}
-			recommendationWithBlockers.eventsRow = recommendationRows[i]
+			recommendationWithBlockers.EventsRow = recommendationRows[i]
 			recommendationWithBlockers.BlockersAttributes = make(map[string]any)
 
 			recommendationWithBlockers.BlockersPresent = "false"
@@ -581,7 +581,9 @@ func getOptimizationBlockerData(tempVals recommendationsTemplateValues) (map[str
 func extractStartedBlockersData(dataset *uql.DataSet) (map[string]any, error) {
 	resp_data := &dataset.Data
 	results := make(map[string]any)
-
+	if resp_data == nil {
+		return results, nil
+	}
 	for _, row := range *resp_data {
 
 		attributes := row[0].(uql.ComplexData)
@@ -600,18 +602,18 @@ func extractStartedBlockersData(dataset *uql.DataSet) (map[string]any, error) {
 	return results, nil
 }
 
-func extractEventsData(dataset *uql.DataSet) ([]eventsRow, error) {
+func extractEventsData(dataset *uql.DataSet) ([]EventsRow, error) {
 	if dataset == nil {
-		return []eventsRow{}, nil
+		return []EventsRow{}, nil
 	}
 	resp_data := &dataset.Data
-	results := make([]eventsRow, 0, len(*resp_data))
+	results := make([]EventsRow, 0, len(*resp_data))
 
 	for _, row := range *resp_data {
 		attributes := row[0].(uql.ComplexData)
 		attributesMap, _ := sliceToMap(attributes.Data)
 		timestamp := row[1].(time.Time)
-		results = append(results, eventsRow{Timestamp: timestamp, EventAttributes: attributesMap})
+		results = append(results, EventsRow{Timestamp: timestamp, EventAttributes: attributesMap})
 	}
 
 	return results, nil

--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -578,11 +578,13 @@ func getOptimizationBlockerData(tempVals recommendationsTemplateValues) (map[str
 }
 
 func extractStartedBlockersData(dataset *uql.DataSet) (map[string]any, error) {
-	resp_data := &dataset.Data
+
 	results := make(map[string]any)
-	if resp_data == nil {
+	if dataset == nil {
 		return results, nil
 	}
+	resp_data := &dataset.Data
+
 	for _, row := range *resp_data {
 
 		attributes := row[0].(uql.ComplexData)

--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -66,7 +66,6 @@ type eventsCmdFlags struct {
 type EventsRow struct {
 	Timestamp       time.Time
 	EventAttributes map[string]any
-	Blockers        []string
 }
 
 type recommendationRow struct {

--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -519,8 +519,8 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 
 func getOptimizationBlockerData(row eventsRow, flags *recommendationsCmdFlags) (*[]eventsRow, error) {
 
-	optimizerId, _ := row.EventAttributes["optimize.optimization.optimizer_id"]
-	optimizationNum, _ := row.EventAttributes["optimize.optimization.num"]
+	optimizerId := row.EventAttributes["optimize.optimization.optimizer_id"]
+	optimizationNum := row.EventAttributes["optimize.optimization.num"]
 	tempVals := optimizationStartedTemplateValues{
 		Since:        flags.since,
 		Until:        flags.until,
@@ -561,12 +561,15 @@ func getOptimizationBlockerData(row eventsRow, flags *recommendationsCmdFlags) (
 	if err != nil {
 		return nil, fmt.Errorf("extractEventsData: %w", err)
 	}
-	optimizationStartedRows, err = parseBlockerData(optimizationStartedRows)
+	optimizationStartedRows, err = extractBlockerData(optimizationStartedRows)
+	if err != nil {
+		return nil, fmt.Errorf("extractBlockerData: %w", err)
+	}
 
 	return &optimizationStartedRows, nil
 }
 
-func parseBlockerData(rows []eventsRow) ([]eventsRow, error) {
+func extractBlockerData(rows []eventsRow) ([]eventsRow, error) {
 	for i := range rows {
 		presence := "false"
 		newAttributes := make(map[string]any)

--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -182,7 +182,7 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 
 		if flags.count != -1 {
 			if flags.count > 1000 {
-				return errors.New("Counts higher than 1000 are not supported")
+				return errors.New("counts higher than 1000 are not supported")
 			}
 			tempVals.Limits = strconv.Itoa(flags.count)
 		}
@@ -211,12 +211,12 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 			return nil
 		}
 		if len(main_data_set.Data[0]) < 1 {
-			return fmt.Errorf("Main dataset %v first row has no columns", main_data_set.Name)
+			return fmt.Errorf("main dataset %v first row has no columns", main_data_set.Name)
 		}
 
 		data_set, ok := main_data_set.Data[0][0].(*uql.DataSet)
 		if !ok {
-			return fmt.Errorf("Main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
+			return fmt.Errorf("main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
 		}
 		eventRows, err := extractEventsData(data_set)
 		if err != nil {
@@ -250,14 +250,14 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 				break
 			}
 			if len(main_data_set.Data) < 1 {
-				return fmt.Errorf("Page %v main dataset %v has no rows", page, main_data_set.Name)
+				return fmt.Errorf("page %v main dataset %v has no rows", page, main_data_set.Name)
 			}
 			if len(main_data_set.Data[0]) < 1 {
-				return fmt.Errorf("Page %v main dataset %v first row has no columns", page, main_data_set.Name)
+				return fmt.Errorf("page %v main dataset %v first row has no columns", page, main_data_set.Name)
 			}
 			data_set, ok = main_data_set.Data[0][0].(*uql.DataSet)
 			if !ok {
-				return fmt.Errorf("Page %v main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", page, main_data_set.Name, main_data_set.Data[0][0])
+				return fmt.Errorf("page %v main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", page, main_data_set.Name, main_data_set.Data[0][0])
 			}
 
 			newRows, err := extractEventsData(data_set)
@@ -395,7 +395,7 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 
 		if flags.count != -1 {
 			if flags.count > 1000 {
-				return errors.New("Counts higher than 1000 are not supported")
+				return errors.New("counts higher than 1000 are not supported")
 			}
 			tempVals.Limits = strconv.Itoa(flags.count)
 		}
@@ -424,12 +424,12 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 			return nil
 		}
 		if len(main_data_set.Data[0]) < 1 {
-			return fmt.Errorf("Main dataset %v first row has no columns", main_data_set.Name)
+			return fmt.Errorf("main dataset %v first row has no columns", main_data_set.Name)
 		}
 
 		data_set, ok := main_data_set.Data[0][0].(*uql.DataSet)
 		if !ok {
-			return fmt.Errorf("Main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
+			return fmt.Errorf("main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
 		}
 		recommendationRows, err := extractEventsData(data_set)
 		if err != nil {
@@ -463,14 +463,14 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 				break
 			}
 			if len(main_data_set.Data) < 1 {
-				return fmt.Errorf("Page %v main dataset %v has no rows", page, main_data_set.Name)
+				return fmt.Errorf("page %v main dataset %v has no rows", page, main_data_set.Name)
 			}
 			if len(main_data_set.Data[0]) < 1 {
-				return fmt.Errorf("Page %v main dataset %v first row has no columns", page, main_data_set.Name)
+				return fmt.Errorf("page %v main dataset %v first row has no columns", page, main_data_set.Name)
 			}
 			data_set, ok = main_data_set.Data[0][0].(*uql.DataSet)
 			if !ok {
-				return fmt.Errorf("Page %v main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", page, main_data_set.Name, main_data_set.Data[0][0])
+				return fmt.Errorf("page %v main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", page, main_data_set.Name, main_data_set.Data[0][0])
 			}
 
 			newRows, err := extractEventsData(data_set)
@@ -486,7 +486,7 @@ func listRecommendations(flags *recommendationsCmdFlags) func(*cobra.Command, []
 		// extract blocker rows
 		blockerRows, err := getOptimizationBlockerData(tempVals)
 		if err != nil {
-			return fmt.Errorf("Failed to retrieve optimization_started blocker data: %v", err)
+			return fmt.Errorf("failed to retrieve optimization_started blocker data: %v", err)
 		}
 
 		// iterate through recommendations rows and append blocker data from optimization_started events, linking on optimizer ID + num
@@ -559,15 +559,15 @@ func getOptimizationBlockerData(tempVals recommendationsTemplateValues) (map[str
 
 	main_data_set := resp.Main()
 	if main_data_set == nil || len(main_data_set.Data) < 1 {
-		return nil, fmt.Errorf("No optimization_started results found for given input\n")
+		return nil, fmt.Errorf("no optimization_started results found for given input")
 	}
 	if len(main_data_set.Data[0]) < 1 {
-		return nil, fmt.Errorf("Main dataset %v first row has no columns", main_data_set.Name)
+		return nil, fmt.Errorf("main dataset %v first row has no columns", main_data_set.Name)
 	}
 
 	data_set, ok := main_data_set.Data[0][0].(*uql.DataSet)
 	if !ok {
-		return nil, fmt.Errorf("Main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
+		return nil, fmt.Errorf("main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
 	}
 	startedBlockersData, err := extractStartedBlockersData(data_set)
 	if err != nil {
@@ -653,7 +653,7 @@ func listOptimizations(flags *eventsFlags) ([]string, error) {
 		filterList = append(filterList, fmt.Sprintf("attributes(\"k8s.workload.name\") = %q", flags.workloadName))
 	}
 	if len(filterList) < 1 {
-		return []string{}, errors.New("Sanity check failed, optimizations query must at least filter on namespace or workload name, otherwise this query can be skipped")
+		return []string{}, errors.New("sanity check failed, optimizations query must at least filter on namespace or workload name, otherwise this query can be skipped")
 	}
 	if flags.clusterId != "" {
 		filterList = append(filterList, fmt.Sprintf("attributes(\"k8s.cluster.id\") = %q", flags.clusterId))

--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -330,13 +330,6 @@ type recommendationsTemplateValues struct {
 	SolutionName       string
 }
 
-type optimizationStartedTemplateValues struct {
-	Since        string
-	Until        string
-	Filter       string
-	SolutionName string
-}
-
 var recommendationsTemplate = template.Must(template.New("").Parse(`
 {{ with .Since }}SINCE {{ . }}
 {{ end -}}

--- a/cmd/optimize/management.go
+++ b/cmd/optimize/management.go
@@ -63,7 +63,7 @@ func (flags *managementFlags) getOptimizerConfig() (OptimizerConfiguration, erro
 		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer/%v", flags.solutionName, flags.optimizerId)
 		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers})
 		if err != nil {
-			return optimizerConfig, fmt.Errorf("Unable to fetch config by optimizer ID. api.JSONGet: %w", err)
+			return optimizerConfig, fmt.Errorf("unable to fetch config by optimizer ID. api.JSONGet: %w", err)
 		}
 
 		optimizerConfig = response.Data
@@ -82,12 +82,12 @@ func (flags *managementFlags) getOptimizerConfig() (OptimizerConfiguration, erro
 			return optimizerConfig, fmt.Errorf("unable to fetch config by workload information. api.JSONGet: %w", err)
 		}
 		if configPage.Total != 1 {
-			return optimizerConfig, fmt.Errorf("Found %v optimizer configurations for the given workload information", configPage.Total)
+			return optimizerConfig, fmt.Errorf("found %v optimizer configurations for the given workload information", configPage.Total)
 		}
 
 		optimizerConfig = configPage.Items[0].Data
 	} else {
-		return optimizerConfig, errors.New("No identifying information provided for the optimizer to be managed")
+		return optimizerConfig, errors.New("no identifying information provided for the optimizer to be managed")
 	}
 
 	return optimizerConfig, nil
@@ -97,7 +97,7 @@ func (flags *managementFlags) updateOptimizerConfiguration(config OptimizerConfi
 	var res any
 	urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer/%v", flags.solutionName, config.OptimizerID)
 	if err := api.JSONPut(urlStr, config, &res, &api.Options{Headers: getOrionTenantHeaders()}); err != nil {
-		return fmt.Errorf("Failed to update knowledge object with new optimizer configuration. api.JSONPut: %w", err)
+		return fmt.Errorf("failed to update knowledge object with new optimizer configuration. api.JSONPut: %w", err)
 	}
 	return nil
 }
@@ -140,7 +140,7 @@ func startOptimizer(flags *startFlags) func(cmd *cobra.Command, args []string) e
 		}
 		if config.DesiredState == "started" {
 			if !flags.restart {
-				return errors.New("Optimizer already started (did you mean to specify --restart?)")
+				return errors.New("optimizer already started (did you mean to specify --restart?)")
 			}
 		}
 
@@ -179,7 +179,7 @@ func stopOptimizer(flags *managementFlags) func(cmd *cobra.Command, args []strin
 			return fmt.Errorf("flags.getOptimizerConfig: %w", err)
 		}
 		if config.DesiredState == "stopped" {
-			return errors.New("Optimizer already stopped")
+			return errors.New("optimizer already stopped")
 		}
 
 		config.DesiredState = "stopped"
@@ -236,8 +236,8 @@ func suspendOptimizer(flags *suspendFlags) func(*cobra.Command, []string) error 
 		}
 		if _, ok := optimizerConfig.Suspensions[flags.suspensionId]; ok {
 			return fmt.Errorf(
-				"Optimizer configuration already has suspension with ID %q. "+
-					"Please use a different suspension ID to avoid removing a suspension you may not have added",
+				"optimizer configuration already has suspension with ID %q; "+
+					"please use a different suspension ID to avoid removing a suspension you may not have added",
 				flags.suspensionId,
 			)
 		}
@@ -279,10 +279,10 @@ func unsuspendOptimizer(flags *suspendFlags) func(*cobra.Command, []string) erro
 		}
 
 		if config.Suspensions == nil || len(config.Suspensions) < 1 {
-			return errors.New("Optimizer has no suspensions to remove")
+			return errors.New("optimizer has no suspensions to remove")
 		}
 		if _, ok := config.Suspensions[flags.suspensionId]; !ok {
-			return fmt.Errorf("Optimizer has no suspension with ID %q to be removed", flags.suspensionId)
+			return fmt.Errorf("optimizer has no suspension with ID %q to be removed", flags.suspensionId)
 		}
 		delete(config.Suspensions, flags.suspensionId)
 

--- a/cmd/optimize/servo.go
+++ b/cmd/optimize/servo.go
@@ -117,7 +117,7 @@ func getServoLogs(flags *servoLogsFlags) func(*cobra.Command, []string) error {
 
 		if flags.count != -1 {
 			if flags.count > 1000 {
-				return errors.New("Counts higher than 1000 are not supported")
+				return errors.New("counts higher than 1000 are not supported")
 			}
 			tempVals.Limits = strconv.Itoa(flags.count)
 		}
@@ -146,12 +146,12 @@ func getServoLogs(flags *servoLogsFlags) func(*cobra.Command, []string) error {
 			return nil
 		}
 		if len(main_data_set.Data[0]) < 1 {
-			return fmt.Errorf("Main dataset %v first row has no columns", main_data_set.Name)
+			return fmt.Errorf("main dataset %v first row has no columns", main_data_set.Name)
 		}
 
 		data_set, ok := main_data_set.Data[0][0].(*uql.DataSet)
 		if !ok {
-			return fmt.Errorf("Main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
+			return fmt.Errorf("main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", main_data_set.Name, main_data_set.Data[0][0])
 		}
 		logRows, err := extractLogsData(data_set)
 		if err != nil {
@@ -185,14 +185,14 @@ func getServoLogs(flags *servoLogsFlags) func(*cobra.Command, []string) error {
 				break
 			}
 			if len(main_data_set.Data) < 1 {
-				return fmt.Errorf("Page %v main dataset %v has no rows", page, main_data_set.Name)
+				return fmt.Errorf("page %v main dataset %v has no rows", page, main_data_set.Name)
 			}
 			if len(main_data_set.Data[0]) < 1 {
-				return fmt.Errorf("Page %v main dataset %v first row has no columns", page, main_data_set.Name)
+				return fmt.Errorf("page %v main dataset %v first row has no columns", page, main_data_set.Name)
 			}
 			data_set, ok = main_data_set.Data[0][0].(*uql.DataSet)
 			if !ok {
-				return fmt.Errorf("Page %v main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", page, main_data_set.Name, main_data_set.Data[0][0])
+				return fmt.Errorf("page %v main dataset %v first row first column (type %T) could not be converted to *uql.DataSet", page, main_data_set.Name, main_data_set.Data[0][0])
 			}
 
 			newRows, err := extractLogsData(data_set)

--- a/cmd/optimize/types.go
+++ b/cmd/optimize/types.go
@@ -18,6 +18,7 @@ import "time"
 
 type OptimizerConfiguration struct {
 	Config           Config                `json:"config"`
+	IgnoredBlockers  IgnoredBlockers       `json:"ignoredBlockers"`
 	DesiredState     string                `json:"desiredState"`
 	OptimizerID      string                `json:"optimizerId"`
 	RestartTimestamp string                `json:"restartTimestamp"`
@@ -52,6 +53,45 @@ type Config struct {
 	Guardrails Guardrails `json:"guardrails"`
 	Slo        Slo        `json:"slo"`
 }
+
+type IgnoredBlockers struct {
+	Principal Principal `json:"principal,omitempty"`
+	Timestamp string    `json:"timestamp,omitempty"`
+	Blockers  Blockers  `json:"blockers,omitempty"`
+}
+
+type Principal struct {
+	Id   string `json:"id"`
+	Type string `json:"type"`
+}
+
+type Blockers struct {
+	Stateful                    *Blocker `json:"stateful,omitempty"`
+	NoTraffic                   *Blocker `json:"noTraffic,omitempty"`
+	ResourcesNotSpecified       *Blocker `json:"resourcesNotSpecified,omitempty"`
+	CPUNotSpecified             *Blocker `json:"cpuNotSpecified,omitempty"`
+	MemNotSpecified             *Blocker `json:"memNotSpecified,omitempty"`
+	CPUResourcesChange          *Blocker `json:"cpuResourcesChange,omitempty"`
+	MemoryResourcesChange       *Blocker `json:"memResourcesChange,omitempty"`
+	K8sMetricsDeficient         *Blocker `json:"k8sMetricsDeficient,omitempty"`
+	APMMetricsMissing           *Blocker `json:"apmMetricsMissing,omitempty"`
+	APMMetricsDeficient         *Blocker `json:"apmMetricsDeficient,omitempty"`
+	MultipleAPM                 *Blocker `json:"multipleAPM,omitempty"`
+	UnequalLoadDistribution     *Blocker `json:"unequalLoadDistribution,omitempty"`
+	NoScaling                   *Blocker `json:"noScaling,omitempty"`
+	InsufficientRelativeScaling *Blocker `json:"insufficientRelativeScaling,omitempty"`
+	InsufficientFixedScaling    *Blocker `json:"insufficientFixedScaling,omitempty"`
+	MTBFHigh                    *Blocker `json:"mtbfHigh,omitempty"`
+	ErrorRateHigh               *Blocker `json:"errorRateHigh,omitempty"`
+	NoOrchestrationAgent        *Blocker `json:"noOrchestrationAgent,omitempty"`
+}
+
+type Blocker struct {
+	Description string `json:"description"`
+	Impact      string `json:"impact"`
+	Overridable bool   `json:"-"` // do not write to json for orion
+}
+
 type Suspension struct {
 	Reason    string `json:"reason"`
 	Timestamp string `json:"timestamp"`


### PR DESCRIPTION
…ion fetching

## Description

- By default, refuse to start if there are any blockers (and list them/provide some way to get the list and details)
- Have a --bypass-soft-blockers (or similar) option that allows bypassing the blockers (all at once); make sure that we print the list
- Have a hidden --bypass-hard-blockers option
- Include the "ignored_blockers" section when writing the optimizer object (make sure to overwrite any old blockers). Note that this should include all blockers that are present, both soft and hard (which are not overridable in GUI, but are in fsoc)
- Show the bypassed blockers on ~status~ and recommendations. The human readable output should indicate if there were blockers ignored, the full output (json/yaml) should provide the full details. For recommendations, we can get the info from the optimization_started entity for the optimization 

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
