### PR TITLE
omit optional lists in FMM objects when empty

### DIFF
--- a/cmd/solution/types-fmm.go
+++ b/cmd/solution/types-fmm.go
@@ -70,7 +70,7 @@ func (entity *FmmEntity) GetTypeName() string {
 
 type FmmEvent struct {
 	*FmmTypeDef
-	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions"`
+	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions"` // required always, do not omitempty
 }
 
 type FmmResourceMapping struct {

--- a/cmd/solution/types-fmm.go
+++ b/cmd/solution/types-fmm.go
@@ -70,7 +70,7 @@ func (entity *FmmEntity) GetTypeName() string {
 
 type FmmEvent struct {
 	*FmmTypeDef
-	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
+	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions"`
 }
 
 type FmmResourceMapping struct {

--- a/cmd/solution/types-fmm.go
+++ b/cmd/solution/types-fmm.go
@@ -57,7 +57,7 @@ type FmmAssociationTypesTypeDef struct {
 
 type FmmEntity struct {
 	*FmmTypeDef
-	AttributeDefinitions  *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions"`
+	AttributeDefinitions  *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
 	LifecyleConfiguration *FmmLifecycleConfigTypeDef      `json:"lifecycleConfiguration"`
 	MetricTypes           []string                        `json:"metricTypes,omitempty"`
 	EventTypes            []string                        `json:"eventTypes,omitempty"`
@@ -70,7 +70,7 @@ func (entity *FmmEntity) GetTypeName() string {
 
 type FmmEvent struct {
 	*FmmTypeDef
-	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions"`
+	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
 }
 
 type FmmResourceMapping struct {
@@ -108,7 +108,7 @@ type FmmMetric struct {
 	IsMonotonic            bool                            `json:"isMonotonic"`
 	Type                   FmmMetricType                   `json:"type"`
 	Unit                   string                          `json:"unit"`
-	AttributeDefinitions   *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions"`
+	AttributeDefinitions   *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
 	IngestGranularities    []int                           `json:"ingestGranularities,omitempty"`
 }
 


### PR DESCRIPTION
When saving FMM objects--particularly when adding new objects to a solution using `solution extend`--omit  `attributeDefinitions` list when it is empty. 

This is a minor improvement and works around them being placed as `nil` rather than as an empty list. It further reduces unnecessary "noise" in these objects.


## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
