### PR TITLE
Update default list of optimize event

### DIFF
--- a/cmd/optimize/events.go
+++ b/cmd/optimize/events.go
@@ -31,7 +31,6 @@ var defaultEvents = []string{
 	"experiment_deployment_completed",
 	"experiment_measurement_started",
 	"experiment_measurement_completed",
-	"experiment_described",
 	"recommendation_identified",
 	"recommendation_verified",
 	"recommendation_invalidated",


### PR DESCRIPTION
Remove experiment_described, which is currently not supported. May bring back in the future