### PR TITLE
support for context and quiet mode in platform calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/moby/term v0.5.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/itchyny/timefmt-go v0.1.5 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/moby/term v0.5.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/platform/api/call_test.go
+++ b/platform/api/call_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -14,17 +15,11 @@ func TestPrepareHTTPRequest(t *testing.T) {
 	cfg := &config.Context{
 		URL: "http://localhost:8080",
 	}
-	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil)
-	assert.Nil(t, err)
-	assert.Equal(t, "http://localhost:8080/test/path/1", req.URL.String())
-}
-
-func TestPrepareJSONRequest(t *testing.T) {
-	client := &http.Client{}
-	cfg := &config.Context{
-		URL: "http://localhost:8080",
+	callCtx := &callContext{
+		goContext: context.Background(),
+		cfg:       cfg,
 	}
-	req, err := prepareHTTPRequest(cfg, client, "POST", "/test/path/1", nil, nil)
+	req, err := prepareHTTPRequest(callCtx, client, "POST", "/test/path/1", nil, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, "http://localhost:8080/test/path/1", req.URL.String())
 }

--- a/platform/api/context.go
+++ b/platform/api/context.go
@@ -23,7 +23,7 @@ import (
 	"github.com/apex/log"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
-	"github.com/mattn/go-isatty"
+	"golang.org/x/term"
 
 	"github.com/cisco-open/fsoc/config"
 )
@@ -55,7 +55,7 @@ func newCallContext(goContext context.Context, quiet bool) *callContext {
 
 	// create spinner if needed
 	var spinnerObj *spinner.Spinner
-	if !quiet && !isatty.IsTerminal(os.Stderr.Fd()) {
+	if !quiet && term.IsTerminal(int(os.Stderr.Fd())) {
 		spinnerObj = spinner.New(spinner.CharSets[21], 50*time.Millisecond, spinner.WithWriterFile(os.Stderr))
 	}
 

--- a/platform/api/login.go
+++ b/platform/api/login.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -51,7 +52,7 @@ var fieldToFlag = map[string]string{
 // Login respects different access profile types (when supported) to provide the correct
 // login mechanism for each.
 func Login() error {
-	callCtx := newCallContext()
+	callCtx := newCallContext(context.Background(), false)
 	defer callCtx.stopSpinner(false) // ensure not running when returning
 
 	return login(callCtx)

--- a/platform/api/proxy.go
+++ b/platform/api/proxy.go
@@ -39,7 +39,7 @@ func RunProxyServer(port int, command []string, statusPrinter func(string), exit
 	}
 
 	// Create a new call context
-	callCtx := newCallContext()
+	callCtx := newCallContext(context.Background(), false)
 	cfg := callCtx.cfg // quick access to config
 
 	// force login if no token


### PR DESCRIPTION
## Description

Internal changes in fsoc that allow callers of the platform package to modify the platform API calls they make:
* specify a go Context (e.g., to control timeouts and cancellations)
* suppress the progress message and spinner shown during calls

In addition, the spinner is now not even created when stderr is not a terminal. (This should not be a user-visible change, since the spinner package already doesn't show the message if the output is not a terminal.)

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
