### PR TITLE
fix location of `solution download` zip file

### DIFF
--- a/cmd/solution/download.go
+++ b/cmd/solution/download.go
@@ -54,11 +54,12 @@ func downloadSolution(cmd *cobra.Command, args []string) {
 	solutionName := getSolutionNameFromArgs(cmd, args, "name")
 	solutionTagFlag, _ := cmd.Flags().GetString("tag")
 
-	if _, err := DownloadSolutionPackage(solutionName, solutionTagFlag, "."); err != nil {
+	zipPath, err := DownloadSolutionPackage(solutionName, solutionTagFlag, ".")
+	if err != nil {
 		log.Fatal(err.Error())
 	}
 
-	message := fmt.Sprintf("Solution %q with tag %s downloaded successfully.\n", solutionName, solutionTagFlag)
+	message := fmt.Sprintf("Solution %q with tag %s downloaded successfully to %v.\n", solutionName, solutionTagFlag, zipPath)
 	output.PrintCmdStatus(cmd, message)
 }
 
@@ -85,7 +86,7 @@ func DownloadSolutionPackage(name string, tag string, targetPath string) (string
 		// if targetPath is an existing directory, place zip there; otherwise, treat as file path
 		fileInfo, err := os.Stat(targetPath)
 		if err == nil && fileInfo.IsDir() {
-			targetPath = filepath.Join(filepath.Dir(targetPath), name+".zip")
+			targetPath = filepath.Join(targetPath, name+".zip")
 		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return "", fmt.Errorf("failed to access target path %q: %v", targetPath, err)
 		} // else treat as file path, possibly overwriting existing file


### PR DESCRIPTION
## Description

The `fsoc solution download` command had inadvertently changed to place the downloaded solution zip file in the parent directory of the current working directory. This is now fixed, the file is placed in the current working directory and the full, absolute path name is displayed for clarity.

Also resolves #357.

## Type of Change

- [X] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [X] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [X] All new and existing tests pass
