### PR TITLE
add table alignment to output for encapsulation

### DIFF
--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/apex/log"
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
 	"github.com/cisco-open/fsoc/cmd/uql"
@@ -290,7 +289,7 @@ func listEvents(flags *eventsCmdFlags) func(*cobra.Command, []string) error {
 			_, next_ok = data_set.Links["next"]
 		}
 
-		tableSettings := &output.Table{DisableAutoWrapText: true, Alignment: tablewriter.ALIGN_LEFT}
+		tableSettings := &output.Table{DisableAutoWrapText: true, Alignment: output.ALIGN_LEFT}
 		tableSettings.DisableAutoWrapText = true
 		output.PrintCmdOutputCustom(cmd, struct {
 			Items []EventsRow `json:"items"`

--- a/output/output.go
+++ b/output/output.go
@@ -41,6 +41,26 @@ const (
 	JsonIndent = "    "
 )
 
+const (
+	ALIGN_DEFAULT = tablewriter.ALIGN_DEFAULT
+	ALIGN_CENTER  = tablewriter.ALIGN_CENTER
+	ALIGN_RIGHT   = tablewriter.ALIGN_RIGHT
+	ALIGN_LEFT    = tablewriter.ALIGN_LEFT
+)
+
+type Table struct {
+	// table output
+	Headers             []string
+	Lines               [][]string
+	Detail              bool // true to print a single line as a name: value multi-line instead of table
+	OmitHeaders         bool // don't print the headers
+	DisableAutoWrapText bool // try to keep each row on a single line as much as possible
+	Alignment           int  // override the automatic alignment for all fields
+
+	// extract field columns in the same order as headers
+	LineBuilder func(v any) []string // use together with Headers and no Lines
+}
+
 type printRequest struct {
 	cmd         *cobra.Command
 	format      string
@@ -111,19 +131,6 @@ func PrintYaml(cmd *cobra.Command, v any) error {
 // for example, to confirm that the operation was completed
 func PrintCmdStatus(cmd *cobra.Command, s string) {
 	print(cmd, s)
-}
-
-type Table struct {
-	// table output
-	Headers             []string
-	Lines               [][]string
-	Detail              bool // true to print a single line as a name: value multi-line instead of table
-	OmitHeaders         bool // don't print the headers
-	DisableAutoWrapText bool // try to keep each row on a single line as much as possible
-	Alignment           int  // override the automatic alignment
-
-	// extract field columns in the same order as headers
-	LineBuilder func(v any) []string // use together with Headers and no Lines
 }
 
 // PrintCmdOutput displays the output of a command in the user-selected output format. If


### PR DESCRIPTION
## Description

Minor refactoring: added alignment constants to the `output` package, so the new alignment option is encapsulated and does not depend on `tablewriter`

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
