### PR TITLE
renamed melt push to send, improved error handling

### DIFF
--- a/platform/api/error.go
+++ b/platform/api/error.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+type HttpStatusError struct {
+	Message    string // used only if WrappedError is nil
+	StatusCode int
+	WrappedErr error
+}
+
+func (e *HttpStatusError) Error() string {
+	if e.WrappedErr != nil {
+		return e.WrappedErr.Error()
+	}
+	return e.Message
+}
+
+func (e *HttpStatusError) Unwrap() error {
+	return e.WrappedErr
+}

--- a/platform/api/problem.go
+++ b/platform/api/problem.go
@@ -17,6 +17,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 )
 
 // Problem type is a json object returned for content-type application/problem+json according to the RFC-7807
@@ -67,9 +68,9 @@ func (p Problem) Error() string {
 	}
 	if p.Status != 0 {
 		if s != "" {
-			s += fmt.Sprintf(" (status %d)", p.Status)
+			s += fmt.Sprintf(" (status %d %v)", p.Status, http.StatusText(p.Status))
 		} else {
-			s = fmt.Sprintf("status %d", p.Status)
+			s = fmt.Sprintf("status %d %v", p.Status, http.StatusText(p.Status))
 		}
 	}
 	if s == "" {


### PR DESCRIPTION
## Description

Renamed the `melt push` command to `melt send`, as it fits better; kept `push` as an alias.

Removed the no-longer-required limitation of using agent principals for sending melt data; updated the help text to reflect the platform changes. Provided a hint regarding using a principal with the required role only if the platform fails due to a permissions issue.

Improved the overall error display of the platform.api.call() when the error is due to a non-200 status code; added a HttpStatusError with the proper Error() and Unwrap() methods. Callers of the api package can now check for this error using standard Go idioms and extract/check the http status code.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
