### PR TITLE
support string names for metric aggregation temporality

### DIFF
--- a/platform/melt/metric_test.go
+++ b/platform/melt/metric_test.go
@@ -1,0 +1,58 @@
+package melt
+
+import (
+	"testing"
+
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestAggregationTemporalityParsing(t *testing.T) {
+
+	validYamlStrings := map[string]AggregationTemporality{
+		"aggregationtemporality: UNSPECIFIED": AggregationTemporalityUnspecified,
+		"aggregationtemporality: delta":       AggregationTemporalityDelta,
+		"aggregationtemporality: Cumulative":  AggregationTemporalityCumulative,
+	}
+	validYamlNumbers := map[string]AggregationTemporality{
+		"aggregationtemporality: 0": AggregationTemporalityUnspecified,
+		"aggregationtemporality: 1": AggregationTemporalityDelta,
+		"aggregationtemporality: 2": AggregationTemporalityCumulative,
+	}
+	invalidYaml := []string{
+		"aggregationtemporality: INVALID",
+		"aggregationtemporality: -1",
+		"aggregationtemporality: 3",
+		"aggregationtemporality: 1.5",
+	}
+
+	var temp Metric
+
+	for text, temporality := range validYamlStrings {
+		err := yaml.Unmarshal([]byte(text), &temp)
+		if err != nil {
+			t.Errorf("Failed to parse valid YAML %q: %v", text, err)
+		}
+		if temp.AggregationTemporality != temporality {
+			t.Errorf("Expected %v, got %v for YAML %q", temporality, temp.AggregationTemporality, text)
+		}
+	}
+
+	for text, temporality := range validYamlNumbers {
+		err := yaml.Unmarshal([]byte(text), &temp)
+		if err != nil {
+			t.Errorf("Failed to parse valid YAML %q: %v", text, err)
+		}
+		if temp.AggregationTemporality != temporality {
+			t.Errorf("Expected %v, got %v for YAML %q", temporality, temp.AggregationTemporality, text)
+		}
+	}
+
+	for _, text := range invalidYaml {
+		err := yaml.Unmarshal([]byte(text), &temp)
+		if err == nil {
+			t.Errorf("Expected error when parsing invalid YAML %q, got nil", text)
+		} else {
+			t.Logf("Got expected error when parsing invalid YAML %q: %v", text, err)
+		}
+	}
+}

--- a/platform/melt/metric_test.go
+++ b/platform/melt/metric_test.go
@@ -9,9 +9,12 @@ import (
 func TestAggregationTemporalityParsing(t *testing.T) {
 
 	validYamlStrings := map[string]AggregationTemporality{
-		"aggregationtemporality: UNSPECIFIED": AggregationTemporalityUnspecified,
-		"aggregationtemporality: delta":       AggregationTemporalityDelta,
-		"aggregationtemporality: Cumulative":  AggregationTemporalityCumulative,
+		"aggregationtemporality: UNSPECIFIED":                         AggregationTemporalityUnspecified,
+		"aggregationtemporality: delta":                               AggregationTemporalityDelta,
+		"aggregationtemporality: Cumulative":                          AggregationTemporalityCumulative,
+		"aggregationtemporality: AGGREGATION_TEMPORALITY_UNSPECIFIED": AggregationTemporalityUnspecified,
+		"aggregationtemporality: AGGREGATION_TEMPORALITY_DELTA":       AggregationTemporalityDelta,
+		"aggregationtemporality: AGGREGATION_TEMPORALITY_CUMULATIVE":  AggregationTemporalityCumulative,
 	}
 	validYamlNumbers := map[string]AggregationTemporality{
 		"aggregationtemporality: 0": AggregationTemporalityUnspecified,
@@ -51,8 +54,6 @@ func TestAggregationTemporalityParsing(t *testing.T) {
 		err := yaml.Unmarshal([]byte(text), &temp)
 		if err == nil {
 			t.Errorf("Expected error when parsing invalid YAML %q, got nil", text)
-		} else {
-			t.Logf("Got expected error when parsing invalid YAML %q: %v", text, err)
 		}
 	}
 }

--- a/platform/melt/types.go
+++ b/platform/melt/types.go
@@ -336,11 +336,11 @@ func (a *AggregationTemporality) UnmarshalYAML(unmarshal func(interface{}) error
 	}
 
 	// First try to parse as an integer
-	if valueInt, err := strconv.Atoi(originalValue); err == nil {
+	if valueInt, err := strconv.ParseInt(originalValue, 10, 8); err == nil {
 		switch valueInt {
-		case int(AggregationTemporalityUnspecified),
-			int(AggregationTemporalityDelta),
-			int(AggregationTemporalityCumulative):
+		case int64(AggregationTemporalityUnspecified),
+			int64(AggregationTemporalityDelta),
+			int64(AggregationTemporalityCumulative):
 			*a = AggregationTemporality(valueInt)
 			return nil
 		default:

--- a/platform/melt/types.go
+++ b/platform/melt/types.go
@@ -338,7 +338,9 @@ func (a *AggregationTemporality) UnmarshalYAML(unmarshal func(interface{}) error
 	// First try to parse as an integer
 	if valueInt, err := strconv.Atoi(originalValue); err == nil {
 		switch valueInt {
-		case 0, 1, 2:
+		case int(AggregationTemporalityUnspecified),
+			int(AggregationTemporalityDelta),
+			int(AggregationTemporalityCumulative):
 			*a = AggregationTemporality(valueInt)
 			return nil
 		default:
@@ -349,11 +351,11 @@ func (a *AggregationTemporality) UnmarshalYAML(unmarshal func(interface{}) error
 	// If that fails, try to match the string
 	valueString := strings.ToLower(originalValue)
 	switch valueString {
-	case "unspecified":
+	case "unspecified", "aggregation_temporality_unspecified":
 		*a = AggregationTemporalityUnspecified
-	case "delta":
+	case "delta", "aggregation_temporality_delta":
 		*a = AggregationTemporalityDelta
-	case "cumulative":
+	case "cumulative", "aggregation_temporality_cumulative":
 		*a = AggregationTemporalityCumulative
 	default:
 		return fmt.Errorf("invalid aggregationtemporality value %q, must be 0-2 or one of (unspecified, delta, cumulative)", originalValue)


### PR DESCRIPTION
## Description

For the `melt send` command, when sending metrics of type `sum`, add support for string values of the aggregation temporality in the YAML file. The numeric values continue to be supported, both for backward compatibility and for those who prefer to use the numeric values.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
