### PR TITLE
ORION-3135: add deletion info in solution status

### DIFF
--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -86,7 +86,7 @@ func getSolutionStatusCmd() *cobra.Command {
 	solutionStatusCmd.Flags().
 		String("status-type", "", "The status type that you want to see.  This can be one of [upload, install, all] and will default to all if not specified")
 
-	_ = solutionStatusCmd.Flags().MarkDeprecated("status-type", "By default, full status will be displayed from now on.")
+	_ = solutionStatusCmd.Flags().MarkDeprecated("status-type", "full status will be displayed from now on by default.")
 
 	solutionStatusCmd.Flags().
 		String("tag", "", "The tag associated with the solution for which you would like to view the status for")

--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Cisco Systems, Inc.
+// Copyright 2024 Cisco Systems, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -262,7 +262,6 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	solutionInstallSuccessfulFilter = `data.isSuccessful eq "true"`
 	solutionVersionFilter = fmt.Sprintf(`data.solutionVersion eq "%s"`, solutionVersion)
 	solutionIDFilter = fmt.Sprintf(`data.solutionID eq "%s"`, solutionID)
-	log.Infof(`value of solutionID filter: %s`, solutionIDFilter)
 
 	if solutionVersion != "" {
 		solutionInstallObjectFilter = fmt.Sprintf(`%s and %s`, solutionVersionFilter, solutionIDFilter)
@@ -276,8 +275,6 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	solutionInstallObjectQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(solutionInstallObjectFilter))
 	successfulSolutionInstallObjectQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(lastSuccesfulInstallFilter))
 	solutionReleaseObjectQuery := fmt.Sprintf("?order=%s&filter=%s&max=1", url.QueryEscape("desc"), url.QueryEscape(solutionReleaseObjectFilter))
-
-	log.Infof(`solution name and version query: %s`, solutionInstallObjectQuery)
 
 	fetchValuesAndPrint(statusTypeToFetch, solutionInstallObjectQuery, solutionReleaseObjectQuery, successfulSolutionInstallObjectQuery, solutionID, solutionName, solutionTag, headers, cmd)
 

--- a/cmd/solution/zap.go
+++ b/cmd/solution/zap.go
@@ -105,7 +105,13 @@ func zapSolution(cmd *cobra.Command, args []string) {
 		solutionInstallObjectChan <- getObjects(fmt.Sprintf(getSolutionInstallUrl(), solutionInstallObjectQuery), headers)
 	}()
 	go func() {
-		solutionObjectChan <- getExtensibilitySolutionObject(getSolutionObjectUrl(solutionId), headers)
+		solutionObject, err := getExtensibilitySolutionObject(getSolutionObjectUrl(solutionId), headers)
+
+		if err != nil {
+			log.Fatalf("Error getting solution object: %v", err)
+		}
+
+		solutionObjectChan <- solutionObject
 	}()
 
 	solutionInstallObject := <-solutionInstallObjectChan


### PR DESCRIPTION
## Description

This PR adds support for including info about the solution if it has been deleted in fsoc solution status.  In the case where the extensibility:solution object returns 404 when making a GET request, we will check to see if there is an extensibility:solutionDeletion object for the given solutionName and tag.  If there is, then we print a helpful message saying that the solution was previously deleted.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
