### PR TITLE
ignore non-json/yaml files when forking

### DIFF
--- a/cmd/solution/fork.go
+++ b/cmd/solution/fork.go
@@ -34,6 +34,8 @@ import (
 
 const pseudoIsolationSuffix = "${$toSuffix(env.tag)}"
 
+var ErrUnsupportedEncoding = fmt.Errorf("unsupported encoding")
+
 var solutionForkCmd = &cobra.Command{
 	Use:   "fork [<solution-name>|--source-dir=<directory>] <target-name> [flags]",
 	Args:  cobra.MaximumNArgs(2),
@@ -285,7 +287,15 @@ func forkFromDisk(sourceDir string, fileSystem afero.Fs, solutionName string, st
 			if dir != nil {
 				dirName = dir.Name
 			}
-			return fmt.Errorf("error forking file %q: %w", filepath.Join(dirName, file.Name), err)
+			path := filepath.Join(dirName, file.Name)
+
+			if err == ErrUnsupportedEncoding {
+				statusPrint("Made no changes in %q; not a json or yaml file", path)
+				log.WithField("file", path).Warn("Not a json or yaml file; skipping")
+				return nil
+			}
+
+			return fmt.Errorf("error forking file %q: %w", path, err)
 		}
 		if nReplacements > 0 {
 			// replace file contents
@@ -380,7 +390,7 @@ func forkFromDisk(sourceDir string, fileSystem afero.Fs, solutionName string, st
 // The function returns the new buffer with the replacements and the number of
 // replacements made, as well as an error.
 func forkFileInBuffer(buffer bytes.Buffer, encoding SolutionFileEncoding, oldNameRe *regexp.Regexp, newName string) (bytes.Buffer, int, error) {
-	// decode buffer to map[string]interace{}
+	// decode buffer to map[string]any
 	var contents any
 	var err error
 	switch encoding {
@@ -389,7 +399,7 @@ func forkFileInBuffer(buffer bytes.Buffer, encoding SolutionFileEncoding, oldNam
 	case EncodingYAML:
 		err = yaml.Unmarshal(buffer.Bytes(), &contents)
 	default:
-		return bytes.Buffer{}, 0, fmt.Errorf("unsupported encoding: %v", encoding)
+		return bytes.Buffer{}, 0, ErrUnsupportedEncoding
 	}
 	if err != nil {
 		return bytes.Buffer{}, 0, fmt.Errorf("error decoding %v file: %w", encoding, err)


### PR DESCRIPTION
## Description

When forking a solution, skip files that are not JSON or YAML (e.g., PNG or ZIP) instead of failing the fork. Supported only in the new fork algorithm, whether forking from a directory or from a platform solution.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
