### PR TITLE
ORION-2271: fix issue with encoding object ids for get by id requests with the new identifyingProperties field

### DIFF
--- a/cmd/iamrole/principals.go
+++ b/cmd/iamrole/principals.go
@@ -64,7 +64,7 @@ type principalsCollection struct {
 func listPrincipals(cmd *cobra.Command, args []string) {
 	// note: the API is not compliant with collections/pagination, so collect as a single request
 	var out principalsResponse
-	err := api.JSONGet(getIamRoleUrl(args[0], "principals"), &out, nil)
+	err := api.JSONGet(getIamRoleUrl(args[0], "principals"), &out, nil, true)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -78,7 +78,7 @@ func editObject(cmd *cobra.Command, args []string) {
 	url := getObjectUrl(fqtn, objID)
 
 	var res KSObject
-	err = api.JSONGet(url, &res, httpOptions)
+	err = api.JSONGet(url, &res, httpOptions, false)
 	if err != nil {
 		log.Fatalf("Failed to fetch object: %v", err)
 	}

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -132,7 +132,7 @@ func getObject(cmd *cobra.Command, args []string, ltFlag layerType) error {
 	var objStoreUrl string
 	var isCollection bool = true
 	if objID != "" {
-		objStoreUrl = getObjectUrl(fqtn, objID)
+		objStoreUrl = getObjectUrl(fqtn, url.QueryEscape(objID))
 		isCollection = false
 	} else {
 		if cmd.Flags().Changed("filter") {

--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -376,7 +376,7 @@ func getOptimizerConfig(optimizerId string, workloadId string, solutionName stri
 		var response configJsonStoreItem
 
 		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer/%v", solutionName, optimizerId)
-		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers})
+		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers}, false)
 		if err != nil {
 			if problem, ok := err.(api.Problem); ok && problem.Status == 404 {
 				return optimizerConfig, fmt.Errorf("%w: No matches found for the given optimizerId", optimizerConfigNotFoundError)
@@ -396,7 +396,7 @@ func getOptimizerConfig(optimizerId string, workloadId string, solutionName stri
 		}
 		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer?filter=%v", solutionName, queryStr)
 
-		err := api.JSONGet(urlStr, &configPage, &api.Options{Headers: headers})
+		err := api.JSONGet(urlStr, &configPage, &api.Options{Headers: headers}, true)
 		if err != nil {
 			return optimizerConfig, fmt.Errorf("unable to fetch existing config by workload ID. api.JSONGet: %w", err)
 		}

--- a/cmd/optimize/management.go
+++ b/cmd/optimize/management.go
@@ -61,7 +61,7 @@ func (flags *managementFlags) getOptimizerConfig() (OptimizerConfiguration, erro
 		var response configJsonStoreItem
 
 		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer/%v", flags.solutionName, flags.optimizerId)
-		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers})
+		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers}, false)
 		if err != nil {
 			return optimizerConfig, fmt.Errorf("Unable to fetch config by optimizer ID. api.JSONGet: %w", err)
 		}
@@ -77,7 +77,7 @@ func (flags *managementFlags) getOptimizerConfig() (OptimizerConfiguration, erro
 			flags.cluster, flags.namespace, flags.workloadName))
 		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:optimizer?filter=%v", flags.solutionName, queryStr)
 
-		err := api.JSONGet(urlStr, &configPage, &api.Options{Headers: headers})
+		err := api.JSONGet(urlStr, &configPage, &api.Options{Headers: headers}, true)
 		if err != nil {
 			return optimizerConfig, fmt.Errorf("unable to fetch config by workload information. api.JSONGet: %w", err)
 		}

--- a/cmd/optimize/servo.go
+++ b/cmd/optimize/servo.go
@@ -101,7 +101,7 @@ func getServoLogs(flags *servoLogsFlags) func(*cobra.Command, []string) error {
 		var response statusJsonStoreItem
 		urlStr := fmt.Sprintf("knowledge-store/v1/objects/%v:status/%v", flags.solutionName, flags.optimizerId)
 
-		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers})
+		err := api.JSONGet(urlStr, &response, &api.Options{Headers: headers}, false)
 		if err != nil {
 			return fmt.Errorf("JSONGet: Unable to fetch %v:status by optimizer ID. api.JSONGet: %w", flags.solutionName, err)
 		}

--- a/cmd/solution/check.go
+++ b/cmd/solution/check.go
@@ -103,7 +103,7 @@ func Fetch(path string, httpOptions *api.Options) map[string]interface{} {
 	// finalize override fields
 	var res map[string]interface{}
 	// fetch data
-	if err := api.JSONGet(path, &res, httpOptions); err != nil {
+	if err := api.JSONGet(path, &res, httpOptions, false); err != nil {
 		log.Fatalf("Platform API call failed: %v", err)
 	}
 	return res

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -45,7 +45,7 @@ func solutionDescribe(cmd *cobra.Command, args []string) {
 
 	log.WithField("solution", solution).Info("Getting solution details")
 	var res Solution
-	err := api.JSONGet(getSolutionDescribeUrl(url.PathEscape(solution)), &res, &api.Options{Headers: headers})
+	err := api.JSONGet(getSolutionDescribeUrl(url.PathEscape(solution)), &res, &api.Options{Headers: headers}, false)
 	if err != nil {
 		log.Fatalf("Cannot get solution details: %v", err)
 	}

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -94,7 +94,7 @@ func getObjects(url string, headers map[string]string) StatusItem {
 	var res ResponseBlob
 	var emptyData StatusItem
 
-	err := api.JSONGet(url, &res, &api.Options{Headers: headers})
+	err := api.JSONGet(url, &res, &api.Options{Headers: headers}, true)
 
 	if err != nil {
 		log.Fatalf("Error fetching status object %q: %v", url, err)
@@ -110,7 +110,7 @@ func getObjects(url string, headers map[string]string) StatusItem {
 func getExtensibilitySolutionObject(url string, headers map[string]string) ExtensibilitySolutionObjectData {
 	var res GetExtensibilitySolutionObjectByIdResponse
 
-	err := api.JSONGet(url, &res, &api.Options{Headers: headers})
+	err := api.JSONGet(url, &res, &api.Options{Headers: headers}, false)
 
 	if err != nil {
 		log.Fatalf("Error fetching extensibility:solution object %q: %v", url, err)

--- a/cmd/solution/test.go
+++ b/cmd/solution/test.go
@@ -187,7 +187,7 @@ func testSolutionStatus(cmd *cobra.Command, args []string) {
 
 	// Send the test-run-id to the test-runner and print the response
 	var res SolutionTestStatusResult
-	err := api.JSONGet(getSolutionTestStatusUrl(suppliedTestId), &res, nil)
+	err := api.JSONGet(getSolutionTestStatusUrl(suppliedTestId), &res, nil, true)
 	if err != nil {
 		log.Fatalf("Solution Test Status request failed: %v", err)
 	}

--- a/cmd/solution/unsubscribe.go
+++ b/cmd/solution/unsubscribe.go
@@ -77,7 +77,7 @@ func isSystemSolution(solutionName string) (bool, error) {
 	}
 
 	getSolutionUrl := fmt.Sprintf(getSolutionListUrl()+"/%s", solutionName)
-	err := api.JSONGet(getSolutionUrl, &solData, &api.Options{Headers: headers})
+	err := api.JSONGet(getSolutionUrl, &solData, &api.Options{Headers: headers}, false)
 	if err != nil {
 		return false, fmt.Errorf("failed to get solution info: %v", err)
 	}

--- a/cmd/uql/execute.go
+++ b/cmd/uql/execute.go
@@ -121,7 +121,7 @@ func (b defaultBackend) Continue(link *Link) (parsedResponse, error) {
 	log.WithFields(log.Fields{"query": link.Href}).Info("continuing UQL query")
 
 	var rawJson json.RawMessage
-	err := api.JSONGet(link.Href, &rawJson, nil)
+	err := api.JSONGet(link.Href, &rawJson, nil, true)
 	if err != nil {
 		return parsedResponse{}, errors.Wrap(err, fmt.Sprintf("failed follow link: '%s'", link.Href))
 	}

--- a/cmdkit/fetch_and_print.go
+++ b/cmdkit/fetch_and_print.go
@@ -88,7 +88,7 @@ func FetchAndPrint(cmd *cobra.Command, path string, options *FetchAndPrintOption
 		res = result
 
 	} else {
-		err = api.JSONRequest(method, path, body, &res, httpOptions)
+		err = api.JSONRequest(method, path, body, &res, httpOptions, false)
 	}
 	if err != nil {
 		log.Fatalf("Platform API call failed: %v", err)

--- a/platform/api/call_test.go
+++ b/platform/api/call_test.go
@@ -14,7 +14,7 @@ func TestPrepareHTTPRequest(t *testing.T) {
 	cfg := &config.Context{
 		URL: "http://localhost:8080",
 	}
-	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil)
+	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "http://localhost:8080/test/path/1", req.URL.String())
 }
@@ -24,7 +24,7 @@ func TestPrepareJSONRequest(t *testing.T) {
 	cfg := &config.Context{
 		URL: "http://localhost:8080",
 	}
-	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil)
+	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil, false)
 	assert.Nil(t, err)
 	assert.Equal(t, "http://localhost:8080/test/path/1", req.URL.String())
 }

--- a/platform/api/collection.go
+++ b/platform/api/collection.go
@@ -35,7 +35,7 @@ const (
 // https://developer.cisco.com/api-guidelines/#rest-style/API.REST.STYLE.25 and
 // https://developer.cisco.com/api-guidelines/#rest-style/API.REST.STYLE.24
 func JSONGetCollection[T any](path string, out *CollectionResult[T], options *Options) (err error) {
-
+	log.WithFields(log.Fields{"options": options}).Info("value of options in JSONGetCollection")
 	subOptions := Options{}
 	if options != nil {
 		subOptions = *options // shallow copy
@@ -45,7 +45,7 @@ func JSONGetCollection[T any](path string, out *CollectionResult[T], options *Op
 	var pageNo int
 	for pageNo = 0; true; pageNo += 1 {
 		// request collection
-		err := httpRequest("GET", path, nil, &page, &subOptions)
+		err := httpRequest("GET", path, nil, &page, &subOptions, true)
 		if err != nil {
 			if pageNo > 0 {
 				return fmt.Errorf("Error retrieving non-first page #%v in collection at %q: %v. All data discarded", pageNo+1, path, err)


### PR DESCRIPTION
## Description

A user observed that the fsoc ks get commands are broken when doing a get by ID with multiple identifying properties.  The multiple instances of / were not being escaped correctly and it was causing 404 issues when folks were trying to use fsoc to get objects by ID.  This pull request will fix that issue and also ensure that all of the other escaping logic that we have in place will still work as well.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
