### PR TITLE
Adding contenType optional flag to solution extend --add-metric

### DIFF
--- a/cmd/melt/geometry-test.go
+++ b/cmd/melt/geometry-test.go
@@ -94,18 +94,18 @@ func exportMetrics() error {
 
 	// add a gauge metric to the entity
 	m1 := melt.NewMetric("geometry:gauge", "count", "gauge", "double")
-	m1.AddDataPoint(st.UnixNano(), et.UnixNano(), rand.Float64()*5)
+	m1.AddDataPoint(st.UnixNano(), et.UnixNano(), map[string]interface{}{}, rand.Float64()*5)
 	e1.AddMetric(m1)
 
 	// add a sum delta metric to the entity
 	m2 := melt.NewMetric("geometry:sum_delta", "sum", "sum", "double")
-	m2.AddDataPoint(st.UnixNano(), et.UnixNano(), rand.Float64()*5)
+	m2.AddDataPoint(st.UnixNano(), et.UnixNano(), map[string]interface{}{}, rand.Float64()*5)
 	m2.AggregationTemporality = melt.AggregationTemporalityDelta
 	e1.AddMetric(m2)
 
 	// add a sum cumulative metric to the entity
 	m3 := melt.NewMetric("geometry:sum_cumulative", "sum", "sum", "double")
-	m3.AddDataPoint(st.UnixNano(), et.UnixNano(), rand.Float64()*5)
+	m3.AddDataPoint(st.UnixNano(), et.UnixNano(), map[string]interface{}{}, rand.Float64()*5)
 	m3.IsMonotonic = true
 	m3.AggregationTemporality = melt.AggregationTemporalityCumulative
 	e1.AddMetric(m3)
@@ -238,7 +238,7 @@ func exportRelationships() error {
 		m := melt.NewMetric("geometry:dummy", "count", "gauge", "double")
 		et := time.Now()
 		st := et.Add(time.Minute * -1)
-		m.AddDataPoint(st.UnixNano(), et.UnixNano(), rand.Float64()*5)
+		m.AddDataPoint(st.UnixNano(), et.UnixNano(), map[string]interface{}{}, rand.Float64()*5)
 		edgeEntity.AddMetric(m)
 
 		el = append(el, edgeEntity)
@@ -255,7 +255,7 @@ func exportRelationships() error {
 	m := melt.NewMetric("geometry:dummy", "count", "gauge", "double")
 	et := time.Now()
 	st := et.Add(time.Minute * -1)
-	m.AddDataPoint(st.UnixNano(), et.UnixNano(), rand.Float64()*5)
+	m.AddDataPoint(st.UnixNano(), et.UnixNano(), map[string]interface{}{}, rand.Float64()*5)
 	e1.AddMetric(m)
 
 	// add relationship to edges

--- a/cmd/melt/send.go
+++ b/cmd/melt/send.go
@@ -161,10 +161,13 @@ func sendDataFromFile(cmd *cobra.Command, dataFileName string) {
 					}
 
 					if m.ContentType == "distribution" {
-						quantiles := []*melt.QuantileValue{{Quantile: 0.0, Value: dp}, {Quantile: 1.0, Value: dp}}
+						quantiles := []*melt.QuantileValue{{Quantile: "0.0", Value: dp}, {Quantile: "1.0", Value: dp}}
 						m.AddDistributionDataPoint(st.UnixNano(), et.UnixNano(), dp, 1, quantiles)
+					} else if m.ContentType == "histogram" {
+						m.AddHistogramDataPoint(st.UnixNano(), et.UnixNano(), dp, 1, "p0", []uint64{1}, []float64{dp})
+						m.AddHistogramDataPoint(st.UnixNano(), et.UnixNano(), dp, 1, "p100", []uint64{1}, []float64{dp})
 					} else {
-						m.AddDataPoint(st.UnixNano(), et.UnixNano(), dp)
+						m.AddDataPoint(st.UnixNano(), et.UnixNano(), nil, dp)
 					}
 
 					st = et

--- a/cmd/solution/extend-fmm.go
+++ b/cmd/solution/extend-fmm.go
@@ -257,6 +257,7 @@ func getMetricComponent(metricName string, contentType FmmMetricContentType, met
 	}
 
 	switch contentType {
+
 	case ContentType_Gauge:
 		{
 			metricComponentDef.AggregationTemporality = "unspecified"
@@ -266,6 +267,16 @@ func getMetricComponent(metricName string, contentType FmmMetricContentType, met
 		{
 			metricComponentDef.AggregationTemporality = "delta"
 			metricComponentDef.Category = Category_Sum
+		}
+	case ContentType_Distribution:
+		{
+			metricComponentDef.AggregationTemporality = "delta"
+			metricComponentDef.Category = Category_Average
+		}
+	case ContentType_Histogram:
+		{
+			metricComponentDef.AggregationTemporality = "delta"
+			metricComponentDef.Category = Category_Histogram
 		}
 	}
 

--- a/cmd/solution/extend-fmm.go
+++ b/cmd/solution/extend-fmm.go
@@ -295,7 +295,15 @@ func getServiceComponent(serviceName string) *ServiceDef {
 func checkCreateSolutionNamespace(cmd *cobra.Command, manifest *Manifest, folderName string) {
 	componentType := "fmm:namespace"
 	namespaceName := manifest.GetNamespaceName()
-	fileName := manifest.GetSolutionName() + ".json"
+	var fileFormat string
+	switch manifest.ManifestFormat {
+	case FileFormatJSON:
+		fileFormat = "json"
+	case FileFormatYAML:
+		fileFormat = "yaml"
+	}
+	fileName := fmt.Sprintf("%s.%s", manifest.GetSolutionName(), fileFormat)
+
 	objFilePath := fmt.Sprintf("%s/%s", folderName, fileName)
 
 	componentDef := manifest.GetComponentDef(componentType)

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -38,6 +38,7 @@ var solutionExtendCmd = &cobra.Command{
 	Annotations:      map[string]string{config.AnnotationForConfigBypass: ""}, // this command does not require a valid context
 	TraverseChildren: true,
 }
+var metricContentType string
 
 // Planned options:
 // --add-meltworkflow - Flag to add a new melt workflow component to the current solution package
@@ -54,6 +55,8 @@ func getSolutionExtendCmd() *cobra.Command {
 		String("add-associationDeclarations", "", "Add all associationDeclaration type definitions for a given entity within this solution")
 	solutionExtendCmd.Flags().
 		String("add-metric", "", "Add a new metric type definition to this solution")
+	solutionExtendCmd.Flags().
+		StringVarP(&metricContentType, "contentType", "", "", "Optional flag to be used in conjuntion with --add-metric to support the definition of the contentType for the created metric type")
 	solutionExtendCmd.Flags().
 		String("add-resourceMapping", "", "Add a new resource mapping type definition for a given entity within this solution")
 	solutionExtendCmd.Flags().
@@ -234,10 +237,15 @@ func addNewComponent(cmd *cobra.Command, manifest *Manifest, folderName, compone
 		}
 	case "fmm:metric":
 		{
+			contentType := ContentType_Gauge
+			if metricContentType != "" {
+				contentType = FmmMetricContentType(contentType)
+			}
+
 			metric := &newComponent{
 				Filename:   componentFileName(cmd, manifest, componentName),
 				Type:       componentType,
-				Definition: getMetricComponent(componentName, ContentType_Gauge, Type_Long, namespaceName),
+				Definition: getMetricComponent(componentName, contentType, Type_Long, namespaceName),
 			}
 
 			newComponents = append(newComponents, metric)

--- a/cmd/solution/extend.go
+++ b/cmd/solution/extend.go
@@ -56,7 +56,7 @@ func getSolutionExtendCmd() *cobra.Command {
 	solutionExtendCmd.Flags().
 		String("add-metric", "", "Add a new metric type definition to this solution")
 	solutionExtendCmd.Flags().
-		StringVarP(&metricContentType, "contentType", "", "", "Optional flag to be used in conjuntion with --add-metric to support the definition of the contentType for the created metric type")
+		StringVarP(&metricContentType, "contentType", "", "", "Optional flag to be used in conjuntion with --add-metric to support the definition of the contentType for the created metric type. Valid values are: sum, gauge, distribution, histogram")
 	solutionExtendCmd.Flags().
 		String("add-resourceMapping", "", "Add a new resource mapping type definition for a given entity within this solution")
 	solutionExtendCmd.Flags().
@@ -239,7 +239,7 @@ func addNewComponent(cmd *cobra.Command, manifest *Manifest, folderName, compone
 		{
 			contentType := ContentType_Gauge
 			if metricContentType != "" {
-				contentType = FmmMetricContentType(contentType)
+				contentType = FmmMetricContentType(metricContentType)
 			}
 
 			metric := &newComponent{

--- a/cmd/solution/types-fmm.go
+++ b/cmd/solution/types-fmm.go
@@ -119,10 +119,11 @@ type FmmMetric struct {
 type FmmMetricCategory string
 
 const (
-	Category_Sum     FmmMetricCategory = "sum"
-	Category_Average FmmMetricCategory = "average"
-	Category_Rate    FmmMetricCategory = "rate"
-	Category_Current FmmMetricCategory = "current"
+	Category_Sum       FmmMetricCategory = "sum"
+	Category_Average   FmmMetricCategory = "average"
+	Category_Rate      FmmMetricCategory = "rate"
+	Category_Current   FmmMetricCategory = "current"
+	Category_Histogram FmmMetricCategory = "histogram"
 )
 
 type FmmMetricContentType string
@@ -131,6 +132,7 @@ const (
 	ContentType_Sum          FmmMetricContentType = "sum"
 	ContentType_Gauge        FmmMetricContentType = "gauge"
 	ContentType_Distribution FmmMetricContentType = "distribution"
+	ContentType_Histogram    FmmMetricContentType = "histogram"
 )
 
 type FmmMetricType string


### PR DESCRIPTION
## Description

Allow developers to define what contentType a new metric should be and automatically set the proper category and aggregationTemporality attributes.

Supported contentTypes are:
- sum
- gauge
- distribution
- histogram

To use the new command:

fsoc solution extend --add-metric distmetric --contentType distribution

## Type of Change

- [X] New Feature
