### PR TITLE
Alias for `melt push`

### DIFF
--- a/cmd/melt/push.go
+++ b/cmd/melt/push.go
@@ -33,6 +33,7 @@ fsoc melt push <fsocdatamodel>.yaml --profile <agent-principal-profile>
 Or use input from STDIN:
 cat <fsocdatamodel>.yaml | fsoc melt push --profile <agent-principal-profile>
 `,
+	Aliases:          []string{"send"},
 	TraverseChildren: true,
 	Args:             cobra.MaximumNArgs(1),
 	RunE:             meltSendWithUsageCheck,


### PR DESCRIPTION
## Description

This PR introduces 'send' as an alias for the 'melt push' command. This change helps users distinguish it from 'solution push' when searching their command line history. Typing 'send' will specifically invoke 'melt send', while 'push' remains linked to 'solution push'. This differentiation resolves the confusion caused by using 'push' for both commands.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
