### PR TITLE
initial support for .tag files for native isolation

### DIFF
--- a/cmd/melt/model.go
+++ b/cmd/melt/model.go
@@ -27,8 +27,8 @@ var meltModelCmd = &cobra.Command{
 }
 
 func init() {
-	meltModelCmd.Flags().String("tag", "", "tag for the solution")
-	meltModelCmd.Flags().String("env-file", "./env.json", "path to the env vars json file")
+	meltModelCmd.Flags().String("tag", "", "tag for the solution (only for pseudo-isolated solutions, DEPRECATED)")
+	meltModelCmd.Flags().String("env-file", "./env.json", "path to the env vars json file (only for pseudo-isolated solutions, DEPRECATED)")
 
 	meltModelCmd.MarkFlagsMutuallyExclusive("tag", "env-file")
 
@@ -40,10 +40,10 @@ func meltModel(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Fatalf("Failed to get manifest: %v", err)
 	}
-	if manifest.HasIsolation() {
+	if manifest.HasPseudoIsolation() {
 
 		if !(cmd.Flags().Changed("tag") || cmd.Flags().Changed("env-file")) {
-			log.Fatal("One of the required tags (--tag or --env-file) required for isolation support is missing!")
+			log.Fatal("One of the required tags (--tag or --env-file) required for pseudo-isolation support is missing!")
 		}
 
 		tag, _ := cmd.Flags().GetString("tag")

--- a/cmd/solution/embed-isolate.go
+++ b/cmd/solution/embed-isolate.go
@@ -92,6 +92,17 @@ func embeddedConditionalIsolate(cmd *cobra.Command, sourceDir string) (string, s
 	return targetDir, tag, nil
 }
 
+// determineTagEnvFile returns the tag value and the optional env file path.
+// Note that the --env-file flag has priority over the FSOC_SOLUTION_TAG env var and the .tag file, just like --tag.
+// The priority is:
+//  1. --tag value or --stable flag
+//  2. env file if specified explicitly with the --env-file flag
+//  3. FSOC_SOLUTION_TAG env var
+//  4. .tag file in the solution directory
+//  5. env.json file in the solution directory (implied name)
+//
+// This code duplicates the logic of getEmbeddedTag() to allow support for env files.
+// The function, along with the entire source file, will be removed once the pseudo-isolation support is removed.
 func determineTagEnvFile(cmd *cobra.Command, sourceDir string) (string, string) {
 	// if --tag flag is specified, this overrides everything
 	if cmd.Flags().Changed("tag") {
@@ -105,30 +116,41 @@ func determineTagEnvFile(cmd *cobra.Command, sourceDir string) (string, string) 
 		return "stable", ""
 	}
 
-	// if env var with tag is defined, it overrides env file
-	envTag, found := os.LookupEnv("FSOC_SOLUTION_TAG")
-	if found {
-		return envTag, ""
+	// prepare the env file filename, but don't read it yet
+	envFileSpecified := cmd.Flags().Changed("env-file")
+	envFilePath := ""
+	if envFileSpecified {
+		envFilePath, _ = cmd.Flags().GetString("env-file")
+	} else {
+		envFilePath = filepath.Join(sourceDir, "env.json")
 	}
 
-	// try to determine env.json file path
-	fnameSpecified := cmd.Flags().Changed("env-file")
-	fname := ""
-	if fnameSpecified {
-		fname, _ = cmd.Flags().GetString("env-file")
-	} else {
-		fname = filepath.Join(sourceDir, "env.json")
-	}
-	if fname != "" {
-		_, err := os.Stat(fname)
+	// ignore other methods if env file is explicitly specified
+	if !envFileSpecified {
+		// if env var with tag is defined, it overrides env file
+		envTag, found := os.LookupEnv("FSOC_SOLUTION_TAG")
+		if found {
+			return envTag, ""
+		}
+
+		tagFile := filepath.Join(sourceDir, TagFileName)
+		tagBytes, err := os.ReadFile(tagFile) // ok if no file or empty file
 		if err == nil {
-			return "", fname
+			return strings.TrimSpace(string(tagBytes)), ""
 		}
 	}
-	if fnameSpecified {
-		log.Fatalf("Env file %q not found", fname)
+
+	// return env file
+	if envFilePath != "" {
+		_, err := os.Stat(envFilePath)
+		if err == nil {
+			return "", envFilePath
+		}
+	}
+	if envFileSpecified {
+		log.Fatalf("Env file %q specified but not found", envFilePath)
 	}
 
-	log.Fatalf("Tag must be specified (--tag, --stable, FSOC_SOLUTION_TAG env var or env.json file)")
+	log.Fatalf("A tag for pseudo-isolation must be specified (--tag, --stable, FSOC_SOLUTION_TAG env var, .tag or env.json file)")
 	return "", "" // should never happen, keep linters happy
 }

--- a/cmd/solution/embed-isolate.go
+++ b/cmd/solution/embed-isolate.go
@@ -34,7 +34,7 @@ import (
 // To perform isolation without command dependencies, use isolateSolution().
 func embeddedConditionalIsolate(cmd *cobra.Command, sourceDir string) (string, string, error) {
 	// finalize flags (regardless of isolation)
-	tag, envVarsFile := determineTagEnvFile(cmd, sourceDir)
+	tag, envVarsFile := DetermineTagEnvFile(cmd, sourceDir)
 
 	// don't try to isolate if --no-isolate is specified (ignored if flag not defined)
 	noIsolate, _ := cmd.Flags().GetBool("no-isolate")
@@ -92,7 +92,7 @@ func embeddedConditionalIsolate(cmd *cobra.Command, sourceDir string) (string, s
 	return targetDir, tag, nil
 }
 
-// determineTagEnvFile returns the tag value and the optional env file path.
+// DetermineTagEnvFile returns the tag value and the optional env file path.
 // Note that the --env-file flag has priority over the FSOC_SOLUTION_TAG env var and the .tag file, just like --tag.
 // The priority is:
 //  1. --tag value or --stable flag
@@ -101,9 +101,11 @@ func embeddedConditionalIsolate(cmd *cobra.Command, sourceDir string) (string, s
 //  4. .tag file in the solution directory
 //  5. env.json file in the solution directory (implied name)
 //
+// Deprecated:
 // This code duplicates the logic of getEmbeddedTag() to allow support for env files.
 // The function, along with the entire source file, will be removed once the pseudo-isolation support is removed.
-func determineTagEnvFile(cmd *cobra.Command, sourceDir string) (string, string) {
+// This function is exported for use by `melt model` when modeling data from pseudo-isolated solutions.
+func DetermineTagEnvFile(cmd *cobra.Command, sourceDir string) (string, string) {
 	// if --tag flag is specified, this overrides everything
 	if cmd.Flags().Changed("tag") {
 		tag, _ := cmd.Flags().GetString("tag")

--- a/cmd/solution/isolate.go
+++ b/cmd/solution/isolate.go
@@ -186,7 +186,7 @@ func isolateSolution(cmd *cobra.Command, srcFolder, targetFolder, targetFile, ta
 
 	log.Info("Pseudo-isolation successfully completed")
 
-	return mf.Name, GetTag(envVars), nil
+	return mf.Name, GetPseudoIsolationTag(envVars), nil
 }
 
 func prepareForIsolation(srcPath, targetPath, targetFile string, envVars interface{}) error {
@@ -317,7 +317,7 @@ func LoadEnvVars(cmd *cobra.Command, tag, envVarsFile string) (interface{}, erro
 	return envVars, nil
 }
 
-func GetTag(envVars interface{}) string {
+func GetPseudoIsolationTag(envVars interface{}) string {
 	if root, ok := envVars.(map[string]any); ok {
 		if env, ok := root["env"].(map[string]any); ok {
 			if tag, ok := env["tag"].(string); ok && tag != "" {

--- a/cmd/solution/package.go
+++ b/cmd/solution/package.go
@@ -41,10 +41,12 @@ var solutionPackageCmd = &cobra.Command{
 The input is a solution directory, defaulting to the current working directory.
 The output is either a directory path (in which a fsoc will create the zip file) or path to the zip flie to create.
 
-If fsoc-based solution pseudo-isolation is desired, then
-use the --tag, --stable or --env-file flags. Isolation is automatically enabled if ${} substitution 
-is present in the solution name in the manifest file. There are several ways to specify the tags, based
-on convenience and use cases. The following priority is available:
+Note that when using native solution isolation, there is no need to define a tag, as the package is not tag-specific.
+
+If fsoc-based solution pseudo-isolation is used, then use the --tag, --stable or --env-file flags. 
+Pseudo-isolation is automatically enabled if ${} substitution is present in the solution name in the
+manifest file. There are several ways to specify the tags, based on convenience and use cases. 
+The following priority is available:
 1. --tag=xyz or --stable: use this tag, ignoring env file or env vars
 2. A tag is defined in the FSOC_SOLUTION_TAG environment variable (ignores env file)
 3. An explicitly provided --env-file path
@@ -65,7 +67,7 @@ func getSolutionPackageCmd() *cobra.Command {
 		StringP("directory", "d", "", "Path to the solution root directory (defaults to current dir)")
 
 	solutionPackageCmd.Flags().
-		String("tag", "", "Isolation tag to use if using fsoc isolation; if specified, overrides env.json")
+		String("tag", "", "Isolation tag to use if using fsoc isolation; if specified, takes precedence over env vars and .tag file")
 	solutionPackageCmd.Flags().
 		Bool("stable", false, "Mark the solution as production-ready.  This is equivalent to supplying --tag=stable")
 	solutionPackageCmd.Flags().
@@ -201,7 +203,7 @@ func generateZip(cmd *cobra.Command, solutionPath string, outputPath string) *os
 
 func isAllowedPath(path string, info os.FileInfo) bool {
 	// blacklist files by adding them here.
-	excludeFiles := []string{".DS_Store"}
+	excludeFiles := []string{".DS_Store", TagFileName} // .tag files should not be included in the zip
 	// blacklist paths by adding them here.
 	excludePaths := []string{".git"}
 	allow := true

--- a/cmd/solution/push.go
+++ b/cmd/solution/push.go
@@ -26,10 +26,15 @@ var solutionPushCmd = &cobra.Command{
 The solution manifest for the solution must be in the current directory.
 
 Important details on solution tags:
-(1) A tag must be associated with the solution being uploaded.  All subsequent solution upload requests should use this same tag
-(2) Use caution when supplying the tag value to the solution to upload as typos can result in misleading validation results
-(3) 'stable' is a reserved tag value keyword for production-ready versions and hence should be used appropriately
-(4) For more info on tags, please visit: https://developer.cisco.com/docs/cisco-observability-platform/#!tag-a-solution
+  1. A tag must be associated with the solution being uploaded.  All subsequent solution upload requests should use this same tag
+  2. Use caution when supplying the tag value to the solution to upload as typos can result in misleading validation results
+  3. "stable" is a reserved tag value keyword for production-ready versions and hence should be used appropriately
+  4. For more info on tags, please visit: https://developer.cisco.com/docs/cisco-observability-platform/#!tag-a-solution
+
+A tag may be defined in the following ways (in order of precedence):
+  1. Specified flag --tag=xyz or --stable: use this tag, ignoring .tag file or env vars
+  2. A tag is defined in the FSOC_SOLUTION_TAG environment variable (ignores .tag file)
+  3. A tag is defined in the .tag file in the solution directory (usually not version controlled)
 `,
 	Example: `
   fsoc solution push --tag=stable
@@ -42,11 +47,7 @@ Important details on solution tags:
 }
 
 func getSolutionPushCmd() *cobra.Command {
-	solutionPushCmd.Flags().
-		String("tag", "", "Free-form string tag to associate with provided solution")
-
-	solutionPushCmd.Flags().
-		Bool("stable", false, "Mark the solution as production-ready.  This is equivalent to supplying --tag=stable")
+	addTagFlags(solutionPushCmd) // --tag and --stable
 
 	solutionPushCmd.Flags().IntP("wait", "w", -1, "Wait (in seconds) for the solution to be deployed")
 	solutionPushCmd.Flag("wait").NoOptDefVal = "300"
@@ -61,10 +62,10 @@ func getSolutionPushCmd() *cobra.Command {
 		String("solution-bundle", "", "Path to a prepackaged solution zip")
 
 	solutionPushCmd.Flags().
-		String("env-file", "", "Path to the env vars json file with isolation tag and, optionally, dependency tags")
+		String("env-file", "", "Path to the env vars json file with pseudo-isolation tag and, optionally, dependency tags (DEPRECATED)")
 
 	solutionPushCmd.Flags().
-		Bool("no-isolate", false, "Disable fsoc-supported solution isolation")
+		Bool("no-isolate", false, "Disable fsoc-supported solution pseudo-isolation")
 
 	solutionPushCmd.Flags().
 		Bool("subscribe", false, "Subscribe to the solution that you are pushing")
@@ -73,7 +74,7 @@ func getSolutionPushCmd() *cobra.Command {
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")      // cannot modify prepackaged zip
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "wait")      // TODO: allow when extracting manifest data
 	solutionPushCmd.MarkFlagsMutuallyExclusive("solution-bundle", "subscribe") // TODO: allow when extracting manifest data
-	solutionPushCmd.MarkFlagsMutuallyExclusive("tag", "stable", "env-file")    // stable is an alias for --tag=stable
+	solutionPushCmd.MarkFlagsMutuallyExclusive("tag", "stable", "env-file")
 
 	return solutionPushCmd
 }

--- a/cmd/solution/tag.go
+++ b/cmd/solution/tag.go
@@ -1,0 +1,119 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+)
+
+const TagFileName = ".tag" // tag file in solution directory, similar to .env files; should NOT be version controlled
+
+func addTagFlags(cmd *cobra.Command) {
+	cmd.Flags().String("tag", "", "Tag to use for solution isolation")
+	cmd.Flags().Bool("stable", false, "Use the stable tag for solution isolation. Equivalent to --tag=stable")
+	cmd.MarkFlagsMutuallyExclusive("tag", "stable")
+}
+
+// getEmbeddedTag returns the tag to use for solution isolation for all commands that
+// work with the solution directory.
+// The tag is determined based on the following priority:
+// 1. Specified flag `--tag=xyz` or `--stable“: use this tag, ignoring .tag file or env vars
+// 2. A tag is defined in the FSOC_SOLUTION_TAG environment variable (ignores .tag file)
+// 3. A tag is defined in the .tag file in the solution directory (usually not version controlled)
+func getEmbeddedTag(cmd *cobra.Command, solutionPath string) (string, error) {
+	tag, _ := cmd.Flags().GetString("tag")
+	stable, _ := cmd.Flags().GetBool("stable")
+	method := "--tag flag"
+
+	if tag == "" && stable {
+		tag = "stable"
+		method = "--stable flag"
+	}
+
+	if tag == "" {
+		tag = os.Getenv("FSOC_SOLUTION_TAG")
+		method = "FSOC_SOLUTION_TAG env var"
+	}
+
+	if tag == "" {
+		tagFile := filepath.Join(solutionPath, TagFileName)
+		tagBytes, err := os.ReadFile(tagFile) // ok if no file or empty file
+		if err == nil {
+			tag = strings.TrimSpace(string(tagBytes))
+			method = ".tag file"
+			if tag != "" {
+				checkTagFileIgnored(tagFile) // warn if .tag file may be checked in (unless empty)
+			}
+		}
+	}
+
+	if tag == "" {
+		return "", fmt.Errorf("a non-empty tag must be specified for this command; see command help for options")
+	}
+	if !IsValidSolutionTag(tag) {
+		return "", fmt.Errorf("tag %q, specified in the %s, is invalid", tag, method)
+	}
+
+	log.WithFields(log.Fields{"tag": tag, "source": method}).Info("Using tag for solution isolation")
+
+	return tag, nil
+}
+
+// IsValidTag checks if a tag is valid for use in solution isolation.
+// A valid tag is a non-empty string that starts with an ASCII letter and
+// contains only lowercase ASCII letters and digits, for a max of 10 characters.
+// TODO: add link to documentation on tags
+func IsValidSolutionTag(tag string) bool {
+	if tag == "" {
+		return false
+	}
+	if len(tag) > 10 {
+		return false
+	}
+	match, err := regexp.Match(`^[A-Za-z][a-z0-9]*$`, []byte(tag))
+	if !match || err != nil {
+		return false
+	}
+
+	return true
+}
+
+// checkTagFileIgnored checks if the .tag file is properly excluded from solution's
+// git repository; if not excluded, warns the user. This function assumes that the
+// tag file exists (otherwise, it shouldn't be called).
+func checkTagFileIgnored(tagFilePath string) {
+	// use git to verify if the file is ignored
+	cmd := exec.Command("git", "check-ignore", "-q", tagFilePath)
+	if err := cmd.Run(); err != nil {
+		// if git exits with a non-zero exit status, it could mean the file is not ignored or there was another error
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			// exit code 1 means specifically that the file is not ignored
+			if exitErr.ExitCode() == 1 {
+				log.Warnf("Warning: The %s file is not ignored by git in this solution's repository. .tag files should not be checked in. Consider adding it to .gitignore", TagFileName)
+			}
+			// ignore other errors, including "not a git repo" or no git installed
+		}
+	}
+
+	// If the command exited with status 0, the file is ignored, all good
+}

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -91,7 +91,7 @@ type Solution struct {
 
 func (manifest *Manifest) GetNamespaceName() string {
 	namespaceName := manifest.Name
-	if manifest.HasIsolation() {
+	if manifest.HasPseudoIsolation() {
 		namespaceName = "${sys.solutionId}"
 	}
 	return namespaceName
@@ -99,13 +99,13 @@ func (manifest *Manifest) GetNamespaceName() string {
 
 func (manifest *Manifest) GetSolutionName() string {
 	solutionName := manifest.Name
-	if manifest.HasIsolation() {
+	if manifest.HasPseudoIsolation() {
 		solutionName = strings.Split(manifest.Name, "${")[0]
 	}
 	return solutionName
 }
 
-func (manifest *Manifest) HasIsolation() bool {
+func (manifest *Manifest) HasPseudoIsolation() bool {
 	return strings.Contains(manifest.Name, "${")
 }
 
@@ -228,7 +228,7 @@ func (manifest *Manifest) GetComponentDefs(typeName string) []ComponentDef {
 	var componentDefs []ComponentDef
 	typeConvention := strings.Split(typeName, ":")
 	depIsolation := fmt.Sprintf("${$dependency('%s')}", typeConvention[0])
-	if manifest.HasIsolation() && manifest.CheckDependencyExists(depIsolation) {
+	if manifest.HasPseudoIsolation() && manifest.CheckDependencyExists(depIsolation) {
 		typeName = fmt.Sprintf("%s:%s", depIsolation, typeConvention[1])
 	}
 

--- a/cmd/solution/validate.go
+++ b/cmd/solution/validate.go
@@ -49,11 +49,7 @@ var solutionValidateCmd = &cobra.Command{
 }
 
 func getSolutionValidateCmd() *cobra.Command {
-	solutionValidateCmd.Flags().
-		String("tag", "", "Tag to associate with provided solution.  Ensure tag used for validation & upload are same.")
-
-	solutionValidateCmd.Flags().
-		Bool("stable", false, "Automatically associate the 'stable' tag with solution to validate.  This should only be used for validating solutions uploaded with the 'stable' tag.")
+	addTagFlags(solutionValidateCmd) // tag, stable
 
 	solutionValidateCmd.Flags().
 		BoolP("bump", "b", false, "Increment the patch version before validation")
@@ -65,10 +61,10 @@ func getSolutionValidateCmd() *cobra.Command {
 		String("solution-bundle", "", "Path to a prepackaged solution zip")
 
 	solutionValidateCmd.Flags().
-		String("env-file", "", "Path to the env vars json file with isolation tag and, optionally, dependency tags")
+		String("env-file", "", "Path to the env vars json file with pseudo-isolation tag and, optionally, dependency tags (DEPRECATED)")
 
 	solutionValidateCmd.Flags().
-		Bool("no-isolate", false, "Disable fsoc-supported solution isolation")
+		Bool("no-isolate", false, "Disable fsoc-supported solution pseudo-isolation")
 
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "directory")
 	solutionValidateCmd.MarkFlagsMutuallyExclusive("solution-bundle", "bump")

--- a/cmd/solution/zap.go
+++ b/cmd/solution/zap.go
@@ -46,7 +46,6 @@ func getSolutionZapCmd() *cobra.Command {
 
 	solutionZapCmd.Flags().
 		String("tag", "", "Tag associated with the solution to zap (required)")
-
 	_ = solutionZapCmd.MarkFlagRequired("tag")
 
 	solutionZapCmd.Flags().
@@ -151,6 +150,8 @@ func zapSolution(cmd *cobra.Command, args []string) {
 	solutionZipPath = solutionArchive.Name()
 	defer os.RemoveAll(solutionZipPath)
 
+	// upload the hollowed-out solution
+	// Note that since the tag flag is REQUIRED in this command, the FSOC_SOLUTION_TAG env var and any locally present .tag file will be ignored
 	uploadSolution(cmd, true, WithSolutionName(solutionName), WithSolutionZipPath(solutionZipPath), WithSolutionInstallVersion(updatedManifestVersion))
 
 	output.PrintCmdStatus(cmd, fmt.Sprintf("Solution with name: %s and tag: %s zapped\n", solutionName, solutionTag))


### PR DESCRIPTION
## Description

Added support for default solution tag for `push`, `validate` and a few others to be taken from a `.tag` file in the solution directory, similar to `.env` files. This default tag eliminates the need to always specify the `--tag` value when pushing developer-specific solution versions, reducing effort and likelihood of mistakes. In addition, the use of `FSOC_SOLUTION_TAG` environment variable is now extended to solutions with native isolation.

The tag priority, from highest to lowest:
1. Explicit flag `--tag=value` (or `--stable`, which means `--tag=stable`)
2. Environment variable `FSOC_SOLUTION_TAG` set to a non-empty tag value
3. Tag found in a `.tag` file in the same directory as the solution manifest

Note that this default tag applies only to commands that (a) need a tag value and (b) rely on the presence of a solution in the directory (i.e., manifest and objects). This specifically excludes commands, such as `subscribe`, which also take tags but don't need local solution files, as well as commands like `solution extend`, which require local files but not tags.

Note that the `.tag` file is a developer convenience (just like the environment variable) and, as such, will not be included in solution's bundle. Additionally, as the workflow intent is for `.tag` files to be local/per developer, fsoc will warn if the `.tag` file in the solution is not excluded in .gitignore (in cases the solution is in a git repo), to reduce the chance of inadvertently checking the `.tag` file into the solution repo.

The support for `.tag` file is also propagated to pseudo-isolated solutions, in order to allow moving away from env.json-type files and aligning with native isolation. For pseudo-isolation, which is now deprecated and new solutions should not use, the priorities include:
...
1.5. Explicit flag `--env-file`
...
4. Presence of `env.json` in the solution root directory.

Note that support for env files remains available only for pseudo-isolation and is expected to be removed with it. This streamlines the tag support and also avoids conflict and confusion with `env/` directory files used in native isolation.

This is a non-breaking change.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
