### PR TITLE
Fix linter errors and package names to comply with latest style

### DIFF
--- a/cmd/uql/api_version.go
+++ b/cmd/uql/api_version.go
@@ -16,10 +16,8 @@ package uql
 
 import (
 	"fmt"
+	"slices"
 	"strings"
-
-	"github.com/pkg/errors"
-	"golang.org/x/exp/slices"
 )
 
 // UQL API version type, supporting a limited set of values.
@@ -46,10 +44,10 @@ var supportedApiVersions = []string{
 func (a *ApiVersion) ValidateAndSet(v any) error {
 	s, ok := v.(string)
 	if !ok {
-		return errors.New(fmt.Sprintf(`the API version value must be a string, found %T instead`, v))
+		return fmt.Errorf("the API version value must be a string, found %T instead", v)
 	}
 	if !slices.Contains(supportedApiVersions, s) {
-		return errors.New(fmt.Sprintf(`API version %q is not supported; valid value(s): "%v"`, v, strings.Join(supportedApiVersions, `", "`)))
+		return fmt.Errorf(`API version %q is not supported; valid value(s): "%v"`, v, strings.Join(supportedApiVersions, `", "`))
 	}
 	*a = ApiVersion(s)
 	return nil


### PR DESCRIPTION
## Description

Fix linter errors for simpler code/idiomatic use and change packages names to their latest location, as they are now part of the standard library (`errors` and `slices`). No behavior changes.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [X] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
