### PR TITLE
Specifing specific value for metrics in melt push command.

### DIFF
--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -149,6 +149,18 @@ func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
 						}
 					}
 
+					// 2023-12-06, Wayne Brown
+					// If value is specified, use that instead
+					if m.Value != "" {
+						dpvalue, value_err := strconv.ParseFloat(m.Value, 64)
+
+						if value_err != nil {
+							log.Warnf("Could not parse value for %q.", entity.TypeName)
+						} else {
+							dp = dpvalue
+						}
+					}
+
 					m.AddDataPoint(st.UnixNano(), et.UnixNano(), dp)
 					et = st
 				}

--- a/platform/melt/types.go
+++ b/platform/melt/types.go
@@ -66,6 +66,7 @@ type Metric struct {
 	DataPoints             []*DataPoint           `yaml:"datapoints,omitempty"`
 	Min                    string                 `yaml:"min,omitempty"`
 	Max                    string                 `yaml:"max,omitempty"`
+	Value                  string                 `yaml:"value,omitempty"`
 	IsMonotonic            bool                   `yaml:"ismonotonic,omitempty"`
 	AggregationTemporality AggregationTemporality `yaml:"aggregationtemporality,omitempty"`
 }


### PR DESCRIPTION
## Description

Adding a new property to MELT YAML metric definition called "value" to allow users to specify a precise value for generated telemetry packets. 

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
