### PR TITLE
fixed json encoding of `melt send --dump` data

### DIFF
--- a/platform/melt/exporter.go
+++ b/platform/melt/exporter.go
@@ -17,6 +17,7 @@ import (
 	metrics "go.opentelemetry.io/proto/otlp/metrics/v1"
 	resource "go.opentelemetry.io/proto/otlp/resource/v1"
 	spans "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -538,11 +539,12 @@ func dumpPayload(m proto.Message, format string, writer func(string)) {
 	case DumpFormatHuman:
 		s = prototext.Format(m)
 	case DumpFormatText:
-		b, err = prototext.Marshal(m)
+		b, err = prototext.Marshal(m) // untagged field names will go to lowerCamelCase
 	case DumpFormatJson:
-		b, err = json.MarshalIndent(m, "", output.JsonIndent)
+		// nb: protojson is required for marshalling proto3 messages; it also defaults to lowerCamelCase field name encoding
+		b, err = protojson.MarshalOptions{Multiline: true, Indent: output.JsonIndent}.Marshal(m)
 	case DumpFormatYaml:
-		b, err = yaml.Marshal(m)
+		b, err = yaml.Marshal(m) // untagged field names will go to lowerCamelCase
 	case DumpFormatHex:
 		b, err = proto.Marshal(m)
 		if err == nil {


### PR DESCRIPTION
## Description

Fixed a bug in how `melt send --dump --output=json` data is encoded. Protobuf requires specific json encoding that is supported by a protobuf/encoding package. This change switches the json encoding of MELT data dump to use this package. Note that this affects only what fsoc sends to stdout when the `--dump --output=json` flags are specified; it does not change the format of the data actually sent to the OpenTelemetry ingestion endpoints.

Potentially fixes also FSOC-195

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
