### PR TITLE
Lip tenant lookup command

### DIFF
--- a/cmd/provisioning.go
+++ b/cmd/provisioning.go
@@ -1,0 +1,21 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "github.com/cisco-open/fsoc/cmd/provisioning"
+
+func init() {
+	registerSubsystem(provisioning.NewSubCmd())
+}

--- a/cmd/provisioning.go
+++ b/cmd/provisioning.go
@@ -14,8 +14,10 @@
 
 package cmd
 
-import "github.com/cisco-open/fsoc/cmd/provisioning"
+import (
+	"github.com/cisco-open/fsoc/cmd/provisioning"
+)
 
 func init() {
-	registerSubsystem(provisioning.NewSubCmd())
+	registerSubSystemWithConfig(provisioning.NewSubCmd(), &provisioning.GlobalConfig)
 }

--- a/cmd/provisioning/api_version.go
+++ b/cmd/provisioning/api_version.go
@@ -16,10 +16,8 @@ package provisioning
 
 import (
 	"fmt"
+	"slices"
 	"strings"
-
-	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 )
 
 // Tenant Provisioning API version type, supporting a limited set of values.
@@ -38,10 +36,10 @@ var supportedApiVersions = []string{
 func (a *ApiVersion) ValidateAndSet(version any) error {
 	s, ok := version.(string)
 	if !ok {
-		return errors.New(fmt.Sprintf(`the API version value must be a string, found %T instead`, version))
+		return fmt.Errorf(`the API version value must be a string, found %T instead`, version)
 	}
 	if !slices.Contains(supportedApiVersions, s) {
-		return errors.New(fmt.Sprintf(`API version %q is not supported; valid value(s): "%v"`, version, strings.Join(supportedApiVersions, `", "`)))
+		return fmt.Errorf(`API version %q is not supported; valid value(s): "%v"`, version, strings.Join(supportedApiVersions, `", "`))
 	}
 	*a = ApiVersion(s)
 	return nil

--- a/cmd/provisioning/api_version.go
+++ b/cmd/provisioning/api_version.go
@@ -1,0 +1,70 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/exp/slices"
+)
+
+// Tenant Provisioning API version type, supporting a limited set of values.
+// Implements the StringEnumer interface defined by the fsoc config package in order
+// to support parsing apiver from an fsoc config file.
+type ApiVersion string
+
+const (
+	ApiVersionDefault ApiVersion = ApiVersion("v1beta")
+)
+
+var supportedApiVersions = []string{
+	string(ApiVersionDefault),
+}
+
+func (a *ApiVersion) ValidateAndSet(version any) error {
+	s, ok := version.(string)
+	if !ok {
+		return errors.New(fmt.Sprintf(`the API version value must be a string, found %T instead`, version))
+	}
+	if !slices.Contains(supportedApiVersions, s) {
+		return errors.New(fmt.Sprintf(`API version %q is not supported; valid value(s): "%v"`, version, strings.Join(supportedApiVersions, `", "`)))
+	}
+	*a = ApiVersion(s)
+	return nil
+}
+
+func (a *ApiVersion) String() string {
+	if a == nil || string(*a) == "" {
+		return string(ApiVersionDefault)
+	} else {
+		return string(*a)
+	}
+}
+
+func getBaseUrl() string {
+	var version ApiVersion
+	if GlobalConfig.ApiVersion != nil && *GlobalConfig.ApiVersion != "" {
+		version = *GlobalConfig.ApiVersion // version from config file
+	} else {
+		version = ApiVersionDefault
+	}
+	return fmt.Sprintf("/provisioning/%v", version)
+}
+
+func getTenantLookupUrl(vanityUrl string) string {
+	return fmt.Sprintf("%v/tenants/lookup/vanityUrl/%v", getBaseUrl(), vanityUrl)
+}

--- a/cmd/provisioning/lookup.go
+++ b/cmd/provisioning/lookup.go
@@ -16,10 +16,12 @@ package provisioning
 
 import (
 	"fmt"
+
 	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
 	"github.com/cisco-open/fsoc/output"
 	"github.com/cisco-open/fsoc/platform/api"
-	"github.com/spf13/cobra"
 )
 
 var lookupCmd = &cobra.Command{
@@ -43,11 +45,16 @@ func lookup(cmd *cobra.Command, args []string) {
 
 	log.WithFields(log.Fields{"command": cmd.Name(), "vanityUrl": vanityUrl}).Info("Provisioning group command")
 
+	response := callBackend(vanityUrl)
+
+	output.PrintCmdOutput(cmd, response)
+}
+
+func callBackend(vanityUrl string) any {
 	var response any
 	err := api.JSONGet(fmt.Sprintf("/provisioning/v1beta/tenants/lookup/vanityUrl/%s", vanityUrl), &response, nil)
 	if err != nil {
 		log.Fatalf("Tenant lookup failed with %v", err.Error())
 	}
-
-	output.PrintCmdOutput(cmd, response)
+	return response
 }

--- a/cmd/provisioning/lookup.go
+++ b/cmd/provisioning/lookup.go
@@ -38,5 +38,5 @@ Tenant lookup doesn't require valid authentication (auth=none) but any configure
 
 func lookup(cmd *cobra.Command, args []string) {
 	vanityUrl := args[0]
-	cmdkit.FetchAndPrint(cmd, getTenantLookupUrl(vanityUrl), &cmdkit.FetchAndPrintOptions{})
+	cmdkit.FetchAndPrint(cmd, getTenantLookupUrl(vanityUrl), nil)
 }

--- a/cmd/provisioning/lookup.go
+++ b/cmd/provisioning/lookup.go
@@ -24,20 +24,23 @@ import (
 	"github.com/cisco-open/fsoc/platform/api"
 )
 
-var lookupCmd = &cobra.Command{
-	Use:              "lookup",
-	Short:            "Lookup for a tenant by vanity URL",
-	Long:             `Check whether tenant exist and return tenant Id if it does.`,
-	Example:          ` provisioning lookup --vanityUrl=fsoc-test.saas.appd-test.com`,
-	Args:             cobra.ExactArgs(0),
-	Run:              lookup,
-	TraverseChildren: true,
-}
+func newCmdLookup() *cobra.Command {
 
-func init() {
-	lookupCmd.Flags().String("vanityUrl", "", "Vanity URL")
+	var lookupCmd = &cobra.Command{
+		Use:              "lookup-tenant",
+		Short:            "Lookup for a tenant by vanity URL",
+		Long:             `Check whether tenant exist and return tenant Id if it does.`,
+		Example:          `  provisioning lookup-tenant --vanityUrl=fsoc-test.saas.appd-test.com`,
+		Args:             cobra.ExactArgs(0),
+		Run:              lookup,
+		TraverseChildren: true,
+	}
 
-	provisioningCmd.AddCommand(lookupCmd)
+	vanityUrlFlag := "vanityUrl"
+	lookupCmd.Flags().String(vanityUrlFlag, "", "Vanity URL")
+	_ = lookupCmd.MarkFlagRequired(vanityUrlFlag)
+
+	return lookupCmd
 }
 
 func lookup(cmd *cobra.Command, args []string) {

--- a/cmd/provisioning/lookup.go
+++ b/cmd/provisioning/lookup.go
@@ -15,10 +15,9 @@
 package provisioning
 
 import (
-	"github.com/apex/log"
-	"github.com/cisco-open/fsoc/output"
-	"github.com/cisco-open/fsoc/platform/api"
 	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/fsoc/cmdkit"
 )
 
 func newCmdLookup() *cobra.Command {
@@ -28,9 +27,8 @@ func newCmdLookup() *cobra.Command {
 		Short: "Lookup for a tenant Id by vanity URL",
 		Long: `Check whether tenant exist and return tenant Id if it does.
 Tenant lookup doesn't require valid authentication (auth=none) but any configured auth type/tenant will also work.`,
-		Example: `  fsoc provisioning lookup your-vanity-url.appdynamics.com
-  or with alias
-  fsoc tep lookup your-vanity-url.appdynamics.com`,
+		Example: `  fsoc provisioning lookup MYTENANT.observe.appdynamics.com
+  fsoc tep lookup MYTENANT.observe.appdynamics.com`,
 		Args:             cobra.ExactArgs(1),
 		Run:              lookup,
 		TraverseChildren: true,
@@ -40,16 +38,5 @@ Tenant lookup doesn't require valid authentication (auth=none) but any configure
 
 func lookup(cmd *cobra.Command, args []string) {
 	vanityUrl := args[0]
-
-	response := callBackend(vanityUrl)
-	output.PrintCmdOutput(cmd, response)
-}
-
-func callBackend(vanityUrl string) any {
-	var response any
-	err := api.JSONGet(getTenantLookupUrl(vanityUrl), &response, nil)
-	if err != nil {
-		log.Fatalf("Tenant lookup failed with %v", err.Error())
-	}
-	return response
+	cmdkit.FetchAndPrint(cmd, getTenantLookupUrl(vanityUrl), &cmdkit.FetchAndPrintOptions{})
 }

--- a/cmd/provisioning/lookup.go
+++ b/cmd/provisioning/lookup.go
@@ -37,7 +37,7 @@ func newCmdLookup() *cobra.Command {
 	}
 
 	vanityUrlFlag := "vanityUrl"
-	lookupCmd.Flags().String(vanityUrlFlag, "", "Vanity URL")
+	lookupCmd.Flags().String(vanityUrlFlag, "", "Vanity URL without a scheme. Provide only domain part.")
 	_ = lookupCmd.MarkFlagRequired(vanityUrlFlag)
 
 	return lookupCmd

--- a/cmd/provisioning/lookup.go
+++ b/cmd/provisioning/lookup.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"fmt"
+	"github.com/apex/log"
+	"github.com/cisco-open/fsoc/output"
+	"github.com/cisco-open/fsoc/platform/api"
+	"github.com/spf13/cobra"
+)
+
+var lookupCmd = &cobra.Command{
+	Use:              "lookup",
+	Short:            "Lookup for a tenant by vanity URL",
+	Long:             `Check whether tenant exist and return tenant Id if it does.`,
+	Example:          ` provisioning lookup --vanityUrl=fsoc-test.saas.appd-test.com`,
+	Args:             cobra.ExactArgs(0),
+	Run:              lookup,
+	TraverseChildren: true,
+}
+
+func init() {
+	lookupCmd.Flags().String("vanityUrl", "", "Vanity URL")
+
+	provisioningCmd.AddCommand(lookupCmd)
+}
+
+func lookup(cmd *cobra.Command, args []string) {
+	vanityUrl, _ := cmd.Flags().GetString("vanityUrl")
+
+	log.WithFields(log.Fields{"command": cmd.Name(), "vanityUrl": vanityUrl}).Info("Provisioning group command")
+
+	var response any
+	err := api.JSONGet(fmt.Sprintf("/provisioning/v1beta/tenants/lookup/vanityUrl/%s", vanityUrl), &response, nil)
+	if err != nil {
+		log.Fatalf("Tenant lookup failed with %v", err.Error())
+	}
+
+	output.PrintCmdOutput(cmd, response)
+}

--- a/cmd/provisioning/provisioning.go
+++ b/cmd/provisioning/provisioning.go
@@ -18,11 +18,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Config defines the subsystem configuration under fsoc
+type Config struct {
+	ApiVersion *ApiVersion `mapstructure:"apiver,omitempty" fsoc-help:"API version to use for tenant provisioning. The default is \"v1beta\"."`
+}
+
+// To make it work provisioning should be registered as subsystem and
+// provisioning.GlobalConfig needs to be passed as provisioning config
+var GlobalConfig Config
+
 func NewSubCmd() *cobra.Command {
+
 	var cmd = &cobra.Command{
 		Use:              "provisioning",
 		Short:            "Tenant provisioning and management",
 		Long:             `Use to provision new tenant and troubleshoot provisioning workflow.`,
+		Aliases:          []string{"prov", "tep"},
 		Example:          `  fsoc provisioning [flags]`,
 		TraverseChildren: true,
 		Hidden:           true,

--- a/cmd/provisioning/provisioning.go
+++ b/cmd/provisioning/provisioning.go
@@ -1,0 +1,35 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package provisioning
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var provisioningCmd = &cobra.Command{
+	Use:              "provisioning",
+	Short:            "Tenant provisioning and management",
+	Long:             `Use to provision new tenant and troubleshoot provisioning workflow.`,
+	Example:          `  ./fsoc provisioning [flags]`,
+	TraverseChildren: true,
+}
+
+func init() {
+
+}
+
+func NewSubCmd() *cobra.Command {
+	return provisioningCmd
+}

--- a/cmd/provisioning/provisioning.go
+++ b/cmd/provisioning/provisioning.go
@@ -34,7 +34,7 @@ func NewSubCmd() *cobra.Command {
 		Short:            "Tenant provisioning and management",
 		Long:             `Use to provision new tenant and troubleshoot provisioning workflow.`,
 		Aliases:          []string{"prov", "tep"},
-		Example:          `  fsoc provisioning [flags]`,
+		Example:          `  fsoc provisioning`,
 		TraverseChildren: true,
 		Hidden:           true,
 	}

--- a/cmd/provisioning/provisioning.go
+++ b/cmd/provisioning/provisioning.go
@@ -18,19 +18,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var provisioningCmd = &cobra.Command{
-	Use:              "provisioning",
-	Short:            "Tenant provisioning and management",
-	Long:             `Use to provision new tenant and troubleshoot provisioning workflow.`,
-	Example:          `  ./fsoc provisioning [flags]`,
-	TraverseChildren: true,
-	Hidden:           true,
-}
-
-func init() {
-
-}
-
 func NewSubCmd() *cobra.Command {
-	return provisioningCmd
+	var cmd = &cobra.Command{
+		Use:              "provisioning",
+		Short:            "Tenant provisioning and management",
+		Long:             `Use to provision new tenant and troubleshoot provisioning workflow.`,
+		Example:          `  fsoc provisioning [flags]`,
+		TraverseChildren: true,
+		Hidden:           true,
+	}
+
+	cmd.AddCommand(newCmdLookup())
+
+	return cmd
 }

--- a/cmd/provisioning/provisioning.go
+++ b/cmd/provisioning/provisioning.go
@@ -24,6 +24,7 @@ var provisioningCmd = &cobra.Command{
 	Long:             `Use to provision new tenant and troubleshoot provisioning workflow.`,
 	Example:          `  ./fsoc provisioning [flags]`,
 	TraverseChildren: true,
+	Hidden:           true,
 }
 
 func init() {


### PR DESCRIPTION
## Description

New hidden command group **provisioning** is created. This command is needed to provision new tenants to the platform. It should be used only internally by platform admins.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/cisco-open/fsoc/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
