### PR TITLE
Fix JSONGetCollection nil slice edge case

### DIFF
--- a/platform/api/collection.go
+++ b/platform/api/collection.go
@@ -53,7 +53,13 @@ func JSONGetCollection[T any](path string, out *CollectionResult[T], options *Op
 			return err
 		}
 
-		out.Items = append(out.Items, page.Items...)
+		// handle case where out.Items is uninitialized (nil) and page.Items is an initalized but empty slice
+		// append results in a nil slice instead of an empty slice in this case
+		if out.Items == nil && page.Items != nil {
+			out.Items = page.Items
+		} else {
+			out.Items = append(out.Items, page.Items...)
+		}
 
 		// break if no more pages (no response headers, no links or no next link)
 		if subOptions.ResponseHeaders == nil {


### PR DESCRIPTION
## Description

This PR is to fix a bug reported by @pavel-georgiev where empty list responses resulted in panics when trying to create the output table

```
   ⨯ error at data row -1 : %!v(PANIC=Error method: invalid type: *gojq.iteratorError (cannot iterate over: null)); likely a bug; use --output json or yaml for now
   ⨯ error at data row 0 : %!v(PANIC=Error method: invalid type: *gojq.iteratorError (cannot iterate over: null)); likely a bug; use --output json or yaml for now
```

This was caused by an edge case in the behavior of api.JSONGetCollection where a response with an empty array in json was being returned as a nil slice instead of the expected behavior of returning an empty slice. 

Given the bytes `{"total":0,"items":[]}`, json.Unmarshal loads a CollectionResult struct where the `Items` property is set to an emtpy slice. But this function has to account for multiple pages so the CollectionResult is stored on a `page` variable which has to be accumulated into a final CollectionResult struct variable named `out`. However, trying to unpack and append the empty `page` slice to the unitialized nil slice in `out` results in `out.Items` still being a nil slice which does not accurately represent the unmarshalled json response

https://github.com/cisco-open/fsoc/blob/d2dd65a554f973d94f3d0f81864593bea31434dc/platform/api/collection.go#L56 

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
