### PR TITLE
Optimize report support qualified workload id

### DIFF
--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -103,10 +103,7 @@ func listReports(cmd *cobra.Command, args []string) error {
 		filtersList = append(filtersList, fmt.Sprintf("attributes(\"k8s.workload.name\") = %q", workloadName))
 	}
 	tempVals.WorkloadFilters = strings.Join(filtersList, " && ")
-
-	if strings.HasPrefix(tempVals.WorkloadId, "k8s:deployment:") {
-		tempVals.WorkloadId = strings.Split(tempVals.WorkloadId, ":")[2]
-	}
+	tempVals.WorkloadId, _ = strings.CutPrefix(tempVals.WorkloadId, "k8s:deployment:")
 
 	var query string
 	var buff bytes.Buffer

--- a/cmd/optimize/report.go
+++ b/cmd/optimize/report.go
@@ -104,6 +104,10 @@ func listReports(cmd *cobra.Command, args []string) error {
 	}
 	tempVals.WorkloadFilters = strings.Join(filtersList, " && ")
 
+	if strings.HasPrefix(tempVals.WorkloadId, "k8s:deployment:") {
+		tempVals.WorkloadId = strings.Split(tempVals.WorkloadId, ":")[2]
+	}
+
 	var query string
 	var buff bytes.Buffer
 	if err := reportTemplate.Execute(&buff, tempVals); err != nil {


### PR DESCRIPTION
## Description

Prior to this update, the `fsoc optimize report --workload-id` parameter did not support IDs in the form of `k8s:deployment:MtQoe18DOdecDGDXpWT3Ug` and instead required the id without the k8s:deployment: prefix.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
