### PR TITLE
refactored manifest creation, added checks

### DIFF
--- a/cmd/solution/zap.go
+++ b/cmd/solution/zap.go
@@ -137,7 +137,11 @@ func zapSolution(cmd *cobra.Command, args []string) {
 	// any hiccups
 	defer os.RemoveAll(tempDirRoot)
 
-	manifest := createInitialSolutionManifest(solutionName, solutionType, lastSolutionInstallVersion)
+	// create a new solution manifest and bump the version to the next
+	manifest := createInitialSolutionManifest(
+		solutionName,
+		WithSolutionType(solutionType),
+		WithSolutionVersion(lastSolutionInstallVersion))
 	if err := bumpManifestPatchVersion(manifest); err != nil {
 		log.Fatalf(err.Error())
 	}


### PR DESCRIPTION
## Description

Refactored the function that creates an initial solution manifest to allow for extensible options. This has no user-visible impact, just provides for extensibility, such as adding info for `application` and `module` solution types.

Added warnings in case the solution type and the manifest version provided on creation of the manifest don't match the currently supported ones. This should be an error but we don't want to prevent testing of new versions of manifest and/or solution types should they come up.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
