### PR TITLE
Fix for generated event, current version doesn't validate against fmm:event json schema

### DIFF
--- a/cmd/solution/extend-fmm.go
+++ b/cmd/solution/extend-fmm.go
@@ -181,26 +181,31 @@ func getEntityComponent(entityName string, namespaceName string) *FmmEntity {
 	}
 
 	requiredArray := append(emptyStringArray, "name")
+
 	attributesDefinition := &FmmAttributeDefinitionsTypeDef{
-		Required:   requiredArray,
 		Optimized:  emptyStringArray,
 		Attributes: emptyAttributeArray,
+	}
+	requiredAttributesDefinition := &FmmRequiredAttributeDefinitionsTypeDef{
+		Required:                       requiredArray,
+		FmmAttributeDefinitionsTypeDef: attributesDefinition,
 	}
 
 	entityComponentDef := &FmmEntity{
 		FmmTypeDef:            fmmTypeDef,
 		LifecyleConfiguration: lifecycleConfig,
-		AttributeDefinitions:  attributesDefinition,
+		AttributeDefinitions:  requiredAttributesDefinition,
 	}
 
 	return entityComponentDef
 }
 
 func getEventComponent(eventName string, namespaceName string) *FmmEvent {
-	emptyStringArray := make([]string, 0)
-	emptyAttributeArray := make(map[string]*FmmAttributeTypeDef, 1)
+	optimizedAttributes := make([]string, 1)
+	attributeArray := make(map[string]*FmmAttributeTypeDef, 1)
 
-	emptyAttributeArray["name"] = &FmmAttributeTypeDef{
+	optimizedAttributes[0] = "name"
+	attributeArray["name"] = &FmmAttributeTypeDef{
 		Type:        "string",
 		Description: fmt.Sprintf("The name of the %s", eventName),
 	}
@@ -218,8 +223,8 @@ func getEventComponent(eventName string, namespaceName string) *FmmEvent {
 	}
 
 	attributesDefinition := &FmmAttributeDefinitionsTypeDef{
-		Optimized:  emptyStringArray,
-		Attributes: emptyAttributeArray,
+		Optimized:  optimizedAttributes,
+		Attributes: attributeArray,
 	}
 
 	eventComponentDef := &FmmEvent{

--- a/cmd/solution/types-fmm.go
+++ b/cmd/solution/types-fmm.go
@@ -40,8 +40,12 @@ type FmmAttributeTypeDef struct {
 	Description string `json:"description,omitempty"`
 }
 
+type FmmRequiredAttributeDefinitionsTypeDef struct {
+	Required []string `json:"required"`
+	*FmmAttributeDefinitionsTypeDef
+}
+
 type FmmAttributeDefinitionsTypeDef struct {
-	Required   []string                        `json:"required"`
 	Optimized  []string                        `json:"optimized"`
 	Attributes map[string]*FmmAttributeTypeDef `json:"attributes"`
 }
@@ -57,11 +61,11 @@ type FmmAssociationTypesTypeDef struct {
 
 type FmmEntity struct {
 	*FmmTypeDef
-	AttributeDefinitions  *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
-	LifecyleConfiguration *FmmLifecycleConfigTypeDef      `json:"lifecycleConfiguration"`
-	MetricTypes           []string                        `json:"metricTypes,omitempty"`
-	EventTypes            []string                        `json:"eventTypes,omitempty"`
-	AssociationTypes      *FmmAssociationTypesTypeDef     `json:"associationTypes,omitempty"`
+	AttributeDefinitions  *FmmRequiredAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
+	LifecyleConfiguration *FmmLifecycleConfigTypeDef              `json:"lifecycleConfiguration"`
+	MetricTypes           []string                                `json:"metricTypes,omitempty"`
+	EventTypes            []string                                `json:"eventTypes,omitempty"`
+	AssociationTypes      *FmmAssociationTypesTypeDef             `json:"associationTypes,omitempty"`
 }
 
 func (entity *FmmEntity) GetTypeName() string {


### PR DESCRIPTION
## Description

Generated event type doesn't validate against fmm:event json schema 

## Type of Change

- [ X ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ X ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ X ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
