### PR TITLE
Proper support for fork + for from directory + solution show

### DIFF
--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Cisco Systems, Inc.
+// Copyright 2024 Cisco Systems, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,18 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package solution
 
 import (
-	"archive/zip"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/apex/log"
-	"github.com/spf13/afero"
-	"github.com/spf13/afero/zipfs"
 	"github.com/spf13/cobra"
 
 	"github.com/cisco-open/fsoc/config"
@@ -118,23 +116,4 @@ func DownloadSolutionPackage(name string, tag string, targetPath string) (string
 
 func getSolutionDownloadUrl(solutionName string) string {
 	return fmt.Sprintf("solution-manager/v1/solutions/%s", solutionName)
-}
-
-func ExtractZipToDirectory(archive string, targetFs afero.Fs) error {
-	archiveFile, err := os.OpenFile(archive, os.O_RDONLY, os.FileMode(0644))
-	if err != nil {
-		return fmt.Errorf("error opening zip file: %w", err)
-	}
-	defer archiveFile.Close()
-
-	archiveFileInfo, err := os.Stat(archive)
-	if err != nil {
-		return fmt.Errorf("error determining zip file size: %w", err)
-	}
-
-	reader, _ := zip.NewReader(archiveFile, archiveFileInfo.Size())
-	zipFileSystem := zipfs.New(reader)
-	dirInfo, _ := afero.ReadDir(zipFileSystem, "./")
-	err = copyFolderToLocal(zipFileSystem, targetFs, dirInfo[0].Name())
-	return err
 }

--- a/cmd/solution/fork-legacy.go
+++ b/cmd/solution/fork-legacy.go
@@ -160,6 +160,25 @@ func downloadSolutionZip(cmd *cobra.Command, solutionName string, solutionTag st
 	}
 }
 
+func ExtractZipToDirectory(archive string, targetFs afero.Fs) error {
+	archiveFile, err := os.OpenFile(archive, os.O_RDONLY, os.FileMode(0644))
+	if err != nil {
+		return fmt.Errorf("error opening zip file: %w", err)
+	}
+	defer archiveFile.Close()
+
+	archiveFileInfo, err := os.Stat(archive)
+	if err != nil {
+		return fmt.Errorf("error determining zip file size: %w", err)
+	}
+
+	reader, _ := zip.NewReader(archiveFile, archiveFileInfo.Size())
+	zipFileSystem := zipfs.New(reader)
+	dirInfo, _ := afero.ReadDir(zipFileSystem, "./")
+	err = copyFolderToLocal(zipFileSystem, targetFs, dirInfo[0].Name())
+	return err
+}
+
 func copyFolderToLocal(zipFileSystem afero.Fs, localFileSystem afero.Fs, subDirectory string) error {
 	dirInfo, err := afero.ReadDir(zipFileSystem, subDirectory)
 	if err != nil {

--- a/cmd/solution/fork-legacy.go
+++ b/cmd/solution/fork-legacy.go
@@ -1,0 +1,215 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/afero"
+	"github.com/spf13/afero/zipfs"
+	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/fsoc/output"
+	"github.com/cisco-open/fsoc/platform/api"
+)
+
+// Legacy algorithm to fork a solution using global string replace and assuming json manifest
+// Remove this code, together with the `--legacy-replace` flag, once the new solution is proven to work well
+
+func legacyFork(cmd *cobra.Command, solutionName string, solutionTag string, forkName string, fileSystemRoot afero.Fs, fileSystem afero.Fs) {
+	// download the solution zip file to the current directory
+	downloadSolutionZip(cmd, solutionName, solutionTag, forkName)
+
+	message := fmt.Sprintf("Solution %s was successfully downloaded in the this directory.\r\n", solutionName)
+	output.PrintCmdStatus(cmd, message)
+
+	message = fmt.Sprintf("Changing solution name in manifest to %s.\r\n", forkName)
+	output.PrintCmdStatus(cmd, message)
+
+	// extract files into the newly created solution directory
+	err := extractZip(fileSystemRoot, fileSystem, solutionName)
+	if err != nil {
+		log.Fatalf("Failed to copy files from the zip file to current directory: %v", err)
+	}
+
+	// global replace of solution name in all files in place
+	editManifest(fileSystem, forkName)
+
+	// cleanup the zip file (TODO: move to temp folder and skip cleanup)
+	err = fileSystemRoot.Remove("./" + solutionName + ".zip")
+	if err != nil {
+		log.Fatalf("Failed to remove zip file in current directory: %v", err)
+	}
+}
+
+func editManifest(fileSystem afero.Fs, forkName string) {
+	manifestFile, err := afero.ReadFile(fileSystem, "./manifest.json")
+	if err != nil {
+		log.Fatalf("Error opening manifest file: %v", err)
+	}
+
+	var manifest Manifest
+	err = json.Unmarshal(manifestFile, &manifest)
+	if err != nil {
+		log.Errorf("Failed to parse solution manifest: %v", err)
+	}
+
+	err = refactorSolution(fileSystem, &manifest, forkName)
+	if err != nil {
+		log.Errorf("Failed to refactor component definition files within the solution: %v", err)
+	}
+	manifest.Name = forkName
+
+	f, err := fileSystem.OpenFile("./manifest.json", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		log.Fatalf("Can't open manifest file: %v", err)
+	}
+	defer f.Close()
+	err = output.WriteJson(manifest, f)
+	if err != nil {
+		log.Errorf("Failed to to write to solution manifest: %v", err)
+	}
+}
+
+func refactorSolution(fileSystem afero.Fs, manifest *Manifest, forkName string) error {
+	objDefs := manifest.Objects
+	var err error
+	for _, objDef := range objDefs {
+		if objDef.ObjectsFile != "" {
+			err = ReplaceStringInFile(fileSystem, objDef.ObjectsFile, manifest.Name, forkName)
+		} else {
+			wkDir, _ := os.Getwd()
+			dirPath := fmt.Sprintf("%s/%s/%s", wkDir, forkName, objDef.ObjectsDir)
+			err = filepath.Walk(dirPath,
+				func(path string, info os.FileInfo, err error) error {
+					// if err != nil {
+					// 	return err
+					// }
+					if !info.IsDir() {
+						removeStr := fmt.Sprintf("%s/%s/", wkDir, forkName)
+						filePath := strings.ReplaceAll(path, removeStr, "")
+						err = ReplaceStringInFile(fileSystem, filePath, manifest.Name, forkName)
+					}
+					return err
+				})
+		}
+	}
+	return err
+}
+
+func ReplaceStringInFile(fileSystem afero.Fs, filePath string, searchValue string, replaceValue string) error {
+	data, err := afero.ReadFile(fileSystem, filePath)
+	if err != nil {
+		return err
+	}
+	newFileContent := string(data)
+	newFileContent = strings.ReplaceAll(newFileContent, searchValue, replaceValue)
+	err = afero.WriteFile(fileSystem, filePath, []byte(newFileContent), os.FileMode(os.O_RDWR))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func extractZip(rootFileSystem afero.Fs, fileSystem afero.Fs, solutionName string) error {
+	zipFile, err := rootFileSystem.OpenFile("./"+solutionName+".zip", os.O_RDONLY, os.FileMode(0644))
+	if err != nil {
+		log.Fatalf("Error opening zip file: %v", err)
+	}
+	fileInfo, err := rootFileSystem.Stat("./" + solutionName + ".zip")
+	if err != nil {
+		log.Errorf("Err reading zip: %v", err)
+	}
+	reader, _ := zip.NewReader(zipFile, fileInfo.Size())
+	zipFileSystem := zipfs.New(reader)
+	dirInfo, _ := afero.ReadDir(zipFileSystem, "./")
+	err = copyFolderToLocal(zipFileSystem, fileSystem, dirInfo[0].Name())
+	return err
+}
+
+func downloadSolutionZip(cmd *cobra.Command, solutionName string, solutionTag string, forkName string) {
+	var solutionNameWithZipExtension = solutionName + ".zip"
+
+	headers := map[string]string{
+		"stage":            "STABLE", // TODO: check if still needed
+		"tag":              solutionTag,
+		"solutionFileName": solutionNameWithZipExtension,
+	}
+	httpOptions := api.Options{Headers: headers}
+	bufRes := make([]byte, 0)
+	if err := api.HTTPGet(getSolutionDownloadUrl(solutionName), &bufRes, &httpOptions); err != nil {
+		log.Fatalf("Solution download failed: %v", err)
+	}
+}
+
+func copyFolderToLocal(zipFileSystem afero.Fs, localFileSystem afero.Fs, subDirectory string) error {
+	dirInfo, err := afero.ReadDir(zipFileSystem, subDirectory)
+	if err != nil {
+		return err
+	}
+	for i := range dirInfo {
+		zipLoc := subDirectory + "/" + dirInfo[i].Name()
+		localLoc := convertZipLocToLocalLoc(subDirectory + "/" + dirInfo[i].Name())
+		if !dirInfo[i].IsDir() {
+			err = copyFile(zipFileSystem, localFileSystem, zipLoc, localLoc)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = localFileSystem.Mkdir(localLoc, os.ModeDir)
+			if err != nil {
+				return err
+			}
+			println(localLoc)
+			err = localFileSystem.Chmod(localLoc, 0700)
+			if err != nil {
+				return err
+			}
+			err = copyFolderToLocal(zipFileSystem, localFileSystem, zipLoc)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func copyFile(zipFileSystem afero.Fs, localFileSystem afero.Fs, zipLoc string, localLoc string) error {
+	data, err := afero.ReadFile(zipFileSystem, zipLoc)
+	if err != nil {
+		return err
+	}
+	_, err = localFileSystem.Create(localLoc)
+	if err != nil {
+		return err
+	}
+	err = afero.WriteFile(localFileSystem, localLoc, data, os.FileMode(os.O_RDWR))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func convertZipLocToLocalLoc(zipLoc string) string {
+	secondSlashIndex := strings.Index(zipLoc[2:], "/")
+	return zipLoc[secondSlashIndex+3:]
+}

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -158,8 +158,9 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 	log.WithField("temp_solution_dir", sourceDir).Info("Extracting downloaded solution in temp target directory")
 
 	// extract files from the archive into the source directory
+	// Note that archives have a top level directory that should be skipped at extraction)
 	sourceDirFs := afero.NewBasePathFs(afero.NewOsFs(), sourceDir)
-	if err = ExtractZipToDirectory(archivePath, sourceDirFs); err != nil {
+	if err = UnzipToAferoFs(archivePath, sourceDirFs, 1); err != nil {
 		log.Fatalf("Failed to extract downloaded solution archive: %v", err)
 	}
 

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -335,7 +335,7 @@ func ReplaceStringInFile(fileSystem afero.Fs, filePath string, searchValue strin
 // -- New style fork
 // 1. Replaces the solution name only in values but not in keys
 // 2. Replaces the solution name only on word boundaries
-// 3. Omits specical files, such as .tag, from the output solution
+// 3. Omits special files, such as .tag, from the output solution
 // 4. Renames the namespace file if it is the same as the solution name
 // 5. Logs detailed list of changes made to the solution, with key names and old/new values
 

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -212,7 +212,8 @@ func forkFromDisk(sourceDir string, fileSystem afero.Fs, solutionName string, st
 	} else {
 		solution.Manifest.Name = solutionName
 	}
-	statusPrint("Forking %q to %q...", oldName, solutionName)
+	solution.Manifest.SolutionVersion = "1.0.0" // reset version
+	statusPrint("Forking %q to %q (version %v)...", oldName, solutionName, solution.Manifest.SolutionVersion)
 
 	// remove files that should not be carried over, e.g., a .tag file in the root directory
 	err = solution.WalkFiles(func(file *SolutionFile, dir *SolutionSubDirectory) error {

--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -15,7 +15,6 @@
 package solution
 
 import (
-	"archive/zip"
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -26,24 +25,23 @@ import (
 
 	"github.com/apex/log"
 	"github.com/spf13/afero"
-	"github.com/spf13/afero/zipfs"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
 	"github.com/cisco-open/fsoc/config"
 	"github.com/cisco-open/fsoc/output"
-	"github.com/cisco-open/fsoc/platform/api"
 )
 
 const pseudoIsolationSuffix = "${$toSuffix(env.tag)}"
 
 var solutionForkCmd = &cobra.Command{
-	Use:     "fork [<solution-name>|--source-dir=<directory>] <target-name> [flags]",
-	Args:    cobra.MaximumNArgs(2),
-	Short:   "Fork a solution into the specified directory",
-	Long:    `This command downloads the specified solution into the current directory and changes its name to <target-name>`,
-	Example: `  fsoc solution fork spacefleet myfleet`,
-	Run:     solutionForkCommand,
+	Use:   "fork [<solution-name>|--source-dir=<directory>] <target-name> [flags]",
+	Args:  cobra.MaximumNArgs(2),
+	Short: "Fork a solution into the specified directory",
+	Long:  `This command downloads the specified solution into the current directory and changes its name to <target-name>`,
+	Example: `  fsoc solution fork spacefleet myfleet
+  fsoc solution fork --source-dir=spacefleet myfleet`,
+	Run: solutionForkCommand,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) >= 1 {
 			return nil, cobra.ShellCompDirectiveDefault
@@ -62,7 +60,13 @@ func GetSolutionForkCommand() *cobra.Command {
 
 	solutionForkCmd.Flags().StringP("source-dir", "s", "", "directory with a solution to fork from disk")
 	solutionForkCmd.Flags().String("tag", "stable", "tag for the solution to download and fork")
+	solutionForkCmd.MarkFlagsMutuallyExclusive("source-dir", "tag")
+	solutionForkCmd.MarkFlagsMutuallyExclusive("source-dir", "source-name")
+
 	solutionForkCmd.Flags().BoolP("quiet", "q", false, "suppress output")
+
+	solutionForkCmd.Flags().Bool("legacy-replace", false, "use pre-v0.68 fork algorithm (string replacement) (DEPRECATED)")
+	solutionForkCmd.MarkFlagsMutuallyExclusive("legacy-replace", "quiet") // legacy code doesn't support quiet mode
 
 	return solutionForkCmd
 }
@@ -72,6 +76,7 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 	sourceDir, _ := cmd.Flags().GetString("source-dir")
 	solutionName, _ := cmd.Flags().GetString("source-name")
 	forkName, _ := cmd.Flags().GetString("name")
+	solutionTag, _ := cmd.Flags().GetString("tag")
 	if len(args) == 2 {
 		if sourceDir != "" {
 			_ = cmd.Help()
@@ -82,13 +87,18 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 		forkName = args[0]
 	} else if len(args) != 0 {
 		_ = cmd.Help()
-		log.Fatal("Exactly 2 arguments required.")
+		log.Fatal("Incorrect argument syntax.")
 	}
 	if (solutionName == "" && sourceDir == "") || forkName == "" {
 		_ = cmd.Help()
 		log.Fatalf("A source and target must be specified")
 	}
-	forkName = strings.ToLower(forkName)
+	if !IsValidSolutionName(forkName) {
+		log.Fatalf("Invalid solution name %q: must start with a lowercase letter and contain only lowercase letters and digits", forkName)
+	}
+	if !IsValidSolutionTag(solutionTag) {
+		log.Fatalf("Invalid solution tag %q: must start with a lowercase letter and contain only lowercase letters and digits", solutionTag)
+	}
 
 	// create a status printer function closure, based on the quiet flag
 	quiet, _ := cmd.Flags().GetBool("quiet")
@@ -108,15 +118,12 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 		log.Fatalf("Error getting current directory: %v", currentDirectory)
 	}
 	fileSystemRoot := afero.NewBasePathFs(afero.NewOsFs(), currentDirectory)
-	if solutionNameFolderInvalid(fileSystemRoot, forkName) {
+	if createSolutionDirectoryOk(fileSystemRoot, forkName) { // TODO: use code from init
 		log.Fatalf(fmt.Sprintf("A non empty directory with the name %s already exists", forkName))
 	}
 	fileSystem := afero.NewBasePathFs(afero.NewOsFs(), currentDirectory+"/"+forkName)
 
-	if manifestExists(fileSystem, forkName) {
-		log.Fatalf("There is already a manifest file in this directory")
-	}
-
+	// fork from disk (always using the new algorithm with proper word boundaries in values only)
 	if sourceDir != "" {
 		err := forkFromDisk(sourceDir, fileSystem, forkName, statusPrint)
 		if err != nil {
@@ -126,25 +133,46 @@ func solutionForkCommand(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// Download & fork from solution, using legacy fork
+	// Download & fork from solution that's already in the platform
+	// (nb: this works only if the tenant has access to the solution)
 
-	downloadSolutionZip(cmd, solutionName, forkName)
-	err = extractZip(fileSystemRoot, fileSystem, solutionName)
-	if err != nil {
-		log.Fatalf("Failed to copy files from the zip file to current directory: %v", err)
+	// backward compatibility: use the old algorithm that does global string replacement
+	if legacyForkFlag, _ := cmd.Flags().GetBool("legacy-replace"); legacyForkFlag {
+		// use the old algorithm that does global string replacement
+		legacyFork(cmd, solutionName, solutionTag, forkName, fileSystemRoot, fileSystem)
+		statusPrint("Successfully forked %s to current directory as %s using deprecated legacy replace.", solutionName, forkName)
+		return
 	}
 
-	editManifest(fileSystem, forkName)
-
-	err = fileSystemRoot.Remove("./" + solutionName + ".zip")
+	// download solution archive to the temporary directory
+	archivePath, err := DownloadSolutionPackage(solutionName, solutionTag, "")
 	if err != nil {
-		log.Fatalf("Failed to remove zip file in current directory: %v", err)
+		log.Fatalf("Failed to download solution %q with tag %q: %v", solutionName, solutionTag, err)
 	}
 
-	statusPrint("Successfully forked %s to current directory.", solutionName)
+	// create a temp directory to extract files to
+	sourceDir, err = os.MkdirTemp("", solutionName+"."+solutionTag+"-")
+	if err != nil {
+		log.Fatalf("Failed to create a temporary directory: %v", err)
+	}
+	log.WithField("temp_solution_dir", sourceDir).Info("Extracting downloaded solution in temp target directory")
+
+	// extract files from the archive into the source directory
+	sourceDirFs := afero.NewBasePathFs(afero.NewOsFs(), sourceDir)
+	if err = ExtractZipToDirectory(archivePath, sourceDirFs); err != nil {
+		log.Fatalf("Failed to extract downloaded solution archive: %v", err)
+	}
+
+	// fork solution from the extracted directory
+	err = forkFromDisk(sourceDir, fileSystem, forkName, statusPrint)
+	if err != nil {
+		log.Fatalf("Failed to fork solution (consider using --legacy-replace flag as a workaround): %v", err)
+	}
+
+	statusPrint("Successfully forked %s to current directory as %s.", solutionName, forkName)
 }
 
-func solutionNameFolderInvalid(fileSystem afero.Fs, forkName string) bool {
+func createSolutionDirectoryOk(fileSystem afero.Fs, forkName string) bool {
 	exists, _ := afero.DirExists(fileSystem, forkName)
 	if exists {
 		empty, _ := afero.IsEmpty(fileSystem, forkName)
@@ -160,176 +188,6 @@ func solutionNameFolderInvalid(fileSystem afero.Fs, forkName string) bool {
 		}
 	}
 	return false
-}
-
-func manifestExists(fileSystem afero.Fs, forkName string) bool {
-	exists, err := afero.Exists(fileSystem, forkName+"/manifest.json")
-	if err != nil {
-		log.Fatalf("Failed to read filesystem for manifest: %v", err)
-	}
-	return exists
-}
-
-func extractZip(rootFileSystem afero.Fs, fileSystem afero.Fs, solutionName string) error {
-	zipFile, err := rootFileSystem.OpenFile("./"+solutionName+".zip", os.O_RDONLY, os.FileMode(0644))
-	if err != nil {
-		log.Fatalf("Error opening zip file: %v", err)
-	}
-	fileInfo, err := rootFileSystem.Stat("./" + solutionName + ".zip")
-	if err != nil {
-		log.Errorf("Err reading zip: %v", err)
-	}
-	reader, _ := zip.NewReader(zipFile, fileInfo.Size())
-	zipFileSystem := zipfs.New(reader)
-	dirInfo, _ := afero.ReadDir(zipFileSystem, "./")
-	err = copyFolderToLocal(zipFileSystem, fileSystem, dirInfo[0].Name())
-	return err
-}
-
-func editManifest(fileSystem afero.Fs, forkName string) {
-	manifestFile, err := afero.ReadFile(fileSystem, "./manifest.json")
-	if err != nil {
-		log.Fatalf("Error opening manifest file: %v", err)
-	}
-
-	var manifest Manifest
-	err = json.Unmarshal(manifestFile, &manifest)
-	if err != nil {
-		log.Errorf("Failed to parse solution manifest: %v", err)
-	}
-
-	err = refactorSolution(fileSystem, &manifest, forkName)
-	if err != nil {
-		log.Errorf("Failed to refactor component definition files within the solution: %v", err)
-	}
-	manifest.Name = forkName
-
-	f, err := fileSystem.OpenFile("./manifest.json", os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		log.Fatalf("Can't open manifest file: %v", err)
-	}
-	defer f.Close()
-	err = output.WriteJson(manifest, f)
-	if err != nil {
-		log.Errorf("Failed to to write to solution manifest: %v", err)
-	}
-}
-
-func downloadSolutionZip(cmd *cobra.Command, solutionName string, forkName string) {
-	var solutionNameWithZipExtension = getSolutionNameWithZip(solutionName)
-	solutionTagFlag, _ := cmd.Flags().GetString("tag")
-	var message string
-
-	headers := map[string]string{
-		"stage":            "STABLE",
-		"tag":              solutionTagFlag,
-		"solutionFileName": solutionNameWithZipExtension,
-	}
-	httpOptions := api.Options{Headers: headers}
-	bufRes := make([]byte, 0)
-	if err := api.HTTPGet(getSolutionDownloadUrl(solutionName), &bufRes, &httpOptions); err != nil {
-		log.Fatalf("Solution download failed: %v", err)
-	}
-
-	message = fmt.Sprintf("Solution %s was successfully downloaded in the this directory.\r\n", solutionName)
-	output.PrintCmdStatus(cmd, message)
-
-	message = fmt.Sprintf("Changing solution name in manifest to %s.\r\n", forkName)
-	output.PrintCmdStatus(cmd, message)
-}
-
-func copyFolderToLocal(zipFileSystem afero.Fs, localFileSystem afero.Fs, subDirectory string) error {
-	dirInfo, err := afero.ReadDir(zipFileSystem, subDirectory)
-	if err != nil {
-		return err
-	}
-	for i := range dirInfo {
-		zipLoc := subDirectory + "/" + dirInfo[i].Name()
-		localLoc := convertZipLocToLocalLoc(subDirectory + "/" + dirInfo[i].Name())
-		if !dirInfo[i].IsDir() {
-			err = copyFile(zipFileSystem, localFileSystem, zipLoc, localLoc)
-			if err != nil {
-				return err
-			}
-		} else {
-			err = localFileSystem.Mkdir(localLoc, os.ModeDir)
-			if err != nil {
-				return err
-			}
-			println(localLoc)
-			err = localFileSystem.Chmod(localLoc, 0700)
-			if err != nil {
-				return err
-			}
-			err = copyFolderToLocal(zipFileSystem, localFileSystem, zipLoc)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-func copyFile(zipFileSystem afero.Fs, localFileSystem afero.Fs, zipLoc string, localLoc string) error {
-	data, err := afero.ReadFile(zipFileSystem, zipLoc)
-	if err != nil {
-		return err
-	}
-	_, err = localFileSystem.Create(localLoc)
-	if err != nil {
-		return err
-	}
-	err = afero.WriteFile(localFileSystem, localLoc, data, os.FileMode(os.O_RDWR))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func convertZipLocToLocalLoc(zipLoc string) string {
-	secondSlashIndex := strings.Index(zipLoc[2:], "/")
-	return zipLoc[secondSlashIndex+3:]
-}
-
-func refactorSolution(fileSystem afero.Fs, manifest *Manifest, forkName string) error {
-	objDefs := manifest.Objects
-	var err error
-	for _, objDef := range objDefs {
-		if objDef.ObjectsFile != "" {
-			err = ReplaceStringInFile(fileSystem, objDef.ObjectsFile, manifest.Name, forkName)
-		} else {
-			wkDir, _ := os.Getwd()
-			dirPath := fmt.Sprintf("%s/%s/%s", wkDir, forkName, objDef.ObjectsDir)
-			err = filepath.Walk(dirPath,
-				func(path string, info os.FileInfo, err error) error {
-					// if err != nil {
-					// 	return err
-					// }
-					if !info.IsDir() {
-						removeStr := fmt.Sprintf("%s/%s/", wkDir, forkName)
-						filePath := strings.ReplaceAll(path, removeStr, "")
-						err = ReplaceStringInFile(fileSystem, filePath, manifest.Name, forkName)
-					}
-					return err
-				})
-		}
-	}
-	return err
-}
-
-func ReplaceStringInFile(fileSystem afero.Fs, filePath string, searchValue string, replaceValue string) error {
-	data, err := afero.ReadFile(fileSystem, filePath)
-	if err != nil {
-		return err
-	}
-	newFileContent := string(data)
-	newFileContent = strings.ReplaceAll(newFileContent, searchValue, replaceValue)
-	err = afero.WriteFile(fileSystem, filePath, []byte(newFileContent), os.FileMode(os.O_RDWR))
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // -- New style fork

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -61,6 +61,22 @@ func getInitSolutionCmd() *cobra.Command {
 	return solutionInitCmd
 }
 
+// IsValidSolutionName checks if the solution name is valid
+func IsValidSolutionName(name string) bool {
+	if name == "" {
+		return false
+	}
+	if len(name) > 25 {
+		return false
+	}
+
+	match, err := regexp.Match(`^[a-z][a-z0-9]*$`, []byte(name))
+	if err != nil {
+		log.Fatalf("(bug) Failed to validate solution name %q: %v", name, err)
+	}
+	return match
+}
+
 func createNewSolution(cmd *cobra.Command, args []string) {
 	solutionName := strings.ToLower(args[0])
 	solutionType, _ := cmd.Flags().GetString("solution-type") // checked when creating manifest

--- a/cmd/solution/processor.go
+++ b/cmd/solution/processor.go
@@ -1,0 +1,332 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/fsoc/output"
+)
+
+type SolutionDirectoryContents struct {
+	Manifest    Manifest
+	Directories []SolutionSubDirectory
+	RootFiles   []SolutionFile // any files in the root dir except the manifest
+}
+
+type SolutionDirectoryContentsType string
+
+const (
+	KnowledgeTypes SolutionDirectoryContentsType = "types"
+	ObjectsDir     SolutionDirectoryContentsType = "objectsDir"
+	ObjectsFile    SolutionDirectoryContentsType = "objectsFile"
+)
+
+type SolutionSubDirectory struct {
+	Name        string // full name relative to the solution root
+	Type        SolutionDirectoryContentsType
+	ObjectsType string // used only for ObjecsDir directory types
+	Files       []SolutionFile
+}
+
+type SolutionFileEncoding string
+
+const (
+	EncodingUnknown SolutionFileEncoding = ""
+	EncodingJSON    SolutionFileEncoding = "json"
+	EncodingYAML    SolutionFileEncoding = "yaml"
+)
+
+type SolutionFileKinds string
+
+const (
+	KindUnknown       SolutionFileKinds = ""
+	KindKnowledgeType SolutionFileKinds = "knowledge type"
+	KindObjectType    SolutionFileKinds = "object"
+)
+
+type SolutionFile struct {
+	Name       string // file name relative to the directory
+	FileKind   SolutionFileKinds
+	ObjectType string // empty if not known or not KindObjectType
+	Encoding   SolutionFileEncoding
+	Contents   bytes.Buffer
+}
+
+var extensionMap = map[string]SolutionFileEncoding{
+	".json": EncodingJSON,
+	".yaml": EncodingYAML,
+	".yml":  EncodingYAML,
+}
+
+// New creates a new SolutionDirectoryContents object with a simple manifest
+func NewSolutionDirectoryContents(name string, solutionType SolutionType) (*SolutionDirectoryContents, error) {
+	manifest := *createInitialSolutionManifest(name, string(solutionType))
+	return &SolutionDirectoryContents{
+		Manifest: manifest,
+	}, nil
+}
+
+// Read reads the full contents of the solution directory from the specified root
+func NewSolutionDirectoryContentsFromDisk(path string) (*SolutionDirectoryContents, error) {
+	// init empty object
+	s := SolutionDirectoryContents{}
+
+	// get absolute path (deals with relative paths, .., ~, etc.)
+	rootPath := absolutizePath(path)
+
+	// read manifest
+	manifest, err := getSolutionManifest(path)
+	if err != nil {
+		return nil, err
+	}
+	s.Manifest = *manifest
+	s.Directories = make([]SolutionSubDirectory, 0)
+	s.RootFiles = make([]SolutionFile, 0)
+
+	// read contents
+	err = s.readContents(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read solution objects: %w", err)
+	}
+
+	// process objects from the manifest
+	err = s.annotateFiles()
+	if err != nil {
+		return nil, fmt.Errorf("failed to process solution objects: %w", err)
+	}
+
+	return &s, nil
+}
+
+// Write writes the full contents of the solution directory to the specified path
+// If overwrite is true, it will overwrite the existing directory; otherwise it will
+// require that the directory is either empty or does not exist (it will create it)
+func (s *SolutionDirectoryContents) Write(path string, overwrite bool) error {
+	panic("not implemented")
+}
+
+// Dump displays the contents of the solution contents object
+func (s *SolutionDirectoryContents) Dump(cmd *cobra.Command) {
+	t := output.Table{
+		Headers: []string{"Solution Name", "Solution Version", "Solution Type", "Manifest Version", "Description"},
+		Lines: [][]string{
+			{s.Manifest.Name},
+			{s.Manifest.SolutionVersion},
+			{string(s.Manifest.SolutionType)},
+			{s.Manifest.ManifestVersion},
+			{s.Manifest.Description},
+		},
+		Detail: true,
+	}
+	output.PrintCmdOutputCustom(cmd, nil, &t)
+}
+
+// --- Internal methods
+
+// readContents reads the contents of the solution directory from the specified root
+func (s *SolutionDirectoryContents) readContents(rootPath string) error {
+	// read directories & files
+	err := filepath.Walk(rootPath,
+		func(path string, info os.FileInfo, err error) error {
+			fmt.Printf("Walking %q dir=%v err=%v\n", path, info.IsDir(), err)
+			if err != nil {
+				return err
+			}
+			if path == rootPath {
+				return nil // skip the root directory itself
+			}
+			entryType := map[bool]string{true: "directory", false: "file"}[info.IsDir()]
+			relPath, err := filepath.Rel(rootPath, path)
+			if err != nil {
+				return fmt.Errorf("found %v %q that not under the root %q: %v", entryType, path, rootPath, err)
+			}
+			if strings.HasPrefix(relPath, ".") {
+				return fmt.Errorf("found %v %q that not under the root %q: %q", entryType, path, rootPath, relPath)
+			}
+			if !isAllowedPath(path, info) {
+				log.Warnf("Found %v %q which cannot be bundled; it will still be included", entryType, relPath)
+			}
+
+			if info.IsDir() {
+				dir := SolutionSubDirectory{
+					Name:  relPath,
+					Files: make([]SolutionFile, 0),
+				}
+				s.Directories = append(s.Directories, dir)
+				fmt.Printf("Appended a directory %#v\n", dir)
+			} else {
+				contents, err := os.ReadFile(path)
+				if err != nil {
+					return fmt.Errorf("error reading file %q: %w", relPath, err)
+				}
+				dirName, name := filepath.Split(relPath)
+				dirName = filepath.Clean(dirName) // removes the trailing separator
+				encoding := extensionMap[filepath.Ext(name)]
+				file := SolutionFile{
+					Name:     name,
+					Encoding: encoding,
+					Contents: *bytes.NewBuffer(contents),
+				}
+				if dirName == "" || dirName == "." {
+					s.RootFiles = append(s.RootFiles, file)
+					fmt.Printf("Appended a root file %#v\n", file)
+				} else {
+					// find directory
+					found := false
+					for _, dir := range s.Directories {
+						if dir.Name == dirName {
+							found = true
+							dir.Files = append(dir.Files, file)
+							fmt.Printf("Appended file %#v to directory %#v\n", file, dir)
+							break
+						}
+					}
+					if !found {
+						return fmt.Errorf("file %q is in directory %q which was not found", name, dirName)
+					}
+				}
+			}
+			return nil
+		})
+	if err != nil {
+		return fmt.Errorf("error walking the solution directory: %w", err)
+	}
+
+	return nil
+}
+
+// annotateFiles annotates the files with the object type based on the manifest
+func (s *SolutionDirectoryContents) annotateFiles() error {
+	// process types in the manifest
+	for _, typeFile := range s.Manifest.Types {
+		err := s.annotateFile(typeFile, KindKnowledgeType, "")
+		if err != nil {
+			return fmt.Errorf("failed to annotate knowledge type file %q: %w", typeFile, err)
+		}
+	}
+
+	// process objects in the manifest
+	for _, objectDef := range s.Manifest.Objects {
+		// ensure that the object definition is valid
+		nDescriptions := 0
+		if objectDef.ObjectsDir != "" {
+			nDescriptions++
+		}
+		if objectDef.ObjectsFile != "" {
+			nDescriptions++
+		}
+		switch nDescriptions {
+		case 0:
+			return fmt.Errorf("object %q must have either objectsDir or objectsFile specified", objectDef.Type)
+		case 1:
+			// good, continue
+		default:
+			return fmt.Errorf("object %q must have only one of objectsDir or objectsFile", objectDef.Type)
+		}
+
+		if objectDef.ObjectsFile != "" {
+			err := s.annotateFile(objectDef.ObjectsFile, KindObjectType, objectDef.Type)
+			if err != nil {
+				return fmt.Errorf("failed to annotate object file %q: %w", objectDef.ObjectsFile, err)
+			}
+		} else {
+			err := s.annotateDirectory(objectDef.ObjectsDir, KindObjectType, objectDef.Type)
+			if err != nil {
+				return fmt.Errorf("failed to annotate object directory %q: %w", objectDef.ObjectsDir, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (s *SolutionDirectoryContents) annotateFile(name string, kind SolutionFileKinds, objectType string) error {
+	var file *SolutionFile
+
+	dirName, fileName := filepath.Split(name)
+	if dirName == "" {
+		log.Warnf("File %q for %v %v is in the root directory; it should be in a subdirectory", name, kind, objectType)
+
+		// find the file
+		for _, f := range s.RootFiles {
+			if f.Name == name {
+				file = &f
+				break
+			}
+		}
+	} else {
+		// find the directory & file
+		found := false
+		for _, dir := range s.Directories {
+			if dir.Name == dirName {
+				found = true
+				for _, f := range dir.Files {
+					if f.Name == fileName {
+						file = &f
+						break
+					}
+				}
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("directory %q for %v %v was not found", dirName, kind, objectType)
+		}
+	}
+	if file == nil {
+		return fmt.Errorf("file %q for %v %v was not found", name, kind, objectType)
+	}
+
+	// annotate file
+	file.FileKind = kind
+	file.ObjectType = objectType
+
+	return nil
+}
+
+func (s *SolutionDirectoryContents) annotateDirectory(name string, kind SolutionFileKinds, objectType string) error {
+	if kind != KindObjectType {
+		panic(fmt.Sprintf("bug: annotateDirectory for %q is called for %v but allowed only for objects", name, kind))
+	}
+
+	// find the directory
+	var dir *SolutionSubDirectory
+	for _, d := range s.Directories {
+		if d.Name == name {
+			dir = &d
+			break
+		}
+	}
+	if dir == nil {
+		return fmt.Errorf("directory %q for %v %v was not found", name, kind, objectType)
+	}
+
+	// propagate object type to directory and files
+	dir.Type = ObjectsDir
+	dir.ObjectsType = objectType
+	for _, f := range dir.Files {
+		f.FileKind = kind
+		f.ObjectType = objectType
+	}
+
+	return nil
+}

--- a/cmd/solution/show.go
+++ b/cmd/solution/show.go
@@ -1,0 +1,141 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/apex/log"
+	"github.com/spf13/cobra"
+
+	"github.com/cisco-open/fsoc/output"
+)
+
+var solutionShowCmd = &cobra.Command{
+	Use:     "show [-d <directory>]",
+	Args:    cobra.NoArgs,
+	Short:   "Show solution details",
+	Long:    `Show all objects that are part of the solution in this directory`,
+	Example: `  fsoc solution show`,
+	Run:     solutionShow,
+	Annotations: map[string]string{
+		output.DetailFieldsAnnotation: "ManifestVersion:.ManifestVersion, Name:.SolutionName, Version:.SolutionVersion, Type:.SolutionType, Description:.Description, Dependencies:.Dependencies",
+	},
+}
+
+type solutionManifestDisplay struct {
+	ManifestVersion string
+	SolutionName    string
+	SolutionVersion string
+	SolutionType    string
+	Description     string
+	Dependencies    []string
+}
+
+type solutionFileElement struct {
+	Path string
+	Kind string
+	Type string
+}
+
+type solutionFileList struct {
+	Items []solutionFileElement `json:"items"`
+	Total int                   `json:"total"`
+}
+
+func getSolutionShowCmd() *cobra.Command {
+	solutionShowCmd.Flags().
+		StringP("directory", "d", "", "Path to the solution root directory (defaults to current dir)")
+
+	return solutionShowCmd
+}
+
+func solutionShow(cmd *cobra.Command, args []string) {
+	solutionDirectoryPath, _ := cmd.Flags().GetString("directory")
+
+	// finalize solution path
+	if solutionDirectoryPath == "" {
+		currentDir, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		solutionDirectoryPath = currentDir
+	}
+	if !isSolutionPackageRoot(solutionDirectoryPath) {
+		log.Fatal("Could not find solution manifest") //nb: isSolutionPackageRoot prints clear message
+	}
+
+	contents, err := NewSolutionDirectoryContentsFromDisk(solutionDirectoryPath)
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
+	manifest := contents.Manifest
+	display := solutionManifestDisplay{
+		ManifestVersion: manifest.ManifestVersion,
+		SolutionName:    manifest.Name,
+		SolutionVersion: manifest.SolutionVersion,
+		SolutionType:    manifest.SolutionType,
+		Description:     manifest.Description,
+		Dependencies:    manifest.Dependencies,
+	}
+
+	_ = cmd.Flags().Set("output", "detail")
+	_ = cmd.Flags().Set("fields", "ManifestVersion:.ManifestVersion, Name:.SolutionName, Version:.SolutionVersion, Type:.SolutionType, Description:.Description, Dependencies:.Dependencies")
+	output.PrintCmdOutput(cmd, display)
+
+	// create list of files
+	var files []solutionFileElement
+	for _, rootFile := range contents.RootFiles {
+		if rootFile.FileKind == KindHidden {
+			continue
+		}
+		files = append(files, solutionFileElement{
+			Path: rootFile.Name,
+			Kind: verboseFileKind(rootFile.FileKind),
+			Type: rootFile.ObjectType,
+		})
+	}
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+	rootFileCount := len(files)
+	for _, dir := range contents.Directories {
+		for _, file := range dir.Files {
+			files = append(files, solutionFileElement{
+				Path: filepath.Join(dir.Name, file.Name),
+				Kind: verboseFileKind(file.FileKind),
+				Type: file.ObjectType,
+			})
+		}
+	}
+	sort.Slice(files[rootFileCount:], func(i, j int) bool {
+		return files[i].Path < files[j].Path
+	})
+
+	_ = cmd.Flags().Set("output", "table")
+	_ = cmd.Flags().Set("fields", "File:.Path, Kind:.Kind, Type:.Type")
+	output.PrintCmdOutput(cmd, solutionFileList{Items: files, Total: len(files)})
+}
+
+func verboseFileKind(kind SolutionFileKinds) string {
+	if kind == KindUnknown {
+		return "unknown"
+	} else {
+		return string(kind)
+	}
+}

--- a/cmd/solution/solution.go
+++ b/cmd/solution/solution.go
@@ -61,6 +61,7 @@ func NewSubCmd() *cobra.Command {
 	solutionCmd.AddCommand(getSolutionCheckCmd())
 	solutionCmd.AddCommand(getSolutionStatusCmd())
 	solutionCmd.AddCommand(getSolutionDescribeCmd())
+	solutionCmd.AddCommand(getSolutionShowCmd())
 	solutionCmd.AddCommand(getSolutionBumpCmd())
 	solutionCmd.AddCommand(getSolutionTestCmd())
 	solutionCmd.AddCommand(getSolutionTestStatusCmd())

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -36,6 +36,14 @@ func (f FileFormat) String() string {
 	return [...]string{"json", "yaml"}[f]
 }
 
+type SolutionType string
+
+const (
+	ComponentSolutionType SolutionType = "component"
+	ModuleSolutionType    SolutionType = "module"
+	AppSolutionType       SolutionType = "app"
+)
+
 type Manifest struct {
 	ManifestVersion string         `json:"manifestVersion,omitempty" yaml:"manifestVersion,omitempty"`
 	ManifestFormat  FileFormat     `json:"-" yaml:"-"` // not serialized, in memory

--- a/cmd/solution/unzip.go
+++ b/cmd/solution/unzip.go
@@ -1,0 +1,133 @@
+// Copyright 2024 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package solution
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/apex/log"
+	"github.com/spf13/afero"
+)
+
+// UnzipToAferoFs extracts files from a zip file to an afero file system.
+// skipLevels specifies how many directories from the top level should be skipped
+// over when constructing the target path (similar to the -p flag of the patch command).
+// Note that there should be no files in the skipped levels; otherwise, this function will
+// return an error.
+func UnzipToAferoFs(zipFile string, targetFs afero.Fs, skipLevels int) error {
+	// Open the zip file
+	zipReader, err := zip.OpenReader(zipFile)
+	if err != nil {
+		return fmt.Errorf("failed to open zip file %q: %w", zipFile, err)
+	}
+
+	skippedPrefix := ""
+	skippedLevels := 0
+
+	// Iterate through the files in the zip archive
+	for _, file := range zipReader.File {
+		permissions := file.Mode() & os.ModePerm // ensure only permissions bits are used
+		// fmt.Printf("Extracting %q with permissions %o, isDir=%v\n", file.Name, permissions, file.FileInfo().IsDir())
+
+		// Construct the target file path
+		filePath := file.Name
+		switch filepath.Separator { // convert to the target file system's separator
+		case '\\':
+			filePath = strings.Replace(filePath, "/", "\\", -1) // Linux zips on Windows
+		case '/':
+			filePath = strings.Replace(filePath, "\\", "/", -1) // Windows zips on Linux
+		default:
+			// unknown separator; assume it's the same as the source
+		}
+
+		// Check for ZipSlip (a security vulnerability)
+		// This is a belt-and-suspenders-type check; one reason we use afero in the first
+		// place is to guard against this type of issues. Afero doesn't allow reach outside
+		// the targetFs.
+		// Note the filePath was `Clean`-ed, so if it leaves the root, it will start with "../"
+		if strings.HasPrefix(filePath, ".."+string(os.PathSeparator)) { // definitely illegal
+			return fmt.Errorf("%q: illegal file path in zip file %q", filePath, zipFile)
+		}
+		if strings.Contains(filePath, ".."+string(os.PathSeparator)) { // possible false positive for files like `test../test`
+			return fmt.Errorf("%q: possibly illegal file path in zip file %q", filePath, zipFile)
+		}
+
+		// accumulate directory prefix until the target skip level is reached
+		// Note that there the skipped level directories may be accumulated over several
+		// entries but there can be no files until the target skip level is reached.
+		if skippedLevels < skipLevels {
+			// ensure that only directories are skipped
+			if !file.FileInfo().IsDir() {
+				return fmt.Errorf("found a file, %q, in skipped levels (%v); not supported", file.Name, skipLevels)
+			}
+
+			// ensure we're building up the prefix
+			if !strings.HasPrefix(file.Name, skippedPrefix) {
+				log.Warnf("skip directory %q does not include accumulated prefix %q", file.Name, skippedPrefix)
+			}
+
+			// update prefix
+			dirList := strings.Split(file.Name, string(filepath.Separator))
+			if len(dirList) > skipLevels {
+				dirList = dirList[:skipLevels] // limit skip to specified level
+			}
+			skippedPrefix = filepath.Join(dirList...)
+			skippedLevels = len(dirList)
+			// fmt.Printf("Updated skippedPrefix to %q (%d)\n", skippedPrefix, skippedLevels)
+			continue
+		}
+
+		// remove prefix (if any)
+		filePath, _ = strings.CutPrefix(filePath, skippedPrefix)
+
+		// Create directories if this is a directory entry
+		if file.FileInfo().IsDir() {
+			// fmt.Printf("Creating directory %q\n", filePath)
+			err := targetFs.MkdirAll(filePath, permissions|0o100) // ensure enumerable by owner
+			if err != nil {
+				return fmt.Errorf("failed to create directory %q: %w", filePath, err)
+			}
+			continue
+		}
+
+		// fmt.Printf("Unzipping %q into %q\n", file.Name, filePath)
+
+		// Open the file within the zip archive
+		srcFile, err := file.Open()
+		if err != nil {
+			return fmt.Errorf("failed to open zipped file %q: %w", file.Name, err)
+		}
+		defer srcFile.Close()
+
+		// Create the destination file
+		dstFile, err := targetFs.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, permissions)
+		if err != nil {
+			return fmt.Errorf("failed to create destination file: %w", err)
+		}
+		defer dstFile.Close()
+
+		// Copy the file's contents to the new file
+		if _, err = io.Copy(dstFile, srcFile); err != nil {
+			return fmt.Errorf("failed to copy file contents of %q: %w", file.Name, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description

Implemented a new internal object to read and keep in memory the full solution, with all its files.

Added `solution show` command that displays solution's elements: for now, list of files with annotation of their contents (e.g., knowledge vs. object, object type, etc.)

Added support for `solution fork` from a local directory, as this helps primers/tutorials/workshops and works around the restricted ability to download solutions from other tenants.

Modified the fork capability to not just do global replace (which can inadvertently replace more than necessary and break a solution); instead, it ensures that only values are changed (never keys) and only on word boundary. Additional exceptions are handled, such as renaming the namespace file (which is usually named after the solution name).

Retained the old fork capability for backward compatibility, under a `--legacy-replace` flag, in case the new algorithm doesn't take care of some cases that are covered in tutorials and workshops.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
