### PR TITLE
Support for YAML files in solutions and a `solution fix`

### DIFF
--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -36,7 +36,10 @@ func init() {
 }
 
 func meltModel(cmd *cobra.Command, args []string) {
-	manifest := sol.GetManifest()
+	manifest, err := sol.GetManifest(".")
+	if err != nil {
+		log.Fatalf("Failed to get manifest: %v", err)
+	}
 	if manifest.HasIsolation() {
 
 		if !(cmd.Flags().Changed("tag") || cmd.Flags().Changed("env-file")) {

--- a/cmd/solution/bump.go
+++ b/cmd/solution/bump.go
@@ -57,7 +57,7 @@ func bumpSolutionVersion(cmd *cobra.Command, args []string) {
 	}
 	newVer := manifest.SolutionVersion
 
-	if err = writeSolutionManifest(manifestDir, manifest); err != nil {
+	if err = saveSolutionManifest(manifestDir, manifest); err != nil {
 		log.Fatalf("Failed to update solution manifest: %v", err)
 	}
 

--- a/cmd/solution/describe.go
+++ b/cmd/solution/describe.go
@@ -1,3 +1,17 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package solution
 
 import (

--- a/cmd/solution/embed-isolate.go
+++ b/cmd/solution/embed-isolate.go
@@ -57,6 +57,13 @@ func embeddedConditionalIsolate(cmd *cobra.Command, sourceDir string) (string, s
 		return sourceDir, tag, nil
 	}
 
+	// reject if manifest is in YAML format (pseudo-isolation is supported only for JSON files)
+	if manifest.ManifestFormat != FileFormatJSON {
+		return "", "", fmt.Errorf("pseudo-isolation is supported only for JSON-formatted solutions")
+	}
+
+	log.Warnf("This solution uses fsoc-provided pseudo-isolation, which is now deprecated; please transition your solutions to native isolation soon to get the full isolation benefits.")
+
 	// prepare target directory
 	// TODO: instead of fsoc as prefix, use as much as we can extract from the solution name
 	//       in the manifest (assuming "<solution-name>${<something>}", the idea is to extract <solution-name>

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -66,11 +66,11 @@ func getSolutionExtendCmd() *cobra.Command {
 		Bool("add-ecpHome", false, "Add a template extension definition to build the ecpHome experience for this solution")
 
 	// file format override flags (mutually exclusive)
-	solutionInitCmd.Flags().
+	solutionExtendCmd.Flags().
 		Bool("json", false, "Use JSON format for the component file, even if the manifest is in YAML.")
-	solutionInitCmd.Flags().
+	solutionExtendCmd.Flags().
 		Bool("yaml", false, "Use YAML format for the component file, even if the manifest is in JSON.")
-	solutionInitCmd.MarkFlagsMutuallyExclusive("json", "yaml")
+	solutionExtendCmd.MarkFlagsMutuallyExclusive("json", "yaml")
 
 	return solutionExtendCmd
 

--- a/cmd/solution/fix.go
+++ b/cmd/solution/fix.go
@@ -1,0 +1,217 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/fsoc/config"
+	"github.com/cisco-open/fsoc/output"
+)
+
+var solutionFixCmd = &cobra.Command{
+	Use:   "fix [flags]",
+	Args:  cobra.NoArgs,
+	Short: "Fixes common solution issues and upgrades solution format version",
+	Long: `Rewrites aspects of the solution to:
+	1. Upgrade the solution format to recent changes (e.g., manifest version)
+	2. Fix common issues in the solution (e.g., missing required fields)
+	3. Make common changes and refactoring (e.g., change file format from JSON to YAML)`,
+	Example:     `  fsoc solution fix --manifest-type=yaml --manifest-version`,
+	Run:         solutionFix,
+	Annotations: map[string]string{config.AnnotationForConfigBypass: ""}, // this command does not require a valid context
+}
+
+var ErrNoEffect = errors.New("requested operation is not required as it will have no effect")
+
+var availableFixes = []string{"manifest-version", "manifest-format"}
+
+func getSolutionFixCmd() *cobra.Command {
+	solutionFixCmd.Flags().
+		Bool("manifest-version", false, "Upgrade manifest to the latest format (requires --solution-type)")
+	solutionFixCmd.Flags().
+		String("manifest-format", "", "Change manifest format (should be json or yaml)")
+	solutionFixCmd.Flags().
+		String("solution-type", "", "Define type for the solution (should be one of component, module, or application)")
+
+	return solutionFixCmd
+}
+
+func solutionFix(cmd *cobra.Command, args []string) {
+	// check that at least one fix was requested
+	work := false
+	for _, fix := range availableFixes {
+		if cmd.Flags().Changed(fix) {
+			work = true
+			break
+		}
+	}
+	if !work {
+		log.Fatal("At least one fix must be requested")
+	}
+
+	// collect flags and values
+	manifestVersion, _ := cmd.Flags().GetBool("manifest-version")
+	manifestFormat, _ := cmd.Flags().GetString("manifest-format")
+	solutionType, _ := cmd.Flags().GetString("solution-type")
+
+	// Read solution manifest
+	manifest, err := GetManifest(".")
+	if err != nil {
+		log.WithError(err).Fatal("Failed to read solution manifest. Is this a solution directory?")
+	}
+
+	// backup manifest
+	manifestBackupPath, err := backupManifest(manifest)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to back up manifest; canceling fix")
+	}
+	log.WithField("path", manifestBackupPath).Info("Backed up original manifest")
+
+	// save original format
+	oldManifestFormat := manifest.ManifestFormat
+
+	// create a counter for the fixes
+	nFixes := 0
+
+	// Upgrade manifest version
+	if manifestVersion {
+		if solutionType == "" {
+			log.Fatal("Solution type is required to upgrade manifest version, use the --solution-type flag to specify.")
+		}
+		err := upgradeManifestVersion(cmd, manifest, solutionType)
+		switch {
+		case err == nil:
+			output.PrintCmdStatus(cmd, fmt.Sprintf("Manifest version upgraded to %v.\n", manifest.ManifestVersion))
+			nFixes += 1
+		case errors.Is(err, ErrNoEffect):
+			log.Warn("Manifest version is already up to date for this solution; not changed.")
+		default:
+			log.WithError(err).Fatal("Failed to upgrade manifest version")
+		}
+	}
+
+	if manifestFormat != "" {
+		err := changeManifestFormat(cmd, manifest, manifestFormat)
+		switch {
+		case err == nil:
+			output.PrintCmdStatus(cmd, fmt.Sprintf("Manifest format changed to %v.\n", manifest.ManifestFormat))
+			nFixes += 1
+		case errors.Is(err, ErrNoEffect):
+			log.Warn("Manifest format is already as requested; not changed.")
+		default:
+			log.WithError(err).Fatal("Failed to change manifest format")
+		}
+	}
+
+	// if no fix was applied, print a message and exit
+	if nFixes == 0 {
+		output.PrintCmdStatus(cmd, "No changes were made to the solution.\n")
+		return
+	}
+
+	// update manifest
+	err = saveSolutionManifest(".", manifest)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to write the updated manifest file")
+	}
+	output.PrintCmdStatus(cmd, fmt.Sprintf("Manifest file manifest.%s updated successfully.\n", manifest.ManifestFormat))
+
+	// if file format changed, delete the old manifest file
+	if oldManifestFormat != manifest.ManifestFormat {
+		oldManifestPath := fmt.Sprintf("manifest.%s", oldManifestFormat)
+		output.PrintCmdStatus(cmd, fmt.Sprintf("Removing old manifest file %q (backed up in %q).\n", oldManifestPath, manifestBackupPath))
+		err := os.Remove(oldManifestPath)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to remove old manifest file %q, please delete manually to avoid conflict", oldManifestPath)
+		}
+	}
+
+	output.PrintCmdStatus(cmd, fmt.Sprintf("%v change(s) made to the solution.\n", nFixes))
+}
+
+func upgradeManifestVersion(cmd *cobra.Command, manifest *Manifest, solutionType string) error {
+	// Check if manifest version is already up to date
+	if manifest.ManifestVersion == "1.1.0" {
+		return ErrNoEffect
+	}
+
+	// Check solution type
+	if !slices.Contains(knownSolutionTypes, solutionType) {
+		return fmt.Errorf("unknown solution type %q; Should be one of %q", solutionType, knownSolutionTypes)
+	}
+
+	// Upgrade manifest version
+	manifest.ManifestVersion = "1.1.0"
+	manifest.SolutionType = solutionType
+	// TODO: for type that require additional components, add them here
+	var todo string
+	switch manifest.SolutionType {
+	case "module":
+		todo = "add a module object"
+	case "application":
+		todo = "add an application object"
+	}
+	if todo != "" {
+		log.Warnf("The solution type %q requires additional component(s): please %s", solutionType, todo)
+	}
+	return nil
+}
+
+func changeManifestFormat(cmd *cobra.Command, manifest *Manifest, format string) error {
+	// Validate format value
+	var fileFormat FileFormat
+	switch format {
+	case "json":
+		fileFormat = FileFormatJSON
+	case "yaml":
+		fileFormat = FileFormatYAML
+	default:
+		return fmt.Errorf("unknown manifest format %q; should be json or yaml", format)
+	}
+
+	// Check if manifest format is already as requested
+	if manifest.ManifestFormat == fileFormat {
+		return ErrNoEffect
+	}
+
+	// Change manifest format
+	manifest.ManifestFormat = fileFormat
+	// nb: writing the format back will change the format
+
+	return nil
+}
+
+// backupManifest create a backup of the manifest file. Upon success, it returns the file
+// name of the backup file; otherwise, it returns an error.
+func backupManifest(manifest *Manifest) (string, error) {
+	f, err := os.CreateTemp("", fmt.Sprintf("%s-manifest-backup-*.%s", manifest.Name, manifest.ManifestFormat))
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create manifest backup file")
+	}
+	defer f.Close()
+
+	err = writeSolutionManifest(manifest, f)
+	if err != nil {
+		log.WithError(err).Fatalf("Failed to write manifest backup file %q", f.Name())
+	}
+	return f.Name(), nil
+}

--- a/cmd/solution/fix.go
+++ b/cmd/solution/fix.go
@@ -193,6 +193,11 @@ func changeManifestFormat(cmd *cobra.Command, manifest *Manifest, format string)
 		return ErrNoEffect
 	}
 
+	// Prevent changing pseudo-isolated solutions to YAML
+	if fileFormat == FileFormatYAML {
+		return fmt.Errorf("changing pseudo-isolated solutions to YAML is not supported; pseudo-isolation is supported only for JSON-formatted solutions")
+	}
+
 	// Change manifest format
 	manifest.ManifestFormat = fileFormat
 	// nb: writing the format back will change the format

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 
@@ -260,6 +261,8 @@ func isSolutionPackageRoot(path string) bool {
 }
 
 func getSolutionManifest(path string) (*Manifest, error) {
+	checkStructTags(reflect.TypeOf(Manifest{})) // ensure struct tags are correct
+
 	// Determine manifest name, in JSON or YAML format
 	var manifestPath string
 	manifestPathJson := filepath.Join(path, "manifest.json")

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -250,13 +250,15 @@ func addFileToZip(zipWriter *zip.Writer, fileName string, info os.FileInfo) {
 }
 
 func isSolutionPackageRoot(path string) bool {
-	manifestPath := fmt.Sprintf("%s/manifest.json", path)
-	manifestFile, err := os.Open(manifestPath)
+	_, err := getSolutionManifest(path)
 	if err != nil {
-		log.Errorf("The directory %s is not a solution root directory", path)
+		if errors.Is(err, os.ErrNotExist) {
+			log.Errorf("The directory %s is not a solution root directory", path)
+		} else {
+			log.Errorf("Failed to read solution manifest: %v", err)
+		}
 		return false
 	}
-	manifestFile.Close()
 	return true
 }
 

--- a/cmd/solution/solution.go
+++ b/cmd/solution/solution.go
@@ -52,6 +52,7 @@ func NewSubCmd() *cobra.Command {
 	solutionCmd.AddCommand(getSubscribeSolutionCmd())
 	solutionCmd.AddCommand(getUnsubscribeSolutionCmd())
 	solutionCmd.AddCommand(getSolutionExtendCmd())
+	solutionCmd.AddCommand(getSolutionFixCmd())
 	solutionCmd.AddCommand(getSolutionPackageCmd())
 	solutionCmd.AddCommand(getSolutionPushCmd())
 	solutionCmd.AddCommand(getSolutionDownloadCmd())

--- a/cmd/solution/types-dashui.go
+++ b/cmd/solution/types-dashui.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Cisco Systems, Inc.
+// Copyright 2024 Cisco Systems, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,160 +15,160 @@
 package solution
 
 type DashuiTemplate struct {
-	Kind    string      `json:"kind"`
-	Name    string      `json:"name"`
-	Target  string      `json:"target"`
-	View    string      `json:"view"`
-	Element interface{} `json:"element"`
+	Kind    string      `json:"kind" yaml:"kind"`
+	Name    string      `json:"name" yaml:"name"`
+	Target  string      `json:"target" yaml:"target"`
+	View    string      `json:"view" yaml:"view"`
+	Element interface{} `json:"element" yaml:"element"`
 }
 
 type DashuiTemplatePropsExtension struct {
-	Kind                string      `json:"kind"`
-	Id                  string      `json:"id"`
-	Name                string      `json:"name"`
-	View                string      `json:"view"`
-	Target              string      `json:"target"`
-	RequiredEntityTypes []string    `json:"requiredEntityTypes"`
-	Props               interface{} `json:"props"`
+	Kind                string      `json:"kind" yaml:"kind"`
+	Id                  string      `json:"id" yaml:"id"`
+	Name                string      `json:"name" yaml:"name"`
+	View                string      `json:"view" yaml:"view"`
+	Target              string      `json:"target" yaml:"target"`
+	RequiredEntityTypes []string    `json:"requiredEntityTypes" yaml:"requiredEntityTypes"`
+	Props               interface{} `json:"props" yaml:"props"`
 }
 
 type DashuiWidget struct {
-	InstanceOf interface{} `json:"instanceOf"`
-	Props      interface{} `json:"props,omitempty"`
-	Elements   interface{} `json:"elements,omitempty"`
-	Element    interface{} `json:"element,omitempty"`
+	InstanceOf interface{} `json:"instanceOf" yaml:"instanceOf"`
+	Props      interface{} `json:"props,omitempty" yaml:"props,omitempty"`
+	Elements   interface{} `json:"elements,omitempty" yaml:"elements,omitempty"`
+	Element    interface{} `json:"element,omitempty" yaml:"element,omitempty"`
 }
 
 type DashuiFocusedEntity struct {
 	*DashuiWidget
-	Mode string `json:"mode"`
+	Mode string `json:"mode" yaml:"mode"`
 }
 
 type DashuiString struct {
-	InstanceOf string `json:"instanceOf"`
-	Content    string `json:"content"`
+	Content    string `json:"content" yaml:"content"`
+	InstanceOf string `json:"instanceOf" yaml:"instanceOf"`
 }
 
 type DashuiLabel struct {
-	InstanceOf interface{} `json:"instanceOf"`
-	Path       interface{} `json:"path"`
+	InstanceOf interface{} `json:"instanceOf" yaml:"instanceOf"`
+	Path       interface{} `json:"path" yaml:"path"`
 }
 
 type DashuiProperties struct {
-	InstanceOf interface{}       `json:"instanceOf"`
-	Elements   []*DashuiProperty `json:"elements"`
+	InstanceOf interface{}       `json:"instanceOf" yaml:"instanceOf"`
+	Elements   []*DashuiProperty `json:"elements" yaml:"elements"`
 }
 type DashuiProperty struct {
-	Label *DashuiString `json:"label"`
-	Value *DashuiLabel  `json:"value"`
+	Label *DashuiString `json:"label" yaml:"label"`
+	Value *DashuiLabel  `json:"value" yaml:"value"`
 }
 
 type DashuiGrid struct {
 	*DashuiWidget
-	RowSets          interface{}         `json:"rowSets"`
-	Style            interface{}         `json:"style,omitempty"`
-	Mode             string              `json:"mode"`
-	Columns          []*DashuiGridColumn `json:"columns"`
-	OnRowSingleClick *DashuiEvent        `json:"onRowSingleClick,omitempty"`
-	OnRowDoubleClick *DashuiEvent        `json:"onRowDoubleClick,omitempty"`
+	RowSets          interface{}         `json:"rowSets" yaml:"rowSets"`
+	Style            interface{}         `json:"style,omitempty" yaml:"style,omitempty"`
+	Mode             string              `json:"mode" yaml:"mode"`
+	Columns          []*DashuiGridColumn `json:"columns" yaml:"columns"`
+	OnRowSingleClick *DashuiEvent        `json:"onRowSingleClick,omitempty" yaml:"onRowSingleClick,omitempty"`
+	OnRowDoubleClick *DashuiEvent        `json:"onRowDoubleClick,omitempty" yaml:"onRowDoubleClick,omitempty"`
 }
 
 type DashuiGridColumn struct {
-	Label string          `json:"label"`
-	Flex  int             `json:"flex"`
-	Width int             `json:"width"`
-	Cell  *DashuiGridCell `json:"cell"`
+	Label string          `json:"label" yaml:"label"`
+	Flex  int             `json:"flex" yaml:"flex"`
+	Width int             `json:"width" yaml:"width"`
+	Cell  *DashuiGridCell `json:"cell" yaml:"cell"`
 }
 
 type DashuiGridCell struct {
-	Default interface{} `json:"default,omitempty"`
+	Default interface{} `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
 type DashuiTooltip struct {
 	*DashuiWidget
-	Truncate bool        `json:"truncate,omitempty"`
-	Trigger  interface{} `json:"trigger,omitempty"`
+	Truncate bool        `json:"truncate,omitempty" yaml:"truncate,omitempty"`
+	Trigger  interface{} `json:"trigger,omitempty" yaml:"trigger,omitempty"`
 }
 
 type DashuiClickable struct {
 	*DashuiWidget
-	OnClick *DashuiEvent `json:"onClick,omitempty"`
-	Trigger *DashuiLabel `json:"trigger,omitempty"`
+	OnClick *DashuiEvent `json:"onClick,omitempty" yaml:"onClick,omitempty"`
+	Trigger *DashuiLabel `json:"trigger,omitempty" yaml:"trigger,omitempty"`
 }
 
 type DashuiEvent struct {
-	Type       string   `json:"type"`
-	Paths      []string `json:"paths,omitempty"`
-	Expression string   `json:"expression"`
+	Type       string   `json:"type" yaml:"type"`
+	Paths      []string `json:"paths,omitempty" yaml:"paths,omitempty"`
+	Expression string   `json:"expression" yaml:"expression"`
 }
 
 type EcpLeftBar struct {
 	*DashuiWidget
-	Label string `json:"label"`
+	Label string `json:"label" yaml:"label"`
 }
 
 type EcpRelationshipMapEntry struct {
-	Key             string `json:"key"`
-	Path            string `json:"path"`
-	EntityAttribute string `json:"entityAttribute"`
-	IconName        string `json:"iconName"`
+	Key             string `json:"key" yaml:"key"`
+	Path            string `json:"path" yaml:"path"`
+	EntityAttribute string `json:"entityAttribute" yaml:"entityAttribute"`
+	IconName        string `json:"iconName" yaml:"iconName"`
 }
 
 type EcpInspectorWidget struct {
 	*DashuiWidget
-	Title string `json:"title"`
+	Title string `json:"title" yaml:"title"`
 }
 
 type EcpHome struct {
-	Sections []*DashuiEcpHomeSection `json:"sections"`
-	Entities []*DashuiEcpHomeEntity  `json:"entities"`
+	Sections []*DashuiEcpHomeSection `json:"sections" yaml:"sections"`
+	Entities []*DashuiEcpHomeEntity  `json:"entities" yaml:"entities"`
 }
 
 type DashuiEcpHomeSection struct {
-	Index int    `json:"index"`
-	Name  string `json:"name"`
-	Title string `json:"title"`
+	Index int    `json:"index" yaml:"index"`
+	Name  string `json:"name" yaml:"name"`
+	Title string `json:"title" yaml:"title"`
 }
 
 type DashuiEcpHomeEntity struct {
-	Index           int    `json:"index"`
-	Section         string `json:"section"`
-	EntityAttribute string `json:"entityAttribute"`
-	TargetType      string `json:"targetType"`
+	Index           int    `json:"index" yaml:"index"`
+	Section         string `json:"section" yaml:"section"`
+	EntityAttribute string `json:"entityAttribute" yaml:"entityAttribute"`
+	TargetType      string `json:"targetType" yaml:"targetType"`
 }
 
 type DashuiOcpSingle struct {
 	*DashuiWidget
-	NameAttribute string `json:"nameAttribute"`
+	NameAttribute string `json:"nameAttribute" yaml:"nameAttribute"`
 }
 
 type DashuiCartesian struct {
 	*DashuiWidget
-	Children []*DashuiCartesianSeries `json:"children"`
+	Children []*DashuiCartesianSeries `json:"children" yaml:"children"`
 }
 
 type DashuiCartesianSeries struct {
-	Props  interface{}            `json:"props"`
-	Metric *DashuiCartesianMetric `json:"metric"`
-	Type   string                 `json:"type"`
+	Props  interface{}            `json:"props" yaml:"props"`
+	Metric *DashuiCartesianMetric `json:"metric" yaml:"metric"`
+	Type   string                 `json:"type" yaml:"type"`
 }
 
 type DashuiCartesianMetric struct {
-	Name   string               `json:"name"`
-	Source string               `json:"source"`
-	Y      *DashuiCartesianAxis `json:"y"`
+	Name   string               `json:"name" yaml:"name"`
+	Source string               `json:"source" yaml:"source"`
+	Y      *DashuiCartesianAxis `json:"y" yaml:"y"`
 }
 
 type DashuiCartesianAxis struct {
-	Field string `json:"type"`
+	Field string `json:"type" yaml:"type"`
 }
 
 type DashuiLogsWidget struct {
-	InstanceOf interface{} `json:"instanceOf"`
-	Source     string      `json:"source"`
+	InstanceOf interface{} `json:"instanceOf" yaml:"instanceOf"`
+	Source     string      `json:"source" yaml:"source"`
 }
 
 type DashuiHtmlWidget struct {
 	*DashuiWidget
-	Style interface{} `json:"style,omitempty"`
+	Style interface{} `json:"style,omitempty" yaml:"style,omitempty"`
 }

--- a/cmd/solution/types-fmm.go
+++ b/cmd/solution/types-fmm.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Cisco Systems, Inc.
+// Copyright 2024 Cisco Systems, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,53 +19,53 @@ import (
 )
 
 type FmmTypeDef struct {
-	Namespace   *FmmNamespaceAssignTypeDef `json:"namespace"`
-	Kind        string                     `json:"kind"`
-	Name        string                     `json:"name"`
-	DisplayName string                     `json:"displayName,omitempty"`
+	Namespace   *FmmNamespaceAssignTypeDef `json:"namespace" yaml:"namespace"`
+	Kind        string                     `json:"kind" yaml:"kind"`
+	Name        string                     `json:"name" yaml:"name"`
+	DisplayName string                     `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 }
 
 type FmmNamespaceAssignTypeDef struct {
-	Name    string `json:"name"`
-	Version int    `json:"version"`
+	Name    string `json:"name" yaml:"name"`
+	Version int    `json:"version" yaml:"version"`
 }
 
 type FmmLifecycleConfigTypeDef struct {
-	PurgeTtlInMinutes     int64 `json:"purgeTtlInMinutes"`
-	RetentionTtlInMinutes int64 `json:"retentionTtlInMinutes"`
+	PurgeTtlInMinutes     int64 `json:"purgeTtlInMinutes" yaml:"purgeTtlInMinutes"`
+	RetentionTtlInMinutes int64 `json:"retentionTtlInMinutes" yaml:"retentionTtlInMinutes"`
 }
 
 type FmmAttributeTypeDef struct {
-	Type        string `json:"type"`
-	Description string `json:"description,omitempty"`
+	Type        string `json:"type" yaml:"type"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 type FmmRequiredAttributeDefinitionsTypeDef struct {
-	Required []string `json:"required"`
+	Required []string `json:"required" yaml:"required"`
 	*FmmAttributeDefinitionsTypeDef
 }
 
 type FmmAttributeDefinitionsTypeDef struct {
-	Optimized  []string                        `json:"optimized"`
-	Attributes map[string]*FmmAttributeTypeDef `json:"attributes"`
+	Optimized  []string                        `json:"optimized" yaml:"optimized"`
+	Attributes map[string]*FmmAttributeTypeDef `json:"attributes" yaml:"attributes"`
 }
 
 type FmmAssociationTypesTypeDef struct {
-	Aggregates_of []string `json:"common:aggregates_of,omitempty"`
-	Consists_of   []string `json:"common:consists_of,omitempty"`
-	Is_a          []string `json:"common:is_a,omitempty"`
-	Has           []string `json:"common:has,omitempty"`
-	Relates_to    []string `json:"common:relates_to,omitempty"`
-	Uses          []string `json:"common:uses,omitempty"`
+	Aggregates_of []string `json:"common:aggregates_of,omitempty" yaml:"common:aggregates_of,omitempty"`
+	Consists_of   []string `json:"common:consists_of,omitempty" yaml:"common:consists_of,omitempty"`
+	Is_a          []string `json:"common:is_a,omitempty" yaml:"common:is_a,omitempty"`
+	Has           []string `json:"common:has,omitempty" yaml:"common:has,omitempty"`
+	Relates_to    []string `json:"common:relates_to,omitempty" yaml:"common:relates_to,omitempty"`
+	Uses          []string `json:"common:uses,omitempty" yaml:"common:uses,omitempty"`
 }
 
 type FmmEntity struct {
 	*FmmTypeDef
-	AttributeDefinitions  *FmmRequiredAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
-	LifecyleConfiguration *FmmLifecycleConfigTypeDef              `json:"lifecycleConfiguration"`
-	MetricTypes           []string                                `json:"metricTypes,omitempty"`
-	EventTypes            []string                                `json:"eventTypes,omitempty"`
-	AssociationTypes      *FmmAssociationTypesTypeDef             `json:"associationTypes,omitempty"`
+	AttributeDefinitions  *FmmRequiredAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty" yaml:"attributeDefinitions,omitempty"`
+	LifecyleConfiguration *FmmLifecycleConfigTypeDef              `json:"lifecycleConfiguration" yaml:"lifecycleConfiguration"`
+	MetricTypes           []string                                `json:"metricTypes,omitempty" yaml:"metricTypes,omitempty"`
+	EventTypes            []string                                `json:"eventTypes,omitempty" yaml:"eventTypes,omitempty"`
+	AssociationTypes      *FmmAssociationTypesTypeDef             `json:"associationTypes,omitempty" yaml:"associationTypes,omitempty"`
 }
 
 func (entity *FmmEntity) GetTypeName() string {
@@ -74,46 +74,46 @@ func (entity *FmmEntity) GetTypeName() string {
 
 type FmmEvent struct {
 	*FmmTypeDef
-	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions"` // required always, do not omitempty
+	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions" yaml:"attributeDefinitions"` // required always, do not omitempty
 }
 
 type FmmResourceMapping struct {
 	*FmmTypeDef
-	EntityType            string               `json:"entityType"`
-	ScopeFilter           string               `json:"scopeFilter"`
-	Mappings              []FmmMapAndTransform `json:"mappings,omitempty"`
-	AttributeNameMappings FmmNameMappings      `json:"attributeNameMappings,omitempty"`
+	EntityType            string               `json:"entityType" yaml:"entityType"`
+	ScopeFilter           string               `json:"scopeFilter" yaml:"scopeFilter"`
+	Mappings              []FmmMapAndTransform `json:"mappings,omitempty" yaml:"mappings,omitempty"`
+	AttributeNameMappings FmmNameMappings      `json:"attributeNameMappings,omitempty" yaml:"attributeNameMappings,omitempty"`
 }
 
 type FmmAssociationDeclaration struct {
 	*FmmTypeDef
-	ScopeFilter     string `json:"scopeFilter"`
-	FromType        string `json:"fromType"`
-	ToType          string `json:"toType"`
-	AssociationType string `json:"associationType"`
+	ScopeFilter     string `json:"scopeFilter" yaml:"scopeFilter"`
+	FromType        string `json:"fromType" yaml:"fromType"`
+	ToType          string `json:"toType" yaml:"toType"`
+	AssociationType string `json:"associationType" yaml:"associationType"`
 }
 
 type FmmMapAndTransform struct {
-	To   string `json:"to"`
-	From string `json:"from"`
+	To   string `json:"to" yaml:"to"`
+	From string `json:"from" yaml:"from"`
 }
 
 type FmmNameMappings map[string]string
 
 type FmmNamespace struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 type FmmMetric struct {
 	*FmmTypeDef
-	Category               FmmMetricCategory               `json:"category"`
-	ContentType            FmmMetricContentType            `json:"contentType"`
-	AggregationTemporality string                          `json:"aggregationTemporality"`
-	IsMonotonic            bool                            `json:"isMonotonic"`
-	Type                   FmmMetricType                   `json:"type"`
-	Unit                   string                          `json:"unit"`
-	AttributeDefinitions   *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty"`
-	IngestGranularities    []int                           `json:"ingestGranularities,omitempty"`
+	Category               FmmMetricCategory               `json:"category" yaml:"category"`
+	ContentType            FmmMetricContentType            `json:"contentType" yaml:"contentType"`
+	AggregationTemporality string                          `json:"aggregationTemporality" yaml:"aggregationTemporality"`
+	IsMonotonic            bool                            `json:"isMonotonic" yaml:"isMonotonic"`
+	Type                   FmmMetricType                   `json:"type" yaml:"type"`
+	Unit                   string                          `json:"unit" yaml:"unit"`
+	AttributeDefinitions   *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty" yaml:"attributeDefinitions,omitempty"`
+	IngestGranularities    []int                           `json:"ingestGranularities,omitempty" yaml:"ingestGranularities,omitempty"`
 }
 
 type FmmMetricCategory string

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Cisco Systems, Inc.
+// Copyright 2024 Cisco Systems, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -53,40 +53,40 @@ type Manifest struct {
 }
 
 type ComponentDef struct {
-	Type        string `json:"type,omitempty"`
-	ObjectsFile string `json:"objectsFile,omitempty"`
-	ObjectsDir  string `json:"objectsDir,omitempty"`
+	Type        string `json:"type,omitempty" yaml:"type,omitempty"`
+	ObjectsFile string `json:"objectsFile,omitempty" yaml:"objectsFile,omitempty"`
+	ObjectsDir  string `json:"objectsDir,omitempty" yaml:"objectsDir,omitempty"`
 }
 
 type ServiceDef struct {
-	Name  string `json:"name,omitempty"`
-	Image string `json:"image,omitempty"`
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
 }
 
 type KnowledgeDef struct {
-	Name                  string                 `json:"name,omitempty"`
-	AllowedLayers         []string               `json:"allowedLayers,omitempty"`
-	IdentifyingProperties []string               `json:"identifyingProperties,omitempty"`
-	SecureProperties      []string               `json:"secureProperties,omitempty"`
-	JsonSchema            map[string]interface{} `json:"jsonSchema,omitempty"`
+	Name                  string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	AllowedLayers         []string               `json:"allowedLayers,omitempty" yaml:"allowedLayers,omitempty"`
+	IdentifyingProperties []string               `json:"identifyingProperties,omitempty" yaml:"identifyingProperties,omitempty"`
+	SecureProperties      []string               `json:"secureProperties,omitempty" yaml:"secureProperties,omitempty"`
+	JsonSchema            map[string]interface{} `json:"jsonSchema,omitempty" yaml:"jsonSchema,omitempty"`
 }
 
 type SolutionDef struct {
-	Dependencies []string `json:"dependencies,omitempty"`
-	IsSubscribed bool     `json:"isSubscribed,omitempty"`
-	IsSystem     bool     `json:"isSystem,omitempty"`
-	Name         string   `json:"name,omitempty"`
+	Dependencies []string `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	IsSubscribed bool     `json:"isSubscribed,omitempty" yaml:"isSubscribed,omitempty"`
+	IsSystem     bool     `json:"isSystem,omitempty" yaml:"isSystem,omitempty"`
+	Name         string   `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 type Solution struct {
-	ID             string `json:"id"`
-	LayerID        string `json:"layerId"`
-	LayerType      string `json:"layerType"`
-	ObjectMimeType string `json:"objectMimeType"`
-	TargetObjectId string `json:"targetObjectId"`
-	CreatedAt      string `json:"createdAt"`
-	UpdatedAt      string `json:"updatedAt"`
-	DisplayName    string `json:"displayName"`
+	ID             string `json:"id" yaml:"id"`
+	LayerID        string `json:"layerId" yaml:"layerId"`
+	LayerType      string `json:"layerType" yaml:"layerType"`
+	ObjectMimeType string `json:"objectMimeType" yaml:"objectMimeType"`
+	TargetObjectId string `json:"targetObjectId" yaml:"targetObjectId"`
+	CreatedAt      string `json:"createdAt" yaml:"createdAt"`
+	UpdatedAt      string `json:"updatedAt" yaml:"updatedAt"`
+	DisplayName    string `json:"displayName" yaml:"displayName"`
 }
 
 func (manifest *Manifest) GetNamespaceName() string {

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -25,19 +25,31 @@ import (
 	"github.com/apex/log"
 )
 
+type FileFormat int8
+
+const (
+	FileFormatJSON FileFormat = iota
+	FileFormatYAML
+)
+
+func (f FileFormat) String() string {
+	return [...]string{"json", "yaml"}[f]
+}
+
 type Manifest struct {
-	ManifestVersion string         `json:"manifestVersion,omitempty"`
-	Name            string         `json:"name,omitempty"`
-	SolutionVersion string         `json:"solutionVersion,omitempty"`
-	SolutionType    string         `json:"solutionType,omitempty"`
-	Dependencies    []string       `json:"dependencies"`
-	Description     string         `json:"description,omitempty"`
-	Contact         string         `json:"contact,omitempty"`
-	HomePage        string         `json:"homepage,omitempty"`
-	GitRepoUrl      string         `json:"gitRepoUrl,omitempty"`
-	Readme          string         `json:"readme,omitempty"`
-	Objects         []ComponentDef `json:"objects,omitempty"`
-	Types           []string       `json:"types,omitempty"`
+	ManifestVersion string         `json:"manifestVersion,omitempty" yaml:"manifestVersion,omitempty"`
+	ManifestFormat  FileFormat     `json:"-" yaml:"-"` // not serialized, in memory
+	Name            string         `json:"name,omitempty" yaml:"name,omitempty"`
+	SolutionVersion string         `json:"solutionVersion,omitempty" yaml:"solutionVersion,omitempty"`
+	SolutionType    string         `json:"solutionType,omitempty" yaml:"solutionType,omitempty"`
+	Dependencies    []string       `json:"dependencies" yaml:"dependencies"`
+	Description     string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Contact         string         `json:"contact,omitempty" yaml:"contact,omitempty"`
+	HomePage        string         `json:"homepage,omitempty" yaml:"homepage,omitempty"`
+	GitRepoUrl      string         `json:"gitRepoUrl,omitempty" yaml:"gitRepoUrl,omitempty"`
+	Readme          string         `json:"readme,omitempty" yaml:"readme,omitempty"`
+	Objects         []ComponentDef `json:"objects,omitempty" yaml:"objects,omitempty"`
+	Types           []string       `json:"types,omitempty" yaml:"types,omitempty"`
 }
 
 type ComponentDef struct {

--- a/cmd/solution/upload.go
+++ b/cmd/solution/upload.go
@@ -64,7 +64,7 @@ func bumpSolutionVersionInManifest(cmd *cobra.Command, manifest *Manifest, manif
 	if err := bumpManifestPatchVersion(manifest); err != nil {
 		log.Fatal(err.Error())
 	}
-	if err := writeSolutionManifest(manifestPath, manifest); err != nil {
+	if err := saveSolutionManifest(manifestPath, manifest); err != nil {
 		log.Fatalf("Failed to update solution manifest in %q after version bump: %v", manifestPath, err)
 	}
 	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution version updated to %v\n", manifest.SolutionVersion))

--- a/output/output.go
+++ b/output/output.go
@@ -111,6 +111,16 @@ func WriteJson(obj interface{}, w io.Writer) error {
 	return err
 }
 
+func WriteYaml(obj interface{}, w io.Writer) error {
+	data, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = w.Write(data)
+	return err
+}
+
 // PrintJson displays the output in prettified JSON
 func PrintJson(cmd *cobra.Command, v any) error {
 	return WriteJson(v, GetOutWriter(cmd))


### PR DESCRIPTION
## Description

Added support for YAML files in solutions. 

Added a new command, `solution fix` to make common changes to solutions.

## Details

1. When doing `solution init`, you can now provide a `--yaml` flag, which will make the manifest saved in a YAML format. A solution can have only one manifest, either YAML or JSON (having both will produce an error)
2. When adding new objects with `solution extend --add-xxx`, new objects are now added in the same format as the manifest. (You can also override this by specifying a `--json` or `--yaml` flag to get the object created with a different format; mostly for those who what to try the YAML format but not ready to switch the whole solution)
3. There is also a new command fsoc solution fix which, similar to go fix (in Go) and cargo fix (in Rust), will make common adjustments to your solution to adapt to recent changes in platform capabilities. We now support two "fixes":
`--manifest-format=yaml|json` -- will rewrite your solution's manifest to the desired format
`--manifest-version` -- will convert and rewrite your manifest into the latest manifest version (`1.1.0` from `1.0.0`), adding the solution type as needed.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
