### PR TITLE
use better example of composite ID get in the knowledge command help

### DIFF
--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -39,8 +39,8 @@ func newGetObjectCmd() *cobra.Command {
   fsoc knowledge get --type=extensibility:solution --object-id=extensibility --layer-type=SOLUTION --layer-id=extensibility 
   fsoc knowledge get --type=extensibility:solution --object-id=extensibility --layer-type=LOCALUSER
 
-  # Get object with a composite ID (note the quotes to escape shell special characters!)
-  fsoc knowledge get --type=mySolution:collectorState --object-id="/context=metrics;/connectionName=myConnection" --layer-type TENANT
+  # Get object with a composite ID (note the quotes to escape shell special characters)
+  fsoc knowledge get --type=fso:module --object-id="fso:/moduleId=optimize;/enriches=cco" --layer-type=SOLUTION --layer-id=fso
 
   # Get list of objects filtering by a data field
   fsoc knowledge get --type=extensibility:solution --layer-type=TENANT --filter="data.isSystem eq true"


### PR DESCRIPTION
## Description

Replace the `knowledge get` example of composite object ID to a concrete one that will return results.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [X] Other (please describe): usage help

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
