### PR TITLE
ORION-2803: put includeTags behind an optional flag

### DIFF
--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -49,7 +49,7 @@ func getCreateObjectCmd() *cobra.Command {
 	_ = objStoreInsertCmd.RegisterFlagCompletionFunc("type", typeCompletionFunc)
 
 	objStoreInsertCmd.Flags().
-	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
 	objStoreInsertCmd.Flags().
 		String("object-file", "", "The fully qualified path to the json file containing the knowledge object data")
@@ -70,8 +70,8 @@ func getCreateObjectCmd() *cobra.Command {
 func insertObject(cmd *cobra.Command, args []string) {
 	objType, _ := cmd.Flags().GetString("type")
 
-	var includeTagsString string = "false";
-	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+	var includeTagsString string = "false"
+	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
 
 	if includeTagsFlag {
 		includeTagsString = "true"

--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -49,6 +49,9 @@ func getCreateObjectCmd() *cobra.Command {
 	_ = objStoreInsertCmd.RegisterFlagCompletionFunc("type", typeCompletionFunc)
 
 	objStoreInsertCmd.Flags().
+	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+
+	objStoreInsertCmd.Flags().
 		String("object-file", "", "The fully qualified path to the json file containing the knowledge object data")
 	_ = objStoreInsertCmd.MarkPersistentFlagRequired("objectFile")
 
@@ -66,6 +69,13 @@ func getCreateObjectCmd() *cobra.Command {
 
 func insertObject(cmd *cobra.Command, args []string) {
 	objType, _ := cmd.Flags().GetString("type")
+
+	var includeTagsString string = "false";
+	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+
+	if includeTagsFlag {
+		includeTagsString = "true"
+	}
 
 	objJsonFilePath, _ := cmd.Flags().GetString("object-file")
 	objectFile, err := os.Open(objJsonFilePath)
@@ -97,7 +107,7 @@ func insertObject(cmd *cobra.Command, args []string) {
 	headers := map[string]string{
 		"layer-type":  layerType,
 		"layer-id":    layerID,
-		"includeTags": "true",
+		"includeTags": includeTagsString,
 	}
 
 	var res any

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -56,7 +56,7 @@ func editObjectCmd() *cobra.Command {
 	_ = editCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
 	editCmd.Flags().
-	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
 	editCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
@@ -73,16 +73,16 @@ func editObject(cmd *cobra.Command, args []string) {
 		log.Fatal(err.Error())
 	}
 
-	var includeTagsString string = "false";
-	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+	var includeTagsString string = "false"
+	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
 
 	if includeTagsFlag {
 		includeTagsString = "true"
 	}
 
 	headers := map[string]string{
-		"layer-type": layerType,
-		"layer-id":   layerID,
+		"layer-type":  layerType,
+		"layer-id":    layerID,
 		"includeTags": includeTagsString,
 	}
 	httpOptions := &api.Options{Headers: headers}

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -56,6 +56,9 @@ func editObjectCmd() *cobra.Command {
 	_ = editCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
 	editCmd.Flags().
+	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+
+	editCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
 
 	return editCmd
@@ -70,9 +73,17 @@ func editObject(cmd *cobra.Command, args []string) {
 		log.Fatal(err.Error())
 	}
 
+	var includeTagsString string = "false";
+	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+
+	if includeTagsFlag {
+		includeTagsString = "true"
+	}
+
 	headers := map[string]string{
 		"layer-type": layerType,
 		"layer-id":   layerID,
+		"includeTags": includeTagsString,
 	}
 	httpOptions := &api.Options{Headers: headers}
 	url := getObjectUrl(fqtn, objID)
@@ -117,7 +128,7 @@ func editObject(cmd *cobra.Command, args []string) {
 		"layer-type":  layerType,
 		"layer-id":    layerID,
 		"If-Match":    etag,
-		"includeTags": "true",
+		"includeTags": includeTagsString,
 	}
 	var resPut any
 	err = api.JSONPut(url, editedData, &resPut, &api.Options{Headers: headersPut})

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -65,7 +65,7 @@ func newGetObjectCmd() *cobra.Command {
 	getCmd.PersistentFlags().String("layer-id", "", "Layer ID of the related knowledge object to fetch")
 
 	getCmd.Flags().
-	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
 	getCmd.Flags().
 		Var(&ltFlag, "layer-type", fmt.Sprintf("Layer type at which the knowledge object exists.  Valid values: %q, %q, %q, %q, %q", solution, account, globalUser, tenant, localUser))
@@ -127,8 +127,8 @@ func getObject(cmd *cobra.Command, args []string, ltFlag layerType) error {
 		return err
 	}
 
-	var includeTagsString string = "false";
-	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+	var includeTagsString string = "false"
+	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
 
 	if includeTagsFlag {
 		includeTagsString = "true"

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -65,6 +65,9 @@ func newGetObjectCmd() *cobra.Command {
 	getCmd.PersistentFlags().String("layer-id", "", "Layer ID of the related knowledge object to fetch")
 
 	getCmd.Flags().
+	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+
+	getCmd.Flags().
 		Var(&ltFlag, "layer-type", fmt.Sprintf("Layer type at which the knowledge object exists.  Valid values: %q, %q, %q, %q, %q", solution, account, globalUser, tenant, localUser))
 	_ = getCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
@@ -124,10 +127,17 @@ func getObject(cmd *cobra.Command, args []string, ltFlag layerType) error {
 		return err
 	}
 
+	var includeTagsString string = "false";
+	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+
+	if includeTagsFlag {
+		includeTagsString = "true"
+	}
+
 	headers := map[string]string{
 		"layer-type":  layerType,
 		"layer-id":    layerID,
-		"includeTags": "true",
+		"includeTags": includeTagsString,
 	}
 
 	// execute command and print output

--- a/cmd/knowledge/update.go
+++ b/cmd/knowledge/update.go
@@ -72,7 +72,7 @@ func getUpdateObjectCmd() *cobra.Command {
 	_ = objStoreUpdateCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
 	objStoreUpdateCmd.Flags().
-	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
 	objStoreUpdateCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
@@ -111,8 +111,8 @@ func updateObject(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	var includeTagsString string = "false";
-	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+	var includeTagsString string = "false"
+	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
 
 	if includeTagsFlag {
 		includeTagsString = "true"

--- a/cmd/knowledge/update.go
+++ b/cmd/knowledge/update.go
@@ -72,6 +72,9 @@ func getUpdateObjectCmd() *cobra.Command {
 	_ = objStoreUpdateCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
 	objStoreUpdateCmd.Flags().
+	Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
+
+	objStoreUpdateCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
 
 	return objStoreUpdateCmd
@@ -108,10 +111,17 @@ func updateObject(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	var includeTagsString string = "false";
+	includeTagsFlag := cmd.Flags().GetBool("include-tags")
+
+	if includeTagsFlag {
+		includeTagsString = "true"
+	}
+
 	headers := map[string]string{
 		"layer-type":  layerType,
 		"layer-id":    layerID,
-		"includeTags": "true",
+		"includeTags": includeTagsString,
 	}
 
 	var res any


### PR DESCRIPTION
## Description

Putting includeTags functionality for fsoc ks commands behind an optional flag

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
