### PR TITLE
Fix smart agent blocker not detected, add burstable blocker support

### DIFF
--- a/cmd/optimize/configure.go
+++ b/cmd/optimize/configure.go
@@ -483,19 +483,19 @@ func assignToBlocker(rawBlockers map[string]interface{}) (blockers Blockers) {
 			blocker.Description = "More than 5% of requests are resulting in errors"
 			blocker.Impact = "This may indicate that there's a larger problem in the service, so we cannot perform optimization tests"
 			blockers.ErrorRateHigh = blocker
-		case "no_orchestration":
+		case "no_orchestration_agent":
 			blocker.Description = "We didn't detect the Orchestration Client on your workload, which is responsible for provisioning and deprovisioning the Servo Agent"
 			blocker.Impact = "Optimization cannot be performed because the Servo Agent can't be provisioned on your cluster"
 			blockers.NoOrchestrationAgent = blocker
+		case "burstable_instance":
+			blocker.Description = "Workload detected to be on a burstable instance type. Unlike standard compute nodes, burstable nodes operate by offering baseline performance levels with the capability to burst, or temporarily increase, performance above the baseline as needed"
+			blocker.Impact = "Using burstable nodes for sustained loads can lead to unpredictable performance and costs compared to regular nodes, which makes them unsuitable for optimization"
+			blockers.BurstableInstance = blocker
 		default:
 			log.Warnf("Unknown blocker %q encountered", key)
 		}
 		data := rawBlockers[key].(map[string]interface{})
-		if data["overridable"] == "true" {
-			blocker.Overridable = true
-		} else {
-			blocker.Overridable = false
-		}
+		blocker.Overridable = data["overridable"] == "true"
 	}
 	return blockers
 }

--- a/cmd/optimize/types.go
+++ b/cmd/optimize/types.go
@@ -168,6 +168,7 @@ type Blockers struct {
 	MTBFHigh                    *Blocker `json:"mtbf_high,omitempty"`
 	ErrorRateHigh               *Blocker `json:"error_rate_high,omitempty"`
 	NoOrchestrationAgent        *Blocker `json:"no_orchestration_agent,omitempty"`
+	BurstableInstance           *Blocker `json:"burstable_instance,omitempty"`
 }
 
 type Blocker struct {


### PR DESCRIPTION
## Description

* Fix: Configure command was able to onboard hard blocker "missing orchestration agent" without passing hard override flag
* Add support for the burstable instance blocker (eg. for AWS T instances)

## Type of Change

- [x] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
