### PR TITLE
ORION-2893: fix bug with --wait flag in fsoc solution zap

### DIFF
--- a/cmd/solution/zap.go
+++ b/cmd/solution/zap.go
@@ -146,12 +146,13 @@ func zapSolution(cmd *cobra.Command, args []string) {
 		log.Fatalf(err.Error())
 	}
 	createSolutionManifestFile(solutionRootDirectory, manifest)
+	updatedManifestVersion := manifest.SolutionVersion
 
 	solutionArchive := generateZip(cmd, solutionRootDirectory, "")
 	solutionZipPath = solutionArchive.Name()
 	defer os.RemoveAll(solutionZipPath)
 
-	uploadSolution(cmd, true, WithSolutionName(solutionName), WithSolutionZipPath(solutionZipPath), WithSolutionInstallVersion(lastSolutionInstallVersion))
+	uploadSolution(cmd, true, WithSolutionName(solutionName), WithSolutionZipPath(solutionZipPath), WithSolutionInstallVersion(updatedManifestVersion))
 
 	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution with name: %s and tag: %s zapped\n", solutionName, solutionTag))
 }


### PR DESCRIPTION
## Description

Minor bugfix with the fsoc solution zap --wait flag functionality.  The solutionVersion that was being passed to --wait is not correct and thus the "waiting" functionality was not working correctly. This has been fixed with these changes.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
