### PR TITLE
ORION-3208: fix issue when tag not provided in fsoc solution status

### DIFF
--- a/cmd/solution/status.go
+++ b/cmd/solution/status.go
@@ -212,6 +212,10 @@ func getSolutionStatus(cmd *cobra.Command, args []string) error {
 	solutionStatusItem, err := getExtensibilitySolutionObject(getSolutionObjectUrl(solutionID), requestHeaders)
 
 	if err != nil {
+		if solutionTag == "" {
+			log.Warn("No tag provided, defaulting to stable tag when querying for objects")
+			solutionTag = "stable"
+		}
 		isSolutionDeleted, solutionDeletionData := checkIfSolutionDeleted(solutionName, solutionTag)
 		// If solution has been deleted previously, print out a helpful message to let the user know
 		// else throw an error


### PR DESCRIPTION
## Description

Fixing minor issue with the fsoc solution status command when a user doesn't provide a tag for the solution using the command.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
