### PR TITLE
ORION-2525: fsoc solution zap + deprecate include-tags flag for fsoc ks commands

### DIFF
--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -51,6 +51,8 @@ func getCreateObjectCmd() *cobra.Command {
 	objStoreInsertCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
+	objStoreInsertCmd.Flags().MarkHidden("include-tags")
+
 	objStoreInsertCmd.Flags().
 		String("object-file", "", "The fully qualified path to the json file containing the knowledge object data")
 	_ = objStoreInsertCmd.MarkPersistentFlagRequired("objectFile")

--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -51,7 +51,7 @@ func getCreateObjectCmd() *cobra.Command {
 	objStoreInsertCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	objStoreInsertCmd.Flags().MarkHidden("include-tags")
+	_ = objStoreInsertCmd.Flags().MarkHidden("include-tags")
 
 	objStoreInsertCmd.Flags().
 		String("object-file", "", "The fully qualified path to the json file containing the knowledge object data")

--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -51,7 +51,7 @@ func getCreateObjectCmd() *cobra.Command {
 	objStoreInsertCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	_ = objStoreInsertCmd.Flags().MarkHidden("include-tags")
+	_ = objStoreInsertCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
 
 	objStoreInsertCmd.Flags().
 		String("object-file", "", "The fully qualified path to the json file containing the knowledge object data")

--- a/cmd/knowledge/create.go
+++ b/cmd/knowledge/create.go
@@ -49,11 +49,6 @@ func getCreateObjectCmd() *cobra.Command {
 	_ = objStoreInsertCmd.RegisterFlagCompletionFunc("type", typeCompletionFunc)
 
 	objStoreInsertCmd.Flags().
-		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
-
-	_ = objStoreInsertCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
-
-	objStoreInsertCmd.Flags().
 		String("object-file", "", "The fully qualified path to the json file containing the knowledge object data")
 	_ = objStoreInsertCmd.MarkPersistentFlagRequired("objectFile")
 
@@ -71,13 +66,6 @@ func getCreateObjectCmd() *cobra.Command {
 
 func insertObject(cmd *cobra.Command, args []string) {
 	objType, _ := cmd.Flags().GetString("type")
-
-	var includeTagsString string = "false"
-	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
-
-	if includeTagsFlag {
-		includeTagsString = "true"
-	}
 
 	objJsonFilePath, _ := cmd.Flags().GetString("object-file")
 	objectFile, err := os.Open(objJsonFilePath)
@@ -107,9 +95,8 @@ func insertObject(cmd *cobra.Command, args []string) {
 	}
 
 	headers := map[string]string{
-		"layer-type":  layerType,
-		"layer-id":    layerID,
-		"includeTags": includeTagsString,
+		"layer-type": layerType,
+		"layer-id":   layerID,
 	}
 
 	var res any

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -58,7 +58,7 @@ func editObjectCmd() *cobra.Command {
 	editCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	editCmd.Flags().MarkHidden("include-tags")
+	_ = editCmd.Flags().MarkHidden("include-tags")
 
 	editCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -56,11 +56,6 @@ func editObjectCmd() *cobra.Command {
 	_ = editCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
 	editCmd.Flags().
-		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
-
-	_ = editCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
-
-	editCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
 
 	return editCmd
@@ -75,17 +70,9 @@ func editObject(cmd *cobra.Command, args []string) {
 		log.Fatal(err.Error())
 	}
 
-	var includeTagsString string = "false"
-	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
-
-	if includeTagsFlag {
-		includeTagsString = "true"
-	}
-
 	headers := map[string]string{
-		"layer-type":  layerType,
-		"layer-id":    layerID,
-		"includeTags": includeTagsString,
+		"layer-type": layerType,
+		"layer-id":   layerID,
 	}
 	httpOptions := &api.Options{Headers: headers}
 	url := getObjectUrl(fqtn, objID)
@@ -127,10 +114,9 @@ func editObject(cmd *cobra.Command, args []string) {
 
 	// Send update to server, with etag
 	headersPut := map[string]string{
-		"layer-type":  layerType,
-		"layer-id":    layerID,
-		"If-Match":    etag,
-		"includeTags": includeTagsString,
+		"layer-type": layerType,
+		"layer-id":   layerID,
+		"If-Match":   etag,
 	}
 	var resPut any
 	err = api.JSONPut(url, editedData, &resPut, &api.Options{Headers: headersPut})

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -58,7 +58,7 @@ func editObjectCmd() *cobra.Command {
 	editCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	_ = editCmd.Flags().MarkHidden("include-tags")
+	_ = editCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
 
 	editCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")

--- a/cmd/knowledge/edit.go
+++ b/cmd/knowledge/edit.go
@@ -58,6 +58,8 @@ func editObjectCmd() *cobra.Command {
 	editCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
+	editCmd.Flags().MarkHidden("include-tags")
+
 	editCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
 

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -65,11 +65,6 @@ func newGetObjectCmd() *cobra.Command {
 	getCmd.PersistentFlags().String("layer-id", "", "Layer ID of the related knowledge object to fetch")
 
 	getCmd.Flags().
-		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
-
-	_ = getCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
-
-	getCmd.Flags().
 		Var(&ltFlag, "layer-type", fmt.Sprintf("Layer type at which the knowledge object exists.  Valid values: %q, %q, %q, %q, %q", solution, account, globalUser, tenant, localUser))
 	_ = getCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
@@ -129,17 +124,9 @@ func getObject(cmd *cobra.Command, args []string, ltFlag layerType) error {
 		return err
 	}
 
-	var includeTagsString string = "false"
-	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
-
-	if includeTagsFlag {
-		includeTagsString = "true"
-	}
-
 	headers := map[string]string{
-		"layer-type":  layerType,
-		"layer-id":    layerID,
-		"includeTags": includeTagsString,
+		"layer-type": layerType,
+		"layer-id":   layerID,
 	}
 
 	// execute command and print output

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -67,7 +67,7 @@ func newGetObjectCmd() *cobra.Command {
 	getCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	getCmd.Flags().MarkHidden("include-tags")
+	_ = getCmd.Flags().MarkHidden("include-tags")
 
 	getCmd.Flags().
 		Var(&ltFlag, "layer-type", fmt.Sprintf("Layer type at which the knowledge object exists.  Valid values: %q, %q, %q, %q, %q", solution, account, globalUser, tenant, localUser))

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -67,7 +67,7 @@ func newGetObjectCmd() *cobra.Command {
 	getCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	_ = getCmd.Flags().MarkHidden("include-tags")
+	_ = getCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
 
 	getCmd.Flags().
 		Var(&ltFlag, "layer-type", fmt.Sprintf("Layer type at which the knowledge object exists.  Valid values: %q, %q, %q, %q, %q", solution, account, globalUser, tenant, localUser))

--- a/cmd/knowledge/get.go
+++ b/cmd/knowledge/get.go
@@ -67,6 +67,8 @@ func newGetObjectCmd() *cobra.Command {
 	getCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
+	getCmd.Flags().MarkHidden("include-tags")
+
 	getCmd.Flags().
 		Var(&ltFlag, "layer-type", fmt.Sprintf("Layer type at which the knowledge object exists.  Valid values: %q, %q, %q, %q, %q", solution, account, globalUser, tenant, localUser))
 	_ = getCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)

--- a/cmd/knowledge/update.go
+++ b/cmd/knowledge/update.go
@@ -74,6 +74,8 @@ func getUpdateObjectCmd() *cobra.Command {
 	objStoreUpdateCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
+	objStoreUpdateCmd.Flags().MarkHidden("include-tags")
+
 	objStoreUpdateCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
 

--- a/cmd/knowledge/update.go
+++ b/cmd/knowledge/update.go
@@ -74,7 +74,7 @@ func getUpdateObjectCmd() *cobra.Command {
 	objStoreUpdateCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	objStoreUpdateCmd.Flags().MarkHidden("include-tags")
+	_ = objStoreUpdateCmd.Flags().MarkHidden("include-tags")
 
 	objStoreUpdateCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")

--- a/cmd/knowledge/update.go
+++ b/cmd/knowledge/update.go
@@ -72,11 +72,6 @@ func getUpdateObjectCmd() *cobra.Command {
 	_ = objStoreUpdateCmd.RegisterFlagCompletionFunc("layer-type", layerTypeCompletionFunc)
 
 	objStoreUpdateCmd.Flags().
-		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
-
-	_ = objStoreUpdateCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
-
-	objStoreUpdateCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")
 
 	return objStoreUpdateCmd
@@ -113,17 +108,9 @@ func updateObject(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	var includeTagsString string = "false"
-	includeTagsFlag, _ := cmd.Flags().GetBool("include-tags")
-
-	if includeTagsFlag {
-		includeTagsString = "true"
-	}
-
 	headers := map[string]string{
-		"layer-type":  layerType,
-		"layer-id":    layerID,
-		"includeTags": includeTagsString,
+		"layer-type": layerType,
+		"layer-id":   layerID,
 	}
 
 	var res any

--- a/cmd/knowledge/update.go
+++ b/cmd/knowledge/update.go
@@ -74,7 +74,7 @@ func getUpdateObjectCmd() *cobra.Command {
 	objStoreUpdateCmd.Flags().
 		Bool("include-tags", false, "Include knowledge object tags in the response from the Knowledge Store")
 
-	_ = objStoreUpdateCmd.Flags().MarkHidden("include-tags")
+	_ = objStoreUpdateCmd.Flags().MarkDeprecated("include-tags", "Support for including tags in the response has been deprecated for now and will be fully added back once the new version of the json-store apis is released.")
 
 	objStoreUpdateCmd.Flags().
 		String("layer-id", "", "The layer-id of the knowledge object to update. Optional for TENANT and SOLUTION layers ")

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -75,7 +75,7 @@ func generateSolutionPackage(cmd *cobra.Command, args []string) {
 		log.Fatal(err.Error())
 	}
 
-	manifest := createInitialSolutionManifest(solutionName, solutionType)
+	manifest := createInitialSolutionManifest(solutionName, solutionType, "1.0.0")
 
 	if cmd.Flags().Changed("include-service") {
 		output.PrintCmdStatus(cmd, "Adding the service-component.json \n")
@@ -109,12 +109,11 @@ func generateSolutionPackage(cmd *cobra.Command, args []string) {
 	createSolutionManifestFile(solutionName, manifest)
 }
 
-func createInitialSolutionManifest(solutionName string, solutionType string) *Manifest {
+func createInitialSolutionManifest(solutionName string, solutionType string, solutionVersion string) *Manifest {
 
 	emptyDeps := make([]string, 0)
 	manifest := &Manifest{
 		ManifestVersion: "1.1.0",
-		SolutionVersion: "1.0.0",
 		Dependencies:    emptyDeps,
 		Description:     "description of your solution",
 		GitRepoUrl:      "the url for the git repo holding your solution",
@@ -124,6 +123,7 @@ func createInitialSolutionManifest(solutionName string, solutionType string) *Ma
 	}
 	manifest.Name = solutionName
 	manifest.SolutionType = solutionType
+	manifest.SolutionVersion = solutionVersion
 
 	return manifest
 

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -162,6 +162,8 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 	solutionPath = absolutizePath(solutionPath)
 	solutionParentPath := filepath.Dir(solutionPath)
 
+	log.Infof("got solution parent path after absolute: %s", solutionParentPath)
+
 	// switch cwd to the solution directory for archiving
 	fsocWorkingDir, err := os.Getwd()
 	if err != nil {

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -162,8 +162,6 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 	solutionPath = absolutizePath(solutionPath)
 	solutionParentPath := filepath.Dir(solutionPath)
 
-	log.Infof("got solution parent path after absolute: %s", solutionParentPath)
-
 	// switch cwd to the solution directory for archiving
 	fsocWorkingDir, err := os.Getwd()
 	if err != nil {

--- a/cmd/solution/solution.go
+++ b/cmd/solution/solution.go
@@ -64,6 +64,7 @@ func NewSubCmd() *cobra.Command {
 	solutionCmd.AddCommand(getSolutionTestCmd())
 	solutionCmd.AddCommand(getSolutionTestStatusCmd())
 	solutionCmd.AddCommand(getsolutionIsolateCmd())
+	solutionCmd.AddCommand(getSolutionZapCmd())
 	solutionListCmd.Flags().StringP("output", "o", "", "Output format (human*, json, yaml)")
 
 	return solutionCmd

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -52,7 +52,8 @@ type GetExtensibilitySolutionObjectByIdResponse struct {
 }
 
 type ExtensibilitySolutionObjectData struct {
-	IsSubscribed bool `json:"isSubscribed,omitempty"`
+	IsSubscribed bool   `json:"isSubscribed,omitempty"`
+	SolutionType string `json:"solutionType,omitempty"`
 }
 
 var solutionStatusCmd = &cobra.Command{
@@ -97,7 +98,7 @@ func getObjects(url string, headers map[string]string) StatusItem {
 	err := api.JSONGet(url, &res, &api.Options{Headers: headers})
 
 	if err != nil {
-		log.Fatalf("Error fetching status object %q: %v", url, err)
+		log.Fatalf("Error fetching solution object %q: %v", url, err)
 	}
 
 	if len(res.Items) > 0 {

--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -62,6 +62,7 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	solutionRootDirectory, _ := cmd.Flags().GetString("directory")
 	solutionVersionFlag, _ := cmd.Flags().GetString("solution-version")
+	solutionNameFromFlag, _ := cmd.Flags().GetString("solution-name")
 
 	// prepare tag-related flags (note: these will be replaced if isolation is attempted)
 	solutionTagFlag, _ := cmd.Flags().GetString("tag")
@@ -76,7 +77,12 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 	if solutionAlreadyZipped {
 		solutionBundlePath = absolutizePath(solutionBundlePath)
 		solutionFileName := filepath.Base(solutionBundlePath)
-		solutionName = solutionFileName[:len(solutionFileName)-len(filepath.Ext(solutionFileName))] // TODO: extract from archive
+		// handle case where we are passing the solution name as a flag argument
+		if solutionNameFromFlag != "" {
+			solutionName = solutionNameFromFlag
+		} else {
+			solutionName = solutionFileName[:len(solutionFileName)-len(filepath.Ext(solutionFileName))] // TODO: extract from archive
+		}
 		solutionVersion = solutionVersionFlag                                                       // TODO: extract from archive
 		solutionDisplayText = fmt.Sprintf("solution archive %q", solutionBundlePath)
 		logFields = map[string]interface{}{

--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -83,7 +83,7 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 		} else {
 			solutionName = solutionFileName[:len(solutionFileName)-len(filepath.Ext(solutionFileName))] // TODO: extract from archive
 		}
-		solutionVersion = solutionVersionFlag                                                       // TODO: extract from archive
+		solutionVersion = solutionVersionFlag // TODO: extract from archive
 		solutionDisplayText = fmt.Sprintf("solution archive %q", solutionBundlePath)
 		logFields = map[string]interface{}{
 			"zip_file":        solutionBundlePath,

--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -61,6 +61,7 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 	bumpFlag, _ := cmd.Flags().GetBool("bump")
 	solutionBundlePath, _ := cmd.Flags().GetString("solution-bundle")
 	solutionRootDirectory, _ := cmd.Flags().GetString("directory")
+	solutionVersionFlag, _ := cmd.Flags().GetString("solution-version")
 
 	// prepare tag-related flags (note: these will be replaced if isolation is attempted)
 	solutionTagFlag, _ := cmd.Flags().GetString("tag")
@@ -76,7 +77,7 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 		solutionBundlePath = absolutizePath(solutionBundlePath)
 		solutionFileName := filepath.Base(solutionBundlePath)
 		solutionName = solutionFileName[:len(solutionFileName)-len(filepath.Ext(solutionFileName))] // TODO: extract from archive
-		solutionVersion = ""                                                                        // TODO: extract from archive
+		solutionVersion = solutionVersionFlag                                                       // TODO: extract from archive
 		solutionDisplayText = fmt.Sprintf("solution archive %q", solutionBundlePath)
 		logFields = map[string]interface{}{
 			"zip_file":        solutionBundlePath,
@@ -250,7 +251,7 @@ func uploadSolution(cmd *cobra.Command, push bool) {
 		}
 		output.PrintCmdStatus(cmd, fmt.Sprintf("Waiting %s for %s to be installed...\n", duration, solutionDisplayText))
 
-		filter := fmt.Sprintf(`data.solutionName eq "%s" and data.solutionVersion eq "%s"`, solutionName, solutionVersion)
+		filter := fmt.Sprintf(`data.solutionName eq "%s" and data.solutionVersion eq "%s" and data.tag eq "%s"`, solutionName, solutionVersion, solutionTagFlag)
 		query := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(filter))
 
 		headers := map[string]string{

--- a/cmd/solution/zap.go
+++ b/cmd/solution/zap.go
@@ -48,6 +48,8 @@ func getSolutionZapCmd() *cobra.Command {
 	solutionZapCmd.Flags().
 		String("tag", "", "Tag associated with the solution to zap (required)")
 
+	_ = solutionZapCmd.MarkFlagRequired("tag")
+
 	solutionZapCmd.Flags().
 		Int("wait", -1, "Wait to terminate the command until the solution is install succesfully")
 
@@ -79,9 +81,9 @@ func zapSolution(cmd *cobra.Command, args []string) {
 	solutionName = strings.ToLower(solutionName)
 
 	if !skipConfirmationMessage {
-		fmt.Print(fmt.Sprintf("Please type YES and hit enter confirm that you want to zap the solution with name: %s and tag: %s ", solutionName, solutionTag))
+		fmt.Printf("Please type YES and hit enter confirm that you want to zap the solution with name: %s and tag: %s ", solutionName, solutionTag)
 		fmt.Scanln(&confirmationAnswer)
-	
+
 		if confirmationAnswer != "YES" {
 			log.Fatal("Solution zap not confirmed, exiting command")
 		}

--- a/cmd/solution/zap.go
+++ b/cmd/solution/zap.go
@@ -1,0 +1,138 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/fsoc/config"
+	//"github.com/cisco-open/fsoc/output"
+)
+
+var solutionZapCmd = &cobra.Command{
+	Use:   "zap <solution-name>",
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Upload an empty version of a solution to clean it up",
+	Long: `This command creates an empty version of an existing solution and uploads it.
+
+This is for the purpose of cleaning up a solution by removing the knowledge types and knowledge objects
+associated with it.  Use this command with caution.`,
+	Example:          `  fsoc solution zap mysolution`,
+	Run:              zapSolution,
+	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""},
+	TraverseChildren: true,
+}
+
+func getSolutionZapCmd() *cobra.Command {
+
+	solutionZapCmd.Flags().
+		String("tag", "", "Tag associated with the solution to zap (required)")
+
+	solutionZapCmd.Flags().
+		Int("wait", -1, "Wait to terminate the command until the solution is install succesfully")
+
+	solutionZapCmd.Flags().
+		Bool("yes", false, "Skip warning message and bypass confirmation step")
+
+	return solutionZapCmd
+}
+
+func zapSolution(cmd *cobra.Command, args []string) {
+	var solutionPathInFlag string
+	var solutionId string
+	var solutionInstallObjectQuery string
+	var lastSolutionInstallVersion string
+	solutionInstallObjectChan := make(chan StatusItem)
+	solutionObjectChan := make(chan ExtensibilitySolutionObjectData)
+	solutionName := getSolutionNameFromArgs(cmd, args, "")
+	cfg := config.GetCurrentContext()
+	solutionName = strings.ToLower(solutionName)
+	solutionTag, _ := cmd.Flags().GetString("tag")
+	cmd.Flags().StringVar(&solutionPathInFlag, "solution-bundle", "", "")
+	cmd.Flags().StringVar(&lastSolutionInstallVersion, "solution-version", "", "")
+
+	headers := map[string]string{
+		"layer-type": "TENANT",
+		"layer-id":   cfg.Tenant,
+	}
+
+	if solutionTag == "dev" {
+		solutionId = solutionName
+	} else if solutionTag == "stable" {
+		log.Fatal("Error: stable solutions are not able to be zapped.  Please specify a tag other that 'stable'")
+	} else {
+		solutionId = fmt.Sprintf("%s.%s", solutionName, solutionTag)
+	}
+
+	solutionInstallObjectFilterQuery := fmt.Sprintf(`data.solutionID eq "%s" and data.tag eq "%s"`, solutionId, solutionTag)
+	solutionInstallObjectQuery = fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(solutionInstallObjectFilterQuery))
+
+	go func() {
+		solutionInstallObjectChan <- getObjects(fmt.Sprintf(getSolutionInstallUrl(), solutionInstallObjectQuery), headers)
+	}()
+	go func() {
+		solutionObjectChan <- getExtensibilitySolutionObject(getSolutionObjectUrl(solutionId), headers)
+	}()
+
+	solutionInstallObject := <-solutionInstallObjectChan
+	solutionObject := <-solutionObjectChan
+	solutionInstallObjectData := solutionInstallObject.StatusData
+	solutionType := solutionObject.SolutionType
+	log.Infof(`solution type: %s`, solutionType)
+	if solutionInstallObjectData.IsEmpty() {
+		log.WithFields(
+			log.Fields{"solution": solutionName, "tag": solutionTag, "solutionID": solutionId},
+		).Info("Previously installed version of the solution not detected.  Install with version 1.0.0.")
+		lastSolutionInstallVersion = "1.0.0"
+	} else {
+		lastSolutionInstallVersion = solutionInstallObjectData.SolutionVersion
+	}
+	log.Infof(`last solution install version: %s`, lastSolutionInstallVersion)
+
+	if err := os.Mkdir(solutionName, os.ModePerm); err != nil {
+		log.Fatal(err.Error())
+	}
+
+	manifest := createInitialSolutionManifest(solutionName, solutionType, lastSolutionInstallVersion)
+	if err := bumpManifestPatchVersion(manifest); err != nil {
+		log.Fatalf(err.Error())
+	}
+	createSolutionManifestFile(solutionName, manifest)
+
+	currentDirectory, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	solutionRootDirectory := filepath.Join(currentDirectory, solutionName)
+	log.Infof(`current solutionRootDirectoryPath: %s`, solutionRootDirectory)
+	solutionArchive := generateZip(cmd, solutionRootDirectory, "")
+	log.Infof(`current solutionArchive path after package in .zap: %v`, solutionArchive.Name())
+	solutionPathInFlag = solutionArchive.Name()
+
+	uploadSolution(cmd, true)
+}
+
+func (s StatusData) IsEmpty() bool {
+	return reflect.DeepEqual(s, StatusData{})
+}

--- a/cmd/solution/zap.go
+++ b/cmd/solution/zap.go
@@ -149,6 +149,10 @@ func zapSolution(cmd *cobra.Command, args []string) {
 	uploadSolution(cmd, true)
 
 	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution with name: %s and tag: %s zapped\n", solutionName, solutionTag))
+
+	// remove the temporary blank solution created so that the zap command can be run again in the same directory without
+	// any hiccups
+	os.RemoveAll(solutionRootDirectory)
 }
 
 func (s StatusData) IsEmpty() bool {


### PR DESCRIPTION
## Description

We are adding a new solution command: fsoc solution zap.  This will upload an empty version of a solution, removing all types and objects that are present in the solution.  This will only work for non-stable tagged solutions.  W

We have also marked the include-tags flag as hidden as this field is not in our public open api spec at this point of time so we should not expose it to our users yet.

## Type of Change

- [X] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
