### PR TITLE
added `config create` and `--login` flag on `config set`

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -40,6 +40,7 @@ func NewSubCmd() *cobra.Command {
 		TraverseChildren: true,
 	}
 
+	cmd.AddCommand(newCmdConfigCreate())
 	cmd.AddCommand(newCmdConfigGet())
 	cmd.AddCommand(newCmdConfigSet())
 	cmd.AddCommand(newCmdConfigUse())

--- a/cmd/config/create.go
+++ b/cmd/config/create.go
@@ -1,0 +1,392 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+	"golang.org/x/exp/slices"
+
+	cfg "github.com/cisco-open/fsoc/config"
+	"github.com/cisco-open/fsoc/output"
+	"github.com/cisco-open/fsoc/platform/api"
+)
+
+var (
+	//	currentContext bool
+	createContextLong = `Create or modify a context entry (profile) in an fsoc config file.
+
+Use the --config and --profile flags to create/update settings in a different config file and profile, respectively. These
+flags are available for all fsoc commands to direct which profile should be used to execute the command. The environment
+variables FSOC_CONFIG and FSOC_PROFILE can be used instead of flags to select a file and profile. The flags take precedence if both
+are specified.
+
+Specifying a profile name that already has some settings will intelligently update the context in a way that avoids
+mixing settings from different auth types. If you want to disable this and just replace values as given, use the --patch flag.
+Setting a value to the empty string (e.g., knowledge.apiver="") will delete the configuration value.
+
+Specifying a profile name that doesn't exist will create a new profile and set the values.
+
+To see the list of configuration settings supported by fsoc, use the "fsoc config show-fields" command.	
+Note that each authentication method requires a slightly different set of values, see examples below.
+`
+
+	createContextExample = `
+  # Set oauth credentials (recommended for interactive use)
+  fsoc config set auth=oauth url=https://mytenant.observe.appdynamics.com
+
+  # Set service or agent principal credentials (secret file must remain accessible)
+  fsoc config set auth=service-principal secret-file=my-service-principal.json
+  fsoc config set auth=agent-principal secret-file=collectors-values.yaml
+  fsoc config set auth=agent-principal secret-file=client-values.json tenant=123456 url=https://mytenant.observe.appdynamics.com
+
+  # Set local access
+  fsoc config set auth=local url=http://localhost appd-pid=PID appd-tid=TID appd-pty=PTY
+  
+  # Set the token field on the "prod" context entry without touching other values
+  fsoc config set profile prod token=top-secret --patch
+ 
+  # Create profiles with different names
+  fsoc config set  --profile ci auth=service-principal secret-file=my-service-principal.json
+  fsoc config set  --profile ingest auth=agent-principal secret-file=agent-helm-values.yaml`
+)
+
+func newCmdConfigCreate() *cobra.Command {
+
+	var cmd = &cobra.Command{
+		Use:         "create [CONTEXT_NAME] [--config CONFIG_FILE] [SETTING=VALUE]+",
+		Short:       "Create a new context an fsoc config file",
+		Long:        createContextLong,
+		Example:     createContextExample,
+		Annotations: map[string]string{cfg.AnnotationForConfigBypass: ""},
+		Args:        cobra.MinimumNArgs(1),
+		Run:         configCreateContext,
+	}
+
+	cmd.Flags().Bool("no-login", false, "Do not attempt to log in to the new context after creating it")
+
+	return cmd
+}
+
+func configCreateContext(cmd *cobra.Command, args []string) {
+	var contextName string
+
+	// -- Perform command-line parsing checks first (syntax)
+
+	// warn if the --profile flag is used (it does not apply to this command)
+	if cmd.Flags().Changed("profile") {
+		log.Warn("Ignored the --profile flag, as it is not used by this command. Please specify the profile name to create as a first positional argument instead")
+	}
+
+	// get the context name, if specified (it will be the first argument and not contain an '=')
+	if !strings.Contains(args[0], "=") {
+		contextName = args[0]
+		args = args[1:]
+	}
+	if contextName == "" {
+		contextName = cfg.DefaultContext
+	}
+
+	// parse settings and separate the core fsoc settings from any subsystem-specific settings
+	// note that, unlike on `set`, this command does not support the legacy --flag-based settings (since it's a new command)
+	coreArgs, subsystemSettingArgs, err := parseCoreArgs(cmd, args)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	// Check that at least one config value is specified (including empty); either core or subsytem-specific setting satisfies this check
+	if len(coreArgs) == 0 && len(subsystemSettingArgs) == 0 {
+		log.Fatal("At least one setting must be specified when creating a new context")
+	}
+
+	// -- Perform other non-parsing validations (e.g., whether the context already exists)
+
+	// fail if the context name already exists
+	if _, err := cfg.GetContext(contextName); err == nil {
+		log.Fatalf("Context %q already exists; create with a different name or use 'fsoc config set' to update this one", contextName)
+	}
+
+	// set the profile name (as if it was provided by --profile)
+	// this is necessary to ensure that the correct profile is used when loggin in and, in general, avoid clobbering an existing profile
+	cfg.ForceSetActiveProfileName(contextName)
+
+	// -- Fill in the new context
+
+	// Create a new context
+	ctxPtr := &cfg.Context{Name: contextName}
+
+	// Process core settings
+	if err = updateCoreSettings(cmd, ctxPtr, coreArgs, false); err != nil {
+		log.Fatalf("Failed to set core settings: %v", err)
+	}
+
+	// process subsystem-specific settings
+	if err := processSubsystemSettings(ctxPtr, subsystemSettingArgs); err != nil {
+		log.Fatalf("Failed to set subsystem-specific settings: %v", err)
+	}
+
+	// -- Apply the new context
+
+	// update config file
+	// TODO: avoid modifying the file if login fails
+	if err := cfg.UpsertContext(ctxPtr); err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	// init a generic output message (to be updated later with more specific status)
+	var message string
+
+	// try to log in to the new context (don't check auth methods, api.Login() will handle degenerate cases)
+	noLogin, _ := cmd.Flags().GetBool("no-login")
+	if !noLogin {
+		if err := api.Login(); err != nil {
+			log.Warnf(`Failed to log in to the new context: %v; use "config set [SETTING=VALUE]+ --login --profile %v" to modify and try again`, err, contextName)
+			message = fmt.Sprintf("Context %q created but is not operable.", contextName)
+		} else {
+			message = fmt.Sprintf("Context %q created successfully.", contextName)
+		}
+	} else {
+		message = fmt.Sprintf("Context %q created ok but not verified by logging in.", contextName)
+	}
+
+	output.PrintCmdOutput(cmd, message)
+}
+
+// parseCoreArgs separates the core fsoc settings from any subsystem-specific settings. It returns the two groups of settings and an error
+func parseCoreArgs(cmd *cobra.Command, args []string) (map[string]string, []string, error) {
+	settings := map[string]string{}
+	remainder := []string{}
+	for i := 0; i < len(args); i++ {
+		// split argument into name=value
+		stringSegments := strings.SplitN(args[i], "=", 2)
+		if len(stringSegments) < 2 {
+			return settings, args, fmt.Errorf("setting %q at position %d must be in the form KEY=VALUE", args[i], i+1)
+		}
+		name, value := stringSegments[0], stringSegments[1]
+
+		// if the argument is a subsystem-specific setting, leave it in the remainder
+		if strings.Contains(name, ".") {
+			remainder = append(remainder, args[i])
+			continue
+		}
+
+		// check arg name is valid (i.e. no disallowed flags)
+		if !slices.Contains(configArgs, name) {
+			// TODO expand the message to accommodate subsystem-specific settings
+			return settings, args, fmt.Errorf("setting name %s must be one of the following values %s", name, strings.Join(configArgs, ", "))
+		}
+
+		// add setting
+		settings[name] = value
+		// make sure flag isn't already set
+	}
+	return settings, remainder, nil
+}
+
+// updateCoreSettings sets the core fsoc settings on the context. It returns an error if any setting fails to be set.
+func updateCoreSettings(cmd *cobra.Command, ctxPtr *cfg.Context, settings map[string]string, patch bool) error {
+	var val string
+	var ok bool
+
+	// process settings in the order they will be applied, allowing for non-patch to clear dependent fields before they are set (if set)
+
+	val, ok = settings["auth"]
+	if ok {
+		if !slices.Contains(GetAuthMethodsStringList(), val) {
+			log.Fatalf(`Invalid auth method %q; must be one of {"%v"}`, val, strings.Join(GetAuthMethodsStringList(), `", "`))
+		}
+		ctxPtr.AuthMethod = val
+		delete(settings, "auth")
+
+		// Clear All fields before setting other fields
+		if !patch {
+			clearFields([]string{"url", "server", "tenant", "user", "token", "refresh_token", "secret-file"}, ctxPtr)
+		}
+	}
+
+	val, ok = settings["envtype"]
+	if ok {
+		potentialEnvTypes := []string{"prod", "dev"}
+		if !slices.Contains(potentialEnvTypes, val) {
+			log.Fatalf("envtype can only take on one of the following values: %s", strings.Join(potentialEnvTypes, ", "))
+		}
+		ctxPtr.EnvType = val
+		delete(settings, "envtype")
+	}
+
+	// handle url and, for backward compatibility, server, which is deprecated
+	val, ok = settings["url"]
+	if !ok {
+		val, ok = settings["server"]
+	}
+	if ok {
+		cleanedUrl, err := validateUrl(val)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		if settings["server"] != "" {
+			log.Warnf(`The "server" setting is now deprecated. In the future, please use the "url" setting instead. We will set the url to %q for you now`, cleanedUrl)
+		} else if cleanedUrl != val {
+			log.Warnf("The specified url, %q, has been automatically updated to %q", val, cleanedUrl)
+		}
+		ctxPtr.URL = cleanedUrl
+
+		// Automate setting EnvType from url if EnvType is not already set (above)
+		if ctxPtr.EnvType == "" {
+			parsedUrl, err := url.Parse(cleanedUrl)
+			if err != nil {
+				log.Fatalf("Failed to parse url: %v", err)
+			}
+			host := parsedUrl.Host
+			if !strings.HasSuffix(host, ".observe.appdynamics.com") {
+				ctxPtr.EnvType = "dev"
+				log.Warnf("Automatically setting envtype to %q", ctxPtr.EnvType)
+			}
+		}
+
+		if !patch {
+			automatedFieldClearing(ctxPtr, "url")
+		}
+	}
+
+	val, ok = settings["tenant"]
+	if ok {
+		// reject if tenant is not an allowed setting for this authentication type
+		err := validateWriteReq(cmd, ctxPtr.AuthMethod, "tenant")
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		// update tenant
+		ctxPtr.Tenant = val
+		delete(settings, "tenant")
+
+		// clear dependent fields if not patching
+		if !patch {
+			automatedFieldClearing(ctxPtr, "tenant")
+		}
+	}
+
+	val, ok = settings["token"]
+	if ok {
+		// reject if token is not an allowed setting for this authentication type
+		err := validateWriteReq(cmd, ctxPtr.AuthMethod, "token")
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		// update token
+		if val == "-" { // token to come from stdin
+			scanner := bufio.NewScanner(os.Stdin)
+			scanner.Scan()
+			ctxPtr.Token = scanner.Text()
+		} else {
+			ctxPtr.Token = val
+		}
+		delete(settings, "token")
+
+		// clear dependent fields if not patching
+		if !patch {
+			automatedFieldClearing(ctxPtr, "token")
+		}
+	}
+
+	val, ok = settings["secret-file"]
+	if ok {
+		// reject if secret-file is not an allowed setting for this authentication type
+		err := validateWriteReq(cmd, ctxPtr.AuthMethod, "secret-file")
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		// canonicalize the path and update it into the context
+		path := expandHomePath(val)
+		ctxPtr.SecretFile, err = filepath.Abs(path)
+		if err != nil {
+			log.WithFields(log.Fields{"path": path, "error": err}).Warn("Failed to convert secret file's path to an absolute path; using it as is")
+			ctxPtr.SecretFile = path
+		}
+		ctxPtr.CsvFile = "" // CSV file is a backward-compatibility value only
+		delete(settings, "secret-file")
+
+		if !patch {
+			automatedFieldClearing(ctxPtr, "secret-file")
+		}
+	}
+
+	// populate fields for local auth
+	if ctxPtr.AuthMethod == cfg.AuthMethodLocal {
+		val, ok = settings[cfg.AppdPid]
+		if ok {
+			// reject if appd-pid is not an allowed setting for this authentication type
+			err := validateWriteReq(cmd, ctxPtr.AuthMethod, cfg.AppdPid)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+
+			// update value
+			ctxPtr.LocalAuthOptions.AppdPid = val
+			delete(settings, cfg.AppdPid)
+			if !patch {
+				automatedFieldClearing(ctxPtr, cfg.AppdPid)
+			}
+		}
+		val, ok = settings[cfg.AppdPty]
+		if ok {
+			// reject if appd-pty is not an allowed setting for this authentication type
+			err := validateWriteReq(cmd, ctxPtr.AuthMethod, cfg.AppdPty)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+
+			// update value
+			ctxPtr.LocalAuthOptions.AppdPty = val
+			delete(settings, cfg.AppdPty)
+			if !patch {
+				automatedFieldClearing(ctxPtr, cfg.AppdPty)
+			}
+		}
+		val, ok = settings[cfg.AppdTid]
+		if ok {
+			// reject if appd-tid is not an allowed setting for this authentication type
+			err := validateWriteReq(cmd, ctxPtr.AuthMethod, cfg.AppdTid)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
+
+			// update value
+			ctxPtr.LocalAuthOptions.AppdTid = val
+			delete(settings, cfg.AppdTid)
+			if !patch {
+				automatedFieldClearing(ctxPtr, cfg.AppdTid)
+			}
+		}
+	}
+
+	// upgrade config format from CsvFile to SecretFile, opportunistically using the update
+	if ctxPtr.SecretFile == "" && ctxPtr.CsvFile != "" {
+		ctxPtr.SecretFile = ctxPtr.CsvFile
+		ctxPtr.CsvFile = ""
+	}
+
+	return nil
+}

--- a/cmd/config/show-fields.go
+++ b/cmd/config/show-fields.go
@@ -31,8 +31,9 @@ func newCmdConfigShowFields() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:         "show-fields",
-		Short:       `Show fields that can be configured with "config set"`,
-		Long:        `Show the names and meaning of fields that can be configured with the "config set" command`,
+		Short:       `Show fields that can be configured in profiles`,
+		Long:        `Show the names and meaning of fields that can be configured with the "config create" and "config set" commands`,
+		Example:     `  fsoc config show-fields`,
 		Args:        cobra.NoArgs,
 		Annotations: map[string]string{cfg.AnnotationForConfigBypass: ""},
 		Run:         configShowFields,
@@ -41,13 +42,8 @@ func newCmdConfigShowFields() *cobra.Command {
 	return cmd
 }
 
-const helpIntro = `The following settings can be configured with the "config set" command.
+const helpIntro = `The following settings can be configured with the "config create" and "config set" commands.
 The current setting values can be seen with the "config get" command. 
-
-Examples:
-  fsoc config set auth=oauth url=mytenant.observe.appdynamics.com
-  fsoc config set auth=oauth url=mytest.observe.appdynamics.com knowledge.apiver=v2beta --profile test
-  fsoc config set auth=oauth url=mytest.observe.appdynamics.com knowledge.apiver="" --profile test
 
 Settings:`
 

--- a/cmd/melt/send.go
+++ b/cmd/melt/send.go
@@ -24,7 +24,7 @@ var meltSendCmd = &cobra.Command{
 This command generates OTLP payload based on a fsoc telemetry data models and sends the data to the platform ingestion services.
 
 To properly use the command you will need to create a fsoc profile using an agent principal yaml:
-fsoc config set --profile=<agent-principal-profile> auth=agent-principal secret-file=<agent-principal.yaml>
+fsoc config create <agent-principal-profile> auth=agent-principal secret-file=<agent-principal.yaml>
 
 Then you will use the agent principal profile as part of the command:
 fsoc melt send <fsocdatamodel>.yaml --profile <agent-principal-profile>

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,8 +80,7 @@ For source code and build instructions, see also https://github.com/cisco-open/f
 NOTE: fsoc is in alpha; breaking changes may occur.`,
 
 	Example: `
-  fsoc config set auth=oauth url=https://MYTENANT.observe.appdynamics.com
-  fsoc login
+  fsoc config create auth=oauth url=https://MYTENANT.observe.appdynamics.com
   fsoc uql "FETCH id, type, attributes FROM entities(k8s:workload)"
   fsoc solution list
   fsoc solution list -o json
@@ -225,7 +224,7 @@ func preExecHook(cmd *cobra.Command, args []string) {
 	// try to read the config file.and profile
 	err = viper.ReadInConfig()
 	if err != nil && !bypass {
-		log.Fatalf("fsoc is not configured, please use \"fsoc config set\" to configure an initial context")
+		log.Fatal(`fsoc is not configured, please use "fsoc config create" to configure an initial context`)
 	}
 
 	// override the config file's current profile from cmd line or env var
@@ -237,7 +236,7 @@ func preExecHook(cmd *cobra.Command, args []string) {
 		cfg := config.GetCurrentContext()         // nil if profile does not exist
 		exists := cfg != nil
 		if !exists && !bypass {
-			log.Fatalf("fsoc is not fully configured: missing profile %q; please use \"fsoc config set\" to configure it", profile)
+			log.Fatalf(`fsoc is not fully configured: missing profile %q; please use "fsoc config create" to configure it`, profile)
 		}
 		customSubsysConfigs := []string{}
 		if exists {

--- a/config/config.go
+++ b/config/config.go
@@ -235,6 +235,14 @@ func SetActiveProfile(cmd *cobra.Command, args []string, emptyOK bool) {
 	activeProfile = profile
 }
 
+// ForceSetActiveProfileName sets the name of the profile to the specified value. This is used
+// primarily when managing profiles, for commands where the profile name is given as an argument
+// (which takes precedence over any name set in env var or config file's default). Note that this
+// function does not validate the profile name or even its existence.
+func ForceSetActiveProfileName(profile string) {
+	activeProfile = profile
+}
+
 // GetCurrentProfileName returns the profile name that is used to select the context.
 // This is mostly the same as returned by GetCurrentContext().Name, except for the
 // case when a new profile is being created.

--- a/config/config.go
+++ b/config/config.go
@@ -229,7 +229,7 @@ func SetActiveProfile(cmd *cobra.Command, args []string, emptyOK bool) {
 	if !emptyOK && getContext(profile) == nil {
 		log.Fatalf("Could not find profile %q", profile)
 	}
-	if activeProfile != "" {
+	if activeProfile != "" && activeProfile != profile {
 		log.Warnf("The selected profile is being overridden: old=%q, new=%q", activeProfile, profile)
 	}
 	activeProfile = profile

--- a/config/manage.go
+++ b/config/manage.go
@@ -42,7 +42,7 @@ func ListContexts(prefix string) []string {
 
 // GetCurrentContext returns the context (access profile) selected by the user
 // for the particular invocation of the fsoc utility. Returns nil if no current context is defined (and the
-// only command allowed in this state is `config set`, which will create the context).
+// only commands allowed in this state are `config create|set`, which will create the context).
 // Note that GetCurrentContext returns a pointer into the config file's overall configuration; it can be
 // modified and then updated using ReplaceCurrentContext().
 func GetCurrentContext() *Context {

--- a/platform/api/context.go
+++ b/platform/api/context.go
@@ -42,7 +42,7 @@ func newCallContext() *callContext {
 	// get current config context
 	cfg := config.GetCurrentContext()
 	if cfg == nil {
-		log.Fatal("Missing context; use 'fsoc config set' to configure your context")
+		log.Fatal(`Missing context; use "fsoc config create" to configure your context`)
 		panic("unreachable") // keep golintci happy (until it recognizes apex/log fatals)
 	}
 	log.WithFields(log.Fields{"context": cfg.Name, "url": cfg.URL, "tenant": cfg.Tenant}).Info("Using context")


### PR DESCRIPTION
## Description

Added a more robust way to create new config profiles, with an explicit `config create` command and automatic login to verify the settings' validity. 

Added an optional `--login` flag to the `config set` command to get the same benefit of validating settings after they a profile is created.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
