### PR TITLE
Fixing issues with embedded references using yaml:,inline impacting f…

### DIFF
--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -329,7 +329,7 @@ func addNewComponent(cmd *cobra.Command, manifest *Manifest, folderName, compone
 			newComponents = append(newComponents, ecpDetails)
 
 			ecpDetailsList := &newComponent{
-				Filename:   componentFileName(cmd, manifest, entity.Name+"DetailsList.json"),
+				Filename:   componentFileName(cmd, manifest, entity.Name+"DetailsList"),
 				Type:       "dashui:template",
 				Definition: getDashuiDetailsList(entity, manifest),
 			}

--- a/cmd/solution/types-dashui.go
+++ b/cmd/solution/types-dashui.go
@@ -40,8 +40,8 @@ type DashuiWidget struct {
 }
 
 type DashuiFocusedEntity struct {
-	*DashuiWidget
-	Mode string `json:"mode" yaml:"mode"`
+	*DashuiWidget `json:",inline" yaml:",inline"`
+	Mode          string `json:"mode" yaml:"mode"`
 }
 
 type DashuiString struct {
@@ -64,7 +64,7 @@ type DashuiProperty struct {
 }
 
 type DashuiGrid struct {
-	*DashuiWidget
+	*DashuiWidget    `json:",inline" yaml:",inline"`
 	RowSets          interface{}         `json:"rowSets" yaml:"rowSets"`
 	Style            interface{}         `json:"style,omitempty" yaml:"style,omitempty"`
 	Mode             string              `json:"mode" yaml:"mode"`
@@ -85,15 +85,15 @@ type DashuiGridCell struct {
 }
 
 type DashuiTooltip struct {
-	*DashuiWidget
-	Truncate bool        `json:"truncate,omitempty" yaml:"truncate,omitempty"`
-	Trigger  interface{} `json:"trigger,omitempty" yaml:"trigger,omitempty"`
+	*DashuiWidget `json:",inline" yaml:",inline"`
+	Truncate      bool        `json:"truncate,omitempty" yaml:"truncate,omitempty"`
+	Trigger       interface{} `json:"trigger,omitempty" yaml:"trigger,omitempty"`
 }
 
 type DashuiClickable struct {
-	*DashuiWidget
-	OnClick *DashuiEvent `json:"onClick,omitempty" yaml:"onClick,omitempty"`
-	Trigger *DashuiLabel `json:"trigger,omitempty" yaml:"trigger,omitempty"`
+	*DashuiWidget `json:",inline" yaml:",inline"`
+	OnClick       *DashuiEvent `json:"onClick,omitempty" yaml:"onClick,omitempty"`
+	Trigger       *DashuiLabel `json:"trigger,omitempty" yaml:"trigger,omitempty"`
 }
 
 type DashuiEvent struct {
@@ -103,8 +103,8 @@ type DashuiEvent struct {
 }
 
 type EcpLeftBar struct {
-	*DashuiWidget
-	Label string `json:"label" yaml:"label"`
+	*DashuiWidget `json:",inline" yaml:",inline"`
+	Label         string `json:"label" yaml:"label"`
 }
 
 type EcpRelationshipMapEntry struct {
@@ -115,8 +115,8 @@ type EcpRelationshipMapEntry struct {
 }
 
 type EcpInspectorWidget struct {
-	*DashuiWidget
-	Title string `json:"title" yaml:"title"`
+	*DashuiWidget `json:",inline" yaml:",inline"`
+	Title         string `json:"title" yaml:"title"`
 }
 
 type EcpHome struct {
@@ -138,13 +138,13 @@ type DashuiEcpHomeEntity struct {
 }
 
 type DashuiOcpSingle struct {
-	*DashuiWidget
+	*DashuiWidget `json:",inline" yaml:",inline"`
 	NameAttribute string `json:"nameAttribute" yaml:"nameAttribute"`
 }
 
 type DashuiCartesian struct {
-	*DashuiWidget
-	Children []*DashuiCartesianSeries `json:"children" yaml:"children"`
+	*DashuiWidget `json:",inline" yaml:",inline"`
+	Children      []*DashuiCartesianSeries `json:"children" yaml:"children"`
 }
 
 type DashuiCartesianSeries struct {
@@ -169,6 +169,6 @@ type DashuiLogsWidget struct {
 }
 
 type DashuiHtmlWidget struct {
-	*DashuiWidget
-	Style interface{} `json:"style,omitempty" yaml:"style,omitempty"`
+	*DashuiWidget `json:",inline" yaml:",inline"`
+	Style         interface{} `json:"style,omitempty" yaml:"style,omitempty"`
 }

--- a/cmd/solution/types-fmm.go
+++ b/cmd/solution/types-fmm.go
@@ -41,8 +41,8 @@ type FmmAttributeTypeDef struct {
 }
 
 type FmmRequiredAttributeDefinitionsTypeDef struct {
-	Required []string `json:"required" yaml:"required"`
-	*FmmAttributeDefinitionsTypeDef
+	Required                        []string `json:"required" yaml:"required"`
+	*FmmAttributeDefinitionsTypeDef `json:",inline" yaml:",inline"`
 }
 
 type FmmAttributeDefinitionsTypeDef struct {
@@ -60,7 +60,7 @@ type FmmAssociationTypesTypeDef struct {
 }
 
 type FmmEntity struct {
-	*FmmTypeDef
+	*FmmTypeDef           `json:",inline" yaml:",inline"`
 	AttributeDefinitions  *FmmRequiredAttributeDefinitionsTypeDef `json:"attributeDefinitions,omitempty" yaml:"attributeDefinitions,omitempty"`
 	LifecyleConfiguration *FmmLifecycleConfigTypeDef              `json:"lifecycleConfiguration" yaml:"lifecycleConfiguration"`
 	MetricTypes           []string                                `json:"metricTypes,omitempty" yaml:"metricTypes,omitempty"`
@@ -73,12 +73,12 @@ func (entity *FmmEntity) GetTypeName() string {
 }
 
 type FmmEvent struct {
-	*FmmTypeDef
+	*FmmTypeDef          `json:",inline" yaml:",inline"`
 	AttributeDefinitions *FmmAttributeDefinitionsTypeDef `json:"attributeDefinitions" yaml:"attributeDefinitions"` // required always, do not omitempty
 }
 
 type FmmResourceMapping struct {
-	*FmmTypeDef
+	*FmmTypeDef           `json:",inline" yaml:",inline"`
 	EntityType            string               `json:"entityType" yaml:"entityType"`
 	ScopeFilter           string               `json:"scopeFilter" yaml:"scopeFilter"`
 	Mappings              []FmmMapAndTransform `json:"mappings,omitempty" yaml:"mappings,omitempty"`
@@ -86,7 +86,7 @@ type FmmResourceMapping struct {
 }
 
 type FmmAssociationDeclaration struct {
-	*FmmTypeDef
+	*FmmTypeDef     `json:",inline" yaml:",inline"`
 	ScopeFilter     string `json:"scopeFilter" yaml:"scopeFilter"`
 	FromType        string `json:"fromType" yaml:"fromType"`
 	ToType          string `json:"toType" yaml:"toType"`
@@ -105,7 +105,7 @@ type FmmNamespace struct {
 }
 
 type FmmMetric struct {
-	*FmmTypeDef
+	*FmmTypeDef            `json:",inline" yaml:",inline"`
 	Category               FmmMetricCategory               `json:"category" yaml:"category"`
 	ContentType            FmmMetricContentType            `json:"contentType" yaml:"contentType"`
 	AggregationTemporality string                          `json:"aggregationTemporality" yaml:"aggregationTemporality"`

--- a/cmd/solution/types.go
+++ b/cmd/solution/types.go
@@ -15,7 +15,6 @@
 package solution
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -23,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/apex/log"
+	"gopkg.in/yaml.v3"
 )
 
 type FileFormat int8
@@ -124,7 +124,7 @@ func (manifest *Manifest) GetFmmEntities() []*FmmEntity {
 					if err != nil {
 						return err
 					}
-					if strings.Contains(path, ".json") {
+					if strings.Contains(path, ".json") || strings.Contains(path, ".yaml") {
 						fmmEntities = append(fmmEntities, getFmmEntitiesFromFile(path)...)
 					}
 					return nil
@@ -153,7 +153,7 @@ func (manifest *Manifest) GetFmmMetrics() []*FmmMetric {
 					if err != nil {
 						return err
 					}
-					if strings.Contains(path, ".json") {
+					if strings.Contains(path, ".json") || strings.Contains(path, ".yaml") {
 						fmmMetrics = append(fmmMetrics, getFmmMetricsFromFile(path)...)
 					}
 					return nil
@@ -182,7 +182,7 @@ func (manifest *Manifest) GetFmmEvents() []*FmmEvent {
 					if err != nil {
 						return err
 					}
-					if strings.Contains(path, ".json") {
+					if strings.Contains(path, ".json") || strings.Contains(path, ".yaml") {
 						fmmEvents = append(fmmEvents, getFmmEventsFromFile(path)...)
 					}
 					return nil
@@ -255,7 +255,7 @@ func (manifest *Manifest) GetDashuiTemplates() []*DashuiTemplate {
 					if err != nil {
 						return err
 					}
-					if strings.Contains(path, ".json") {
+					if strings.Contains(path, ".json") || strings.Contains(path, ".yaml") {
 						dashuiTemplates = append(dashuiTemplates, getDashuiTemplatesFromFile(path)...)
 					}
 					return nil
@@ -278,18 +278,20 @@ func getDashuiTemplatesFromFile(filePath string) []*DashuiTemplate {
 
 	if strings.Index(objDefContent, "[") == 0 {
 		objectsArray := make([]*DashuiTemplate, 0)
-		err := json.Unmarshal(objDefBytes, &objectsArray)
+		//err := json.Unmarshal(objDefBytes, &objectsArray)
+		err := yaml.Unmarshal(objDefBytes, &objectsArray)
 		if err != nil {
 			log.Fatalf("Can't parse an array of dashui:template definition objects from the %q file:\n %v", filePath, err)
 		}
 		dashuiTemplates = append(dashuiTemplates, objectsArray...)
 	} else {
-		var event *DashuiTemplate
-		err := json.Unmarshal(objDefBytes, &event)
+		var object *DashuiTemplate
+		// err := json.Unmarshal(objDefBytes, &object)
+		err := yaml.Unmarshal(objDefBytes, &object)
 		if err != nil {
 			log.Fatalf("Can't parse dashui:template definition objects from the %q file:\n %v ", filePath, err)
 		}
-		dashuiTemplates = append(dashuiTemplates, event)
+		dashuiTemplates = append(dashuiTemplates, object)
 	}
 	return dashuiTemplates
 }
@@ -303,14 +305,16 @@ func getFmmEntitiesFromFile(filePath string) []*FmmEntity {
 
 	if strings.Index(entityDefContent, "[") == 0 {
 		entitiesArray := make([]*FmmEntity, 0)
-		err := json.Unmarshal(entityDefBytes, &entitiesArray)
+		err := yaml.Unmarshal(entityDefBytes, &entitiesArray)
 		if err != nil {
 			log.Fatalf("Can't parse an array of entity definition objects from the %q file:\n %v", filePath, err)
 		}
 		fmmEntities = append(fmmEntities, entitiesArray...)
 	} else {
-		var entity *FmmEntity
-		err := json.Unmarshal(entityDefBytes, &entity)
+		entity := &FmmEntity{
+			FmmTypeDef: &FmmTypeDef{},
+		}
+		err := yaml.Unmarshal(entityDefBytes, &entity)
 		if err != nil {
 			log.Fatalf("Can't parse an entity definition objects from the %q file:\n %v", filePath, err)
 		}
@@ -327,19 +331,24 @@ func getFmmMetricsFromFile(filePath string) []*FmmMetric {
 	metricDefContent := string(metricDefBytes)
 
 	if strings.Index(metricDefContent, "[") == 0 {
-		metricsArray := make([]*FmmMetric, 0)
-		err := json.Unmarshal(metricDefBytes, &metricsArray)
+		objectsArray := make([]*FmmMetric, 0)
+		// err := json.Unmarshal(metricDefBytes, &objectsArray)
+		err := yaml.Unmarshal(metricDefBytes, &objectsArray)
 		if err != nil {
 			log.Fatalf("Can't parse an array of metric definition objects from the %q file:\n %v", filePath, err)
 		}
-		fmmMetrics = append(fmmMetrics, metricsArray...)
+		fmmMetrics = append(fmmMetrics, objectsArray...)
 	} else {
-		var metric *FmmMetric
-		err := json.Unmarshal(metricDefBytes, &metric)
+		// err := json.Unmarshal(metricDefBytes, &object)
+		object := &FmmMetric{
+			FmmTypeDef: &FmmTypeDef{},
+		}
+
+		err := yaml.Unmarshal(metricDefBytes, &object)
 		if err != nil {
 			log.Fatalf("Can't parse a metric definition objects from the %q file:\n %v ", filePath, err)
 		}
-		fmmMetrics = append(fmmMetrics, metric)
+		fmmMetrics = append(fmmMetrics, object)
 	}
 	return fmmMetrics
 }
@@ -352,19 +361,25 @@ func getFmmEventsFromFile(filePath string) []*FmmEvent {
 	eventDefContent := string(eventDefBytes)
 
 	if strings.Index(eventDefContent, "[") == 0 {
-		eventsArray := make([]*FmmEvent, 0)
-		err := json.Unmarshal(eventDefBytes, &eventsArray)
+		objectsArray := make([]*FmmEvent, 0)
+		// err := json.Unmarshal(eventDefBytes, &objectsArray)
+		err := yaml.Unmarshal(eventDefBytes, &objectsArray)
+
 		if err != nil {
 			log.Fatalf("Can't parse an array of event definition objects from the %q file:\n %v", filePath, err)
 		}
-		fmmEvents = append(fmmEvents, eventsArray...)
+		fmmEvents = append(fmmEvents, objectsArray...)
 	} else {
-		var event *FmmEvent
-		err := json.Unmarshal(eventDefBytes, &event)
+		object := &FmmEvent{
+			FmmTypeDef: &FmmTypeDef{},
+		}
+
+		// err := json.Unmarshal(eventDefBytes, &object)
+		err := yaml.Unmarshal(eventDefBytes, &object)
 		if err != nil {
 			log.Fatalf("Can't parse a event` definition objects from the %q file:\n %v ", filePath, err)
 		}
-		fmmEvents = append(fmmEvents, event)
+		fmmEvents = append(fmmEvents, object)
 	}
 	return fmmEvents
 }


### PR DESCRIPTION
fsoc solution extend commands support for yaml object definitions

## Description
The current implementation doesn't generate yaml object definitions properly given the usage of embedded type references, directly impacting fsoc solution extend commands and fsoc melt model.
The fix has been verified for fsoc solution extend command and fsoc melt model.


## Type of Change

- [X] Bug Fix

## Checklist
