### PR TITLE
ORION-2271: add support for properly escaping special characters included in the objectId for get by ID requests

### DIFF
--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -155,7 +155,7 @@ func getTypeUrl(fqtn string) string {
 }
 
 func getObjectUrl(fqtn, objId string) string {
-	return fmt.Sprintf("%v/objects/%s/%s", GetBaseUrl(), fqtn, objId)
+	return fmt.Sprintf("%v/objects/%s/%s", GetBaseUrl(), fqtn, url.QueryEscape(objId))
 }
 
 func getObjectListUrl(fqtn string) string {

--- a/platform/api/call.go
+++ b/platform/api/call.go
@@ -89,6 +89,9 @@ func prepareHTTPRequest(cfg *config.Context, client *http.Client, method string,
 	// body will be JSONified if a body is given but no Content-Type is provided
 	// (if a content type is provided, we assume the body is in the desired format)
 	jsonify := body != nil && (headers == nil || headers["Content-Type"] == "")
+	// Due to issues with encoding the special characters used for ids generated with identifyingProperties, we
+	// need to create the fullPath for the request ourselves instead of calling uri.String()
+	var fullPath string
 
 	// prepare a body reader
 	var bodyReader io.Reader = nil
@@ -110,15 +113,24 @@ func prepareHTTPRequest(cfg *config.Context, client *http.Client, method string,
 
 	// create HTTP request
 	path, query, _ := strings.Cut(path, "?")
-	url, err := url.Parse(cfg.URL)
+	uri, err := url.Parse(cfg.URL)
 	if err != nil {
 		log.Fatalf("Failed to parse the url provided in context (%q): %v", cfg.URL, err)
 	}
-	url.Path = path
-	url.RawQuery = query
-	req, err := http.NewRequest(method, url.String(), bodyReader)
+	// Create the full path again ensuring that we aren't double escaping characters in the path
+	if query == "" {
+		joinedPath, err := url.JoinPath(uri.String(), path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create a request for %q: %w", uri.String(), err)
+		}
+		fullPath = joinedPath
+	} else {
+		fullPath = fmt.Sprintf("%s/%s?%s", uri.String(), path, query)
+	}
+
+	req, err := http.NewRequest(method, fullPath, bodyReader)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create a request for %q: %w", url.String(), err)
+		return nil, fmt.Errorf("failed to create a request for %q: %w", uri.String(), err)
 	}
 
 	// add headers that are not already provided


### PR DESCRIPTION
## Description

A user reported an issue with the way in which we are encoding objectIds generated using the identifyingProperties field in a given type definition for objects of that type.  This PR contains changes to fix the implementation to properly encode the objectId in the case of get by ID requests

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
