### PR TITLE
ORION-2683: remove whitelisted file extensions to support blob properties..

### DIFF
--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/apex/log"
@@ -198,23 +199,23 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 }
 
 func isAllowedPath(path string, info os.FileInfo) bool {
-	fileInclude := []string{".json", ".md"}
-	excludePath := []string{".git"}
-	allow := false
+	// blacklist files by adding them here.
+	excludeFiles := []string{".DS_Store"}
+	// blacklist paths by adding them here.
+	excludePaths := []string{".git"}
+	allow := true
 
 	if info.IsDir() {
-		for _, exclP := range excludePath {
+		// check for blacklisted dirs
+		for _, exclP := range excludePaths {
 			if strings.Contains(path, exclP) {
-				return allow
+				allow = false
 			}
 		}
-		allow = true
 	} else {
-		ext := filepath.Ext(path)
-		for _, inclExt := range fileInclude {
-			if ext == inclExt {
-				allow = true
-			}
+		// check for blacklisted files
+		if slices.Contains(excludeFiles, filepath.Base(path)) {
+			allow = false
 		}
 	}
 


### PR DESCRIPTION


## Description

To support blob properties fsoc should allow any file extensions.


## Type of Change
- [x] New Feature


## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
