### PR TITLE
For service and agent principal, store client ID as profile's user

### DIFF
--- a/platform/api/service_principal.go
+++ b/platform/api/service_principal.go
@@ -174,6 +174,19 @@ func agentOrServicePrincipalLogin(ctx *callContext, principalType string, creden
 	log.Info("Login returned a valid token")
 	ctx.cfg.Token = token.AccessToken
 
+	// extract user (client ID) from token
+	userID, err := extractUser(token.AccessToken)
+	if err != nil {
+		log.Warnf("Could not extract client ID from the bearer token: %v. Continuing without client ID", err)
+		userID = ""
+		// fall through and continue without a user ID
+	} else {
+		log.WithFields(log.Fields{"clientId": userID}).Info("Extracted principal's client ID")
+	}
+	if userID != "" {
+		ctx.cfg.User = userID
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This allows commands that need user's identify (such as `optimize start`) to obtain it in a uniform way across all major auth types (oauth, service and agent principals)


## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
