### PR TITLE
Replace FSO name in messages

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -7,7 +7,7 @@ repository:
   name: fsoc
 
   # A short description of the repository that will show up on GitHub
-  description: FSO Control CLI Utility
+  description: Cisco Observability Platform Control CLI Utility
 
   # Either `true` to make the repository private, or `false` to make it public.
   private: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ brews:
   ids:
   - fsoc-archives
   homepage: https://github.com/cisco-open/fsoc
-  description: "Cisco FSO Platform Developer's Control Tool"
+  description: "Cisco Observability Platform Developer's Control Tool"
   license: "Apache-2.0"
   commit_author:
     name: cisco-service

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# fsoc - Cisco FSO Platform Developer's Control Tool
+# fsoc - Cisco Observability Platform Developer's Control Tool
 
 [![Release](https://img.shields.io/github/release/cisco-open/fsoc.svg?style=for-the-badge)](https://github.com/cisco-open/fsoc/releases/latest)
 [![stability-alpha](https://img.shields.io/badge/stability-alpha-f4d03f.svg?style=for-the-badge)](https://github.com/mkenney/software-guides/blob/master/STABILITY-BADGES.md#alpha)
@@ -7,16 +7,16 @@
 [![Github All Releases](https://img.shields.io/github/downloads/cisco-open/fsoc/total.svg?style=for-the-badge)](https://github.com/cisco-open/fsoc/releases/latest) 
 
 
-The Cisco Full Stack Observability (FSO) Platform  provides core capabilities for developers to build observability solutions to gain visibility and actionable insights across their technology and business stack. The platform leverages OpenTelemetry collections to collect MELT* telemetry and then transforms the raw data into flexible and scalable objects that can be correlated and queried.
+The Cisco Observability Platform provides core capabilities for developers to build observability solutions to gain visibility and actionable insights across their technology and business stack. The platform leverages OpenTelemetry collections to collect MELT* telemetry and then transforms the raw data into flexible and scalable objects that can be correlated and queried.
 
 *MELT: Metrics, Events, Logs and Traces
 
-The FSO control tool, `fsoc`, provides a command line interface to help developers manage their solutions 
-lifecycle and interact with the core services and solutions in the FSO platform.
+The pltform control tool, `fsoc`, provides a command line interface to help developers manage their solutions 
+lifecycle and interact with the core services and solutions in the platform.
 
 ## Documentation
 
-The `fsoc` [user documentation](https://developer.cisco.com/docs/fso/#!developer-tools/platform-cli) is published in Cisco's DevNet as part of the [FSO Platform Documentation](https://developer.cisco.com/docs/fso/). 
+The `fsoc` [user documentation](https://developer.cisco.com/docs/fso/#!developer-tools/platform-cli) is published in Cisco's DevNet as part of the [Platform Documentation](https://developer.cisco.com/docs/fso/). 
 
 As `fsoc` is still evolving quickly, the DevNet documentation may sometimes not include information about the latest released version of `fsoc`. The `fsoc help` command is always the best way to get the correct help for the version of fsoc you have. Most commands provide sample command lines you can try.
 

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The Cisco Observability Platform provides core capabilities for developers to bu
 
 *MELT: Metrics, Events, Logs and Traces
 
-The pltform control tool, `fsoc`, provides a command line interface to help developers manage their solutions 
+The platform control tool, `fsoc`, provides a command line interface to help developers manage their solutions 
 lifecycle and interact with the core services and solutions in the platform.
 
 ## Documentation
 
-The `fsoc` [user documentation](https://developer.cisco.com/docs/fso/#!developer-tools/platform-cli) is published in Cisco's DevNet as part of the [Platform Documentation](https://developer.cisco.com/docs/fso/). 
+The `fsoc` [user documentation](https://developer.cisco.com/docs/fso/#!developer-tools/platform-cli) is published in Cisco's DevNet as part of the [platform documentation](https://developer.cisco.com/docs/fso/). 
 
 As `fsoc` is still evolving quickly, the DevNet documentation may sometimes not include information about the latest released version of `fsoc`. The `fsoc help` command is always the best way to get the correct help for the version of fsoc you have. Most commands provide sample command lines you can try.
 

--- a/cmd/config/show-fields.go
+++ b/cmd/config/show-fields.go
@@ -52,16 +52,16 @@ Examples:
 Settings:`
 
 var fieldHelp = map[string]string{
-	"auth":        `Authentication method, required. Must be one of "` + strings.Join(GetAuthMethodsStringList(), `", "`) + `".`,
+	"auth":        `authentication method, required. Must be one of "` + strings.Join(GetAuthMethodsStringList(), `", "`) + `".`,
 	"url":         `URL to the tenant, scheme and host/port only; required. For example, https://mytenant.observe.appdynamics.com`,
-	"tenant":      `Tenant ID that is required only for auth methods that cannot automatically obtain it. Not needed for the "oauth", "service-principal" and "local" auth methods.`,
-	"secret-file": `File containing login credentials for "service-principal" and "agent-principal" auth methods. The file must remain available, as fsoc saves only the file's path.`,
-	"envtype":     `FSO environment type, optional. Used only for special development/test FSO environments. If specified, can be "dev" or "prod".`,
-	"token":       `Authentication token needed only for the "token" auth method.`,
-	cfg.AppdTid:   `Value of ` + cfg.AppdPid + ` to use with the "local" auth method.`,
-	cfg.AppdPty:   `Value of ` + cfg.AppdPid + ` to use with the "local" auth method.`,
-	cfg.AppdPid:   `Value of ` + cfg.AppdPid + ` to use with the "local" auth method.`,
-	"server":      `Synonym for the "url" setting. Deprecated.`,
+	"tenant":      `tenant ID that is required only for auth methods that cannot automatically obtain it. Not needed for the "oauth", "service-principal" and "local" auth methods.`,
+	"secret-file": `file containing login credentials for "service-principal" and "agent-principal" auth methods. The file must remain available, as fsoc saves only the file's path.`,
+	"envtype":     `platform environment type, optional. Used only for special development/test environments. If specified, can be "dev" or "prod".`,
+	"token":       `authentication token needed only for the "token" auth method.`,
+	cfg.AppdTid:   `value of ` + cfg.AppdPid + ` to use with the "local" auth method.`,
+	cfg.AppdPty:   `value of ` + cfg.AppdPid + ` to use with the "local" auth method.`,
+	cfg.AppdPid:   `value of ` + cfg.AppdPid + ` to use with the "local" auth method.`,
+	"server":      `synonym for the "url" setting. Deprecated.`,
 }
 
 func configShowFields(cmd *cobra.Command, args []string) {

--- a/cmd/iamrole/iamrole.go
+++ b/cmd/iamrole/iamrole.go
@@ -27,7 +27,7 @@ var iamRoleCmd = &cobra.Command{
 	Short: "Manage IAM roles",
 	Long: `Manage roles, as part of identity and access management (IAM)
 
-Roles are usually prefixed with the domain, e.g., "iam:observer". Standard FSO roles include "iam:observer", 
+Roles are usually prefixed with the domain, e.g., "iam:observer". Standard roles include "iam:observer", 
 "iam:tenantAdmin" and "iam:configManager". Solutions often define their own roles that can be bound to principals
 in order to access solution's functionality.
 

--- a/cmd/iamrolebinding/iamrolebinding.go
+++ b/cmd/iamrolebinding/iamrolebinding.go
@@ -32,7 +32,7 @@ var iamRbCmd = &cobra.Command{
 Principals can be user principals, service principals or agent principals. For user principals, use the email
 address of the user; for service and agent principal, use the principal's ID (client ID).
 
-Roles are usually prefixed with the domain, e.g., "iam:observer". Standard FSO roles include "iam:observer", 
+Roles are usually prefixed with the domain, e.g., "iam:observer". Standard roles include "iam:observer", 
 "iam:tenantAdmin" and "iam:configManager". Solutions often define their own roles that can be bound to principals
 in order to access solution's functionality.
 

--- a/cmd/melt/melt.go
+++ b/cmd/melt/melt.go
@@ -21,8 +21,8 @@ import (
 // meltCmd represents the login command
 var meltCmd = &cobra.Command{
 	Use:              "melt",
-	Short:            "Generates fsoc telemetry data models and sends OTLP payloads to the FSO ingestion services",
-	Long:             "This command generate fsoc telemetry data models and sends the data to the FSO Platform Ingestion services. \nIt helps developers to generate mock telemetry data to test their solution's domain models.",
+	Short:            "Generates fsoc telemetry data models and sends OTLP payloads to the platform ingestion services",
+	Long:             "This command generate fsoc telemetry data models and sends the data to the platform ingestion services. \nIt helps developers to generate mock telemetry data to test their solution's domain models.",
 	Args:             cobra.ExactArgs(0),
 	TraverseChildren: true,
 }

--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -22,7 +22,7 @@ var meltPushCmd = &cobra.Command{
 	Use:   "push [DATAFILE]",
 	Short: "Generates OTLP telemetry based on fsoc telemetry data model .yaml",
 	Long: `
-This command generates OTLP payload based on a fsoc telemetry data models and sends the data to the FSO Platform Ingestion services.
+This command generates OTLP payload based on a fsoc telemetry data models and sends the data to the platform ingestion services.
 
 To properly use the command you will need to create a fsoc profile using an agent principal yaml:
 fsoc config set --profile=<agent-principal-profile> auth=agent-principal secret-file=<agent-principal.yaml>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,19 +55,23 @@ var updateChannel chan *semver.Version
 // TODO: replace github link "for more info" with Cisco DevNet link for fsoc once published
 var rootCmd = &cobra.Command{
 	Use:   "fsoc",
-	Short: "fsoc - Cisco FSO Platform Control Tool",
-	Long: `fsoc is an open source utility that serves as an entry point for developers on the Cisco
-Full Stack Observability (FSO) Platform (https://developer.cisco.com/docs/fso/).
+	Short: "fsoc - Cisco Observability Platform Control Tool",
+	Long: `fsoc is an open source utility that serves as an entry point for developers on the Cisco Observability
+Platform (https://developer.cisco.com/docs/fso/).
 
-It allows developers to interact with the product environments--developer, test and production--in a
+It allows developers to interact with the product environments--development, test and production--in a
 uniform way and to perform common tasks. fsoc primarily targets developers building solutions on the platform.
 
-You can use --config and --profile to select authentication credentials to use. You can also use
+You can use the --config and --profile flags to select authentication credentials to use. You can also use
 environment variables FSOC_CONFIG and FSOC_PROFILE, respectively. The command line flags take precedence.
 If a profile is not specified otherwise, the current profile from the config file is used.
 
 fsoc checks once a day if a newer version is available on github and warns if not running the latest stable version.
-You can use --no-version-check or the FSOC_NO_VERSION_CHECK=1 environment variable to suppress the check.
+You can use the --no-version-check flag or the FSOC_NO_VERSION_CHECK=1 environment variable to suppress the check.
+
+fsoc logs its execution details into a log file. By default, fsoc shows only warning- and error-level log messages on 
+the output. You can use the --verbose flag to show all log messages and/or the --log flag to set a desired location
+for saving the log file.
 
 Examples:
   fsoc config set auth=oauth url=https://MYTENANT.observe.appdynamics.com
@@ -103,10 +107,10 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgProfile, "profile", "", "access profile (default is current or \"default\")")
 	rootCmd.PersistentFlags().StringVarP(&outputFormat, "output", "o", "auto", "output format (auto, table, detail, json, yaml)")
 	rootCmd.PersistentFlags().String("fields", "", "perform specified fields transform/extract JQ expression")
-	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable detailed output")
-	rootCmd.PersistentFlags().Bool("curl", false, "Log curl equivalent for platform API calls (implies --verbose)")
-	rootCmd.PersistentFlags().String("log", path.Join(os.TempDir(), "fsoc.log"), "determines the location of the fsoc log file")
-	rootCmd.PersistentFlags().Bool("no-version-check", false, "Skip the daily check for new versions of fsoc")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "enable detailed output")
+	rootCmd.PersistentFlags().Bool("curl", false, "log curl equivalent for platform API calls (implies --verbose)")
+	rootCmd.PersistentFlags().String("log", path.Join(os.TempDir(), "fsoc.log"), "set a location and name for the fsoc log file")
+	rootCmd.PersistentFlags().Bool("no-version-check", false, "skip the daily check for new versions of fsoc")
 	rootCmd.SetOut(os.Stdout)
 	rootCmd.SetErr(os.Stderr)
 	rootCmd.SetIn(os.Stdin)

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -22,7 +22,7 @@ var solutionPushCmd = &cobra.Command{
 	Use:   "push",
 	Args:  cobra.ExactArgs(0),
 	Short: "Deploy your solution",
-	Long: `This command allows the current tenant specified in the profile to deploy a solution to the FSO Platform.
+	Long: `This command allows the current tenant specified in the profile to deploy a solution to the platform.
 The solution manifest for the solution must be in the current directory.
 
 Important details on solution tags:

--- a/cmd/solution/solution.go
+++ b/cmd/solution/solution.go
@@ -23,13 +23,13 @@ import (
 	"github.com/cisco-open/fsoc/config"
 )
 
-// loginCmd represents the login command
+// solutionCmd represents the login command
 var solutionCmd = &cobra.Command{
 	Use:   "solution",
-	Short: "Perform solution lifecycle operations",
-	Long: `Perform solution lifecycle operations with the FSO Platform.
+	Short: "Perform solution operations",
+	Long: `Perform solution lifecycle and control operations.
 
-For more information on FSO solutions, see https://developer.cisco.com/docs/fso/#!create-a-solution-introduction`,
+For more information on platform solutions, see https://developer.cisco.com/docs/fso/#!create-a-solution-introduction`,
 	Example:          `  fsoc solution list`,
 	TraverseChildren: true,
 }

--- a/cmd/uql/uql.go
+++ b/cmd/uql/uql.go
@@ -47,10 +47,10 @@ const (
 var uqlCmd = &cobra.Command{
 	Use:   "uql",
 	Short: "Perform UQL query",
-	Long: `Perform UQL query of MELT data for a tenant. 
+	Long: `Perform a Unified Query Language query of MELT data for a tenant. 
 
 See https://developer.cisco.com/docs/fso/#!data-query-using-unified-query-language
-for more information on the UQL query language for FSO.
+for more information on the unified query language for the Cisco Observability Platform.
 
 Parsed response data are displayed in a table by default.
 Available output formats: ` + availableFormats + `.

--- a/cmd/version/version_check.go
+++ b/cmd/version/version_check.go
@@ -33,12 +33,12 @@ func GetLatestVersion() (string, error) {
 }
 
 func CheckForUpdate() *semver.Version {
-	log.Infof("Checking for newer version of FSOC")
+	log.Infof("Checking for newer version of fsoc")
 	newestVersion, err := GetLatestVersion()
 	if err == nil {
 		log.WithField("latest_github_version", newestVersion).Info("Latest fsoc version available")
 	} else {
-		log.Warnf("Failed to get latest FSOC version number from github: %v", err)
+		log.Warnf("Failed to get latest fsoc version number from github: %v", err)
 	}
 	newestVersionSemVar, err := semver.NewVersion(newestVersion)
 	if err != nil {

--- a/output/output.go
+++ b/output/output.go
@@ -496,7 +496,7 @@ func canonicalizeData(v any) any {
 		// }
 	}
 
-	// if the map already has the standard FSO API structure, use it
+	// if the map already has the standard Cisco API collections structure, use it
 	if _, ok := data["items"]; ok {
 		return data
 	}

--- a/platform/api/call.go
+++ b/platform/api/call.go
@@ -193,7 +193,7 @@ func getCurlCommandOfRequest(req *http.Request) (string, error) {
 }
 
 func httpRequest(method string, path string, body any, out any, options *Options) error {
-	log.WithFields(log.Fields{"method": method, "path": path}).Info("Calling FSO platform API")
+	log.WithFields(log.Fields{"method": method, "path": path}).Info("Calling the observability platform API")
 
 	callCtx := newCallContext()
 	cfg := callCtx.cfg               // quick access


### PR DESCRIPTION
## Description

Modify messages that referred to the Cisco Observability Platform's prior name (Full Stack Observability, FSO). Minor editing of other messages along the way.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
