### PR TITLE
fix fork json encoding issues

### DIFF
--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -408,7 +408,10 @@ func forkFileInBuffer(buffer bytes.Buffer, encoding SolutionFileEncoding, oldNam
 	var newBuffer bytes.Buffer
 	switch encoding {
 	case EncodingJSON:
-		err = json.NewEncoder(&newBuffer).Encode(contents)
+		enc := json.NewEncoder(&newBuffer)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", output.JsonIndent)
+		err = enc.Encode(contents)
 	case EncodingYAML:
 		err = yaml.NewEncoder(&newBuffer).Encode(contents)
 	}

--- a/cmd/solution/init.go
+++ b/cmd/solution/init.go
@@ -174,16 +174,7 @@ func createInitialSolutionManifest(solutionName string, options ...SolutionManif
 func writeSolutionManifest(manifest *Manifest, w io.Writer) error {
 	checkStructTags(reflect.TypeOf(manifest)) // ensure json/yaml struct tags are correct
 
-	// write the manifest into the file, in manifest's selected format
-	var err error
-	switch manifest.ManifestFormat {
-	case FileFormatJSON:
-		err = output.WriteJson(manifest, w)
-	case FileFormatYAML:
-		err = output.WriteYaml(manifest, w)
-	default:
-		err = fmt.Errorf("(bug) unknown manifest format %q", manifest.ManifestFormat)
-	}
+	err := writeComponent(manifest, w, manifest.ManifestFormat)
 	if err != nil {
 		return fmt.Errorf("failed to write the manifest: %w", err)
 	}
@@ -281,9 +272,11 @@ func writeComponent(compDef any, w io.Writer, format FileFormat) error {
 		enc.SetEscapeHTML(false)
 		enc.SetIndent("", output.JsonIndent)
 		err = enc.Encode(compDef)
+	default:
+		err = fmt.Errorf("(bug) unknown file format %q", format)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to write the solution file with %T: %v", compDef, err)
+		return fmt.Errorf("failed to write the solution file with %T: %w", compDef, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

The JSON encoder, by default:
- outputs compact, unindented json
- escapes HTML characters

Both issues were affecting objects files that were modified by fork; the latter issue was affecting any manifest updates (fork, bump, etc.), visible on isolated solutions that have `&` in values.

This commit fixes both issues.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
