### PR TITLE
update config set help to reflect agent yaml file name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ fsoc login  # test access
 
 NOTE: The login command will pop up a browser to perform the log in and then continue executing the command. Subsequent invocations of fsoc will use cached credentials. 
 
+Use `fsoc help config set` to see examples of different authentication methods and the [`fsoc` config page](https://developer.cisco.com/docs/fso/#!install-and-configure-fsoc/configure-access) in the platform docs for more details on how to configure profiles for the different authentication types that `fsoc` supports in addition to OAuth (e.g., service principal, agent principal, local).
+
 ## Assistance and Suggestions
 
 We are working to provide channels for help, suggestions, etc., for this project. In the meantime, if you have suggestions or want to report a problem, please use Github issues.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ fsoc login  # test access
 
 NOTE: The login command will pop up a browser to perform the log in and then continue executing the command. Subsequent invocations of fsoc will use cached credentials. 
 
-Use `fsoc help config set` to see examples of different authentication methods and the [`fsoc` config page](https://developer.cisco.com/docs/fso/#!install-and-configure-fsoc/configure-access) in the platform docs for more details on how to configure profiles for the different authentication types that `fsoc` supports in addition to OAuth (e.g., service principal, agent principal, local).
+Use the `fsoc help config set` command to see examples of the different authentication methods that `fsoc` supports in addition to OAuth (e.g., service principal, agent principal, local). You can find additional details in the `fsoc` [config page](https://developer.cisco.com/docs/fso/#!install-and-configure-fsoc/configure-access) in the platform docs.
 
 ## Assistance and Suggestions
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ lifecycle and interact with the core services and solutions in the platform.
 
 ## Documentation
 
-The `fsoc` [user documentation](https://developer.cisco.com/docs/fso/#!developer-tools/platform-cli) is published in Cisco's DevNet as part of the [platform documentation](https://developer.cisco.com/docs/fso/). 
+The `fsoc` [user documentation](https://developer.cisco.com/docs/fso/#!overview/overview) is published in Cisco's DevNet as part of the [platform documentation](https://developer.cisco.com/docs/fso/). 
 
 As `fsoc` is still evolving quickly, the DevNet documentation may sometimes not include information about the latest released version of `fsoc`. The `fsoc help` command is always the best way to get the correct help for the version of fsoc you have. Most commands provide sample command lines you can try.
 

--- a/cmd/config/set.go
+++ b/cmd/config/set.go
@@ -56,7 +56,7 @@ Note that each authentication method requires a slightly different set of values
 
   # Set service or agent principal credentials (secret file must remain accessible)
   fsoc config set auth=service-principal secret-file=my-service-principal.json
-  fsoc config set auth=agent-principal secret-file=agent-helm-values.yaml
+  fsoc config set auth=agent-principal secret-file=collectors-values.yaml
   fsoc config set auth=agent-principal secret-file=client-values.json tenant=123456 url=https://mytenant.observe.appdynamics.com
 
   # Set local access

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,8 @@ fsoc logs its execution details into a log file. By default, fsoc shows only war
 the output. You can use the --verbose flag to show all log messages and/or the --log flag to set a desired location
 for saving the log file.
 
+Additional user docs for fsoc are available at https://developer.cisco.com/docs/fso/#!overview/overview.
+
 Examples:
   fsoc config set auth=oauth url=https://MYTENANT.observe.appdynamics.com
   fsoc login


### PR DESCRIPTION
## Description

The help for the `fsoc config set` command provides examples of different login types. This PR updates the example for creating a profile with an agent principal to name the specific file name that is produced by AppD/FSO (use the collectors-values not the smartagent-values), as now there are two but fsoc supports only one of them.

In addition, improved the links to the platform documentation where additional info is available.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe) help messages 

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
