### PR TITLE
added check for empty file on melt send

### DIFF
--- a/cmd/melt/send.go
+++ b/cmd/melt/send.go
@@ -85,6 +85,10 @@ func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
 	if err != nil {
 		log.Fatalf("Can't open data file %q: %v", dataFileName, err)
 	}
+	if fsoData == nil {
+		log.Fatalf("Failed to load data from file %q: empty file", dataFileName)
+		panic("unreachable") // unreachable, keep glanci-lint happy for using fsoData below
+	}
 
 	for _, entity := range fsoData.Melt {
 		if _, ok := entity.Attributes["telemetry.sdk.name"]; ok {


### PR DESCRIPTION
## Description

Fixes a crash in `fsoc melt send` when used with an empty yaml file. (Unlike empty json files that produce Unmarshalling error, empty yaml files are valid but can return nil.)

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
